### PR TITLE
Replace relative URLs with absolute ones in RSS feed

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -18,16 +18,16 @@
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
-	  <atom:link href="/docs{{ .RelPermalink }}" rel="self" type="application/rss+xml" />
+	  <atom:link href="{{ .Permalink }}" rel="self" type="application/rss+xml" />
     {{ end }}
     {{ range $pages }}
     {{ if ne .Params.no_print "true" }}
     <item>
       <title>{{ .Title }}</title>
-      <link>/docs{{ .RelPermalink }}</link>
+      <link>{{ .Permalink }}</link>
       <pubDate>{{ .Lastmod.Format "2006-01-02 15:04 MST" | safeHTML }}</pubDate>
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
-      <guid>/docs{{ .RelPermalink }}</guid>
+      <guid>{{ .Permalink }}</guid>
       <description>{{ .Content | html }}</description> 
     </item>
     {{ end }}


### PR DESCRIPTION
Thunderbird was complaining that relative URLs are not allowed in RSS feeds and wouldn't let me add it.
Requires setting baseURL in config.toml

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
