### PR TITLE
Fixing link to kubernetes integration

### DIFF
--- a/content/ReleaseNotes/SCALE/21.02-ALPHA.1.md
+++ b/content/ReleaseNotes/SCALE/21.02-ALPHA.1.md
@@ -69,7 +69,7 @@ Please use only with caution.
   * Periodic Snapshots
   * Rsync
   * Scrub
-* [Docker Images deployed as Helm Charts with Kubernetes NVIDIA / Intel Quicksync GPU passthrough (CLI)]({{ relref "DevNotes#kubernetes-integration-information" >}})
+* [Docker Images deployed as Helm Charts with Kubernetes NVIDIA / Intel Quicksync GPU passthrough (CLI)]({{< relref "/SCALE/DevNotes.md#kubernetes-integration-information" >}})
 * Wireguard (CLI)
 * Networking and Settings UX Refresh
 * OpenVPN Client and Server


### PR DESCRIPTION
Hey, I found that one link was not working for release notes. It was not redirecting to developer notes. I fixed that (tested with Hugo).