### PR TITLE
Specify libvirt socket location

### DIFF
--- a/content/en/hub/scale/dev-notes.md
+++ b/content/en/hub/scale/dev-notes.md
@@ -92,8 +92,8 @@ They should be suitable for very adventurous users and developers who are not af
 
 In order to use PCI passthrough devices with VMs, follow these steps to have PCI devices show up in UI when it is time to create a PCI device to attach to a VM.
 
-1. In the CLI, identify the PCI device to use for passthrough with `virsh nodedev-list pci`.
-2. When the PCI address has been identified, make sure the host OS is not using the device anywhere else (i.e pools). When you're sure the device is not being used, execute `virsh nodedev-detach pci_0000_26_00_0`, where `pci_0000_26_00_0` is the name of the PCI device.
+1. In the CLI, identify the PCI device to use for passthrough with `virsh -c "qemu+unix:///system?socket=/run/truenas_libvirt/libvirt-sock" nodedev-list pci`.
+2. When the PCI address has been identified, make sure the host OS is not using the device anywhere else (i.e pools). When you're sure the device is not being used, execute `virsh -c "qemu+unix:///system?socket=/run/truenas_libvirt/libvirt-sock" nodedev-detach pci_0000_26_00_0`, where `pci_0000_26_00_0` is the name of the PCI device.
 3. Step (2) detaches the PCI device from the host. It can now be used with a VM guest by adding a PCI device to a VM using the UI.
 
 Follow the above steps when there is already 1 VM created with the UI.


### PR DESCRIPTION
This commit adds changes to point out the new non-standard location where libvirt socket is available so that users can do passthrough of devices using `virsh` command.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
