### PR TITLE
Update CloudSyncTasks.md

### DIFF
--- a/content/CORE/Tasks/CloudSyncTasks.md
+++ b/content/CORE/Tasks/CloudSyncTasks.md
@@ -126,3 +126,5 @@ To quickly create a new Cloud Sync that uses the same options but reverses the d
 Enter a new *Description* for this reversed task and define the path to a storage location for the transferred data.
 
 The restored cloud sync is saved as another entry in **Tasks > Cloud Sync Tasks**.
+
+In case the restore destination dataset is the same as the original source dataset, the restored files might have their ownership altered to _root_. If the original files were not created by _root_ and a different owner is required, you can recursively reset ACL Permissions of the restored dataset through the GUI or by running chown from the CLI.


### PR DESCRIPTION
Added line 130: a note of caution aimed mostly at novice users who restore files from the cloud directly into the original source dataset, since the restored files might have their original ownership altered if the dataset owner was not root.

I went through this in this forum post: https://www.truenas.com/community/threads/b2-cloud-task-restore-permissions-reset-on-restored-files.93148/

Thanks!



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
