### PR TITLE
DOCS-1667: Add nolisttrue to TC API license index

### DIFF
--- a/content/TrueCommand/API/license/_index.md
+++ b/content/TrueCommand/API/license/_index.md
@@ -3,6 +3,7 @@ title: "License management"
 draft: false
 pre: "<i class='fa fa-file'></i>	"
 geekdocCollapseSection: true
+no_list: true
 ---
 
 ## API Class: Licensing


### PR DESCRIPTION

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
