### PR TITLE
Remove extra quote character in img tag

### DIFF
--- a/content/en/hub/sharing/s3-object-store/_index.md
+++ b/content/en/hub/sharing/s3-object-store/_index.md
@@ -88,4 +88,4 @@ Select the SSL settings appropriate for the particular setup. The default assume
 
 It is possible to access, create new buckets, or upload files to created buckets.
 
-<img src="/images/S3-ExploreBrowse.png""><br><br>
+<img src="/images/S3-ExploreBrowse.png"><br><br>


### PR DESCRIPTION
Allow image to be visible

Fixes [page](https://www.truenas.com/docs/hub/sharing/s3-object-store/) that looks like this:

![image](https://user-images.githubusercontent.com/156685/108582894-32cf5500-72f3-11eb-9575-54d11153aff1.png)


Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
