### PR TITLE
DOCS-2236: Edit Main Page

### DIFF
--- a/content/TrueCommand/API/alerts/_index.md
+++ b/content/TrueCommand/API/alerts/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Alert management"
+title: "Alert Management"
 draft: false
 pre: "<i class='fa fa-bell'></i>	"
 geekdocCollapseSection: true

--- a/content/TrueCommand/API/cluster/_index.md
+++ b/content/TrueCommand/API/cluster/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Cluster management"
+title: "Cluster Management"
 pre: "<i class='fa fa-bookmark'></i>	"
 draft: false
 geekdocCollapseSection: true

--- a/content/TrueCommand/API/email/_index.md
+++ b/content/TrueCommand/API/email/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Email management"
+title: "Email Management"
 pre: "<i class='fa fa-envelope'></i>	"
 draft: false
 geekdocCollapseSection: true

--- a/content/TrueCommand/API/freenas/_index.md
+++ b/content/TrueCommand/API/freenas/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "FreeNAS management"
+title: "FreeNAS Management"
 draft: false
 pre: "<i class='fa fa-terminal'></i> "
 geekdocCollapseSection: true

--- a/content/TrueCommand/API/license/_index.md
+++ b/content/TrueCommand/API/license/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "License management"
+title: "License Management"
 draft: false
 pre: "<i class='fa fa-file'></i>	"
 geekdocCollapseSection: true

--- a/content/TrueCommand/API/notices/_index.md
+++ b/content/TrueCommand/API/notices/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Notice management"
+title: "Notice Management"
 draft: false
 pre: "<i class='fa fa-flag'></i>	"
 geekdocCollapseSection: true

--- a/content/TrueCommand/API/reports/_index.md
+++ b/content/TrueCommand/API/reports/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "System reports"
+title: "System Reports"
 pre: "<i class='fa fa-book'></i>	"
 draft: false
 geekdocCollapseSection: true

--- a/content/TrueCommand/API/servers/_index.md
+++ b/content/TrueCommand/API/servers/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Server management"
+title: "Server Management"
 draft: false
 pre: "<i class='fa fa-server'></i>	"
 geekdocCollapseSection: true

--- a/content/TrueCommand/API/teams/_index.md
+++ b/content/TrueCommand/API/teams/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Team management"
+title: "Team Management"
 draft: false
 pre: "<i class='fa fa-users'></i>	"
 geekdocCollapseSection: true

--- a/content/TrueCommand/API/users/_index.md
+++ b/content/TrueCommand/API/users/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "User management"
+title: "User Management"
 pre: "<i class='fa fa-users'></i>	"
 draft: false
 geekdocCollapseSection: true

--- a/content/TrueCommand/Introduction/Support.md
+++ b/content/TrueCommand/Introduction/Support.md
@@ -17,5 +17,5 @@ To find more details about the different Warranty and Service Level Agreement (S
 ## TrueCommand Cloud
 
 If any issues are found when using TrueCommand Cloud or an iX Portal account, log in to the Portal Account and click *Manage* > *Request Support*.
-Fill out the *Request Support* form with specific details and screenshots of the issue and click *Send Request*.
+Fill out the *Request Support* form with specific details of the issue and click *Send Request*.
 A copy of the support request is emailed to the registered email account.

--- a/content/TrueCommand/_index.md
+++ b/content/TrueCommand/_index.md
@@ -21,7 +21,7 @@ TrueCommand can monitor an entire fleet of TrueNAS systems and thousands of onli
 ## What Features does TrueCommand have?
 
 {{< expand "Multiple Deployment Options" "v" >}}
-TrueCommand is a lightweight application that supports deployments in either a Virtual Machine or a Docker Container.
+TrueCommand docker container can be deployed as a VM since vhdk and vmdk are no longer supported in version 2.0.
 TrueCommand Cloud is also available as a cloud-based subscription option that allows you to offload TrueCommand resources and deployment and only focus on fine-tuning your configuration.
 {{< /expand >}}
 {{< expand "NAS Fleet Dashboard" "v" >}}


### PR DESCRIPTION
edited line 24 to read: TrueCommand docker container can be deployed as a VM since vhdk and vmdk are no longer supported in version 2.0.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
