### PR TITLE
DOCS-2194: Define a feature image param for each page

### DIFF
--- a/.github/workflows/build-external-contrib.yml
+++ b/.github/workflows/build-external-contrib.yml
@@ -65,6 +65,6 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: "https://${{ steps.preview_step.outputs.preview_url }}"
-          cmd_params: "--skip-tls-verification --timeout=30 --rate-limit=30 --max-connections=10 --color=always --exclude=docs/files/ --exclude=files/TrueNASCollection.vssx --exclude=update.freenas.org --exclude=microsoft.com --exclude=oracle.com --exclude=amazon.com --exclude=apple.com --exclude=fastmail.com --exclude=linode.com --exclude=community.openvpn.net --exclude=tools.ietf.org --exclude=github.com --exclude=freebsd.org --exclude=jira.ixsystems.com --exclude=linkedin.com --exclude=googletagmanager.com --exclude=youtube.com --exclude=vmware.com --exclude=cyberciti.biz --exclude=truenas-documentation-deploy.surge.sh --exclude=tc2api.html"
+          cmd_params: "--skip-tls-verification --timeout=30 --rate-limit=30 --max-connections=10 --color=always --exclude=docs/files/ --exclude=files/TrueNASCollection.vssx --exclude=update.freenas.org --exclude=microsoft.com --exclude=oracle.com --exclude=amazon.com --exclude=apple.com --exclude=fastmail.com --exclude=linode.com --exclude=community.openvpn.net --exclude=tools.ietf.org --exclude=github.com --exclude=freebsd.org --exclude=jira.ixsystems.com --exclude=linkedin.com --exclude=googletagmanager.com --exclude=youtube.com --exclude=vmware.com --exclude=cyberciti.biz --exclude=truenas-documentation-deploy.surge.sh --exclude=tc2api.html --exclude=/docs/images/tn-openstorage-logo.png"
           run_timeout: 600
           debug: true

--- a/.github/workflows/build-internal-contrib.yml
+++ b/.github/workflows/build-internal-contrib.yml
@@ -64,6 +64,6 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: "https://${{ steps.preview_step.outputs.preview_url }}"
-          cmd_params: "--skip-tls-verification --timeout=30 --rate-limit=30 --max-connections=10 --color=always --exclude=docs/files/ --exclude=files/TrueNASCollection.vssx --exclude=update.freenas.org --exclude=microsoft.com --exclude=oracle.com --exclude=amazon.com --exclude=apple.com --exclude=fastmail.com --exclude=linode.com --exclude=community.openvpn.net --exclude=tools.ietf.org --exclude=github.com --exclude=freebsd.org --exclude=jira.ixsystems.com --exclude=linkedin.com --exclude=googletagmanager.com --exclude=youtube.com --exclude=vmware.com --exclude=cyberciti.biz --exclude=truenas-documentation-deploy.surge.sh --exclude=tc2api.html"
+          cmd_params: "--skip-tls-verification --timeout=30 --rate-limit=30 --max-connections=10 --color=always --exclude=docs/files/ --exclude=files/TrueNASCollection.vssx --exclude=update.freenas.org --exclude=microsoft.com --exclude=oracle.com --exclude=amazon.com --exclude=apple.com --exclude=fastmail.com --exclude=linode.com --exclude=community.openvpn.net --exclude=tools.ietf.org --exclude=github.com --exclude=freebsd.org --exclude=jira.ixsystems.com --exclude=linkedin.com --exclude=googletagmanager.com --exclude=youtube.com --exclude=vmware.com --exclude=cyberciti.biz --exclude=truenas-documentation-deploy.surge.sh --exclude=tc2api.html --exclude=/docs/images/tn-openstorage-logo.png"
           run_timeout: 600
           debug: true

--- a/config.toml
+++ b/config.toml
@@ -45,6 +45,7 @@ id = "UA-2174408-20"
 enable = true
 
 [params]
+
   # (Optional, default 6) Set how many table of contents levels to be showed on page.
   # Use false to hide ToC, note that 0 will default to 6 (https://gohugo.io/functions/default/)
   # You can also specify this parameter per page in front matter.
@@ -98,6 +99,9 @@ enable = true
 
   # (Optional, default true) Copy anchor url to clipboard on click.
   geekdocAnchorCopy = true
+
+  # Featured image for search results
+  featured_image = "/docs/images/tn-openstorage-logo.png"
 
 [frontmatter]
 lastmod = ["lastmod", ":git", ":fileModTime", ":default"]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,6 +16,9 @@
 </head>
 
 <body>
+    <!-- Define feature image for search results or linking -->
+    <a href="#" style="display: none;" class="image featured">{{ with .Site.Params.featured_image }}<img src="{{ . }}"></img>{{end}}</a>
+
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P87FM6K"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/static/includes/ServicesSNMPFields.md.part
+++ b/static/includes/ServicesSNMPFields.md.part
@@ -10,7 +10,7 @@
 
 | Name | Description |
 |------|-------------|
-| SNMP v3 Support | Set to to enable support for [SNMP version 3](https://tools.ietf.org/html/rfc3410). See [snmpd.conf(5)](http://net-snmp.sourceforge.net/docs/man/snmpd.conf.html) for configuration details. |
+| SNMP v3 Support | Set to to enable support for [SNMP version 3](https://tools.ietf.org/html/rfc3410). See [snmpd.conf(5)](https://net-snmp.sourceforge.io/docs/man/snmpd.conf.html) for configuration details. |
 | Username | Enter a username to register with this service. |
 | Authentication Type | Choose an authentication method: `---` for none, *[SHA](https://tools.ietf.org/html/rfc4634)*, or *[MD5](https://tools.ietf.org/html/rfc1321)*|
 | Password | Enter a password of at least eight characters. |
@@ -21,7 +21,7 @@
 
 | Name | Description |
 |------|-------------|
-| Auxiliary Parameters | Enter any additional [snmpd.conf](http://net-snmp.sourceforge.net/docs/man/snmpd.conf.html) options. Add one option for each line. |
+| Auxiliary Parameters | Enter any additional [snmpd.conf](https://net-snmp.sourceforge.io/docs/man/snmpd.conf.html) options. Add one option for each line. |
 | Expose zilstat via SNMP | Enabling this option may have performance implications on your pools. |
 | Log Level | Choose how many log entries to create. Choices range from the least log entries (Emergency) to the most (Debug). |
 | Enable Network Performance Statistics | Include [iftop](https://linuxcommandlibrary.com/man/iftop) network performance statistics in SNMP messages. |


### PR DESCRIPTION
Use a placeholder TN open storage logo for search results thumbnails.
Defined as a site parameter for easy adjustment or removal.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
