### PR TITLE
DOCS-1667: Add nolisttrue to TC API sys2 index

### DIFF
--- a/content/TrueCommand/API/sys/_index.md
+++ b/content/TrueCommand/API/sys/_index.md
@@ -3,6 +3,7 @@ title: "System Management"
 draft: false
 pre: "<i class='fa fa-cogs'></i>	"
 geekdocCollapseSection: true
+no_list: true
 ---
 
 ## API Class: sys


### PR DESCRIPTION

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
