### PR TITLE
Update changelog version

### DIFF
--- a/content/ReleaseNotes/SCALE/21.04-ALPHA.1.md
+++ b/content/ReleaseNotes/SCALE/21.04-ALPHA.1.md
@@ -79,7 +79,7 @@ These features are still in early development and will be landing in Nightly ima
 * TrueCommand Clustering UI for SCALE
 * NFSv4 ACL support
 
-## 21.02-ALPHA.1 Changelog
+## 21.04-ALPHA.1 Changelog
 
 ### New Feature
 


### PR DESCRIPTION
Update changelog version to show "21.04-ALPHA.1 Changelog". Currently it shows previous version "21.02-ALPHA.1 Changelog"



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
