### PR TITLE
DOCS-2133: Add HA Upgrade warning to archived doc

### DIFF
--- a/content/Archive.md
+++ b/content/Archive.md
@@ -18,7 +18,7 @@ All documentation provided here is End of Life (EoL) and no longer receives **an
 <div class="dropdown">
   <button onclick="myFunction()" class="dropbtn">Legacy TrueNAS</button>
   <div id="myDropdown" class="dropdown-content">
-    <a href="https://www.ixsystems.com/documentation/truenas/11.3-U5/TrueNAS-11.3-U5-User-Guide_screen.pdf">11.3</a>
+    <a href="https://www.truenas.com/docs/files/TrueNAS-11.3-U5-User-Guide.pdf">11.3</a>
     <a href="https://www.ixsystems.com/documentation/truenas/11.2-U8-legacy/TrueNAS-11.2-U8-Legacy-User-Guide_screen.pdf">11.2</a>
     <a href="https://www.ixsystems.com/documentation/truenas/11.1/TrueNAS.pdf">11.1</a>
   </div>


### PR DESCRIPTION
Edited the EoL 11.3-U5 User Guide PDF and added the HA upgrade warning to the beginning of the doc and at the beginning of the System > Failover section. Uploaded the modified PDF to the web server and am modifying the archive link to point to this updated file.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
