### PR TITLE
Remove other BSD refs in the TrueNAS SCALE docs

### DIFF
--- a/content/SCALE/GettingStarted/InstallingSCALE.md
+++ b/content/SCALE/GettingStarted/InstallingSCALE.md
@@ -155,13 +155,6 @@ and boot environments and at least one additional virtual disk with
 at least 4GB to be used as data storage.
 * NETWORK: Use NAT, Bridged, or Host-only depending on your host network configuration.
 
-{{< expand "FreeBSD UEFI Bug with ESXi" "v">}}
-**VMWare products and EFI boot mode:**
-A third party bug currently affects EFI (UEFI) booting on VMWare products.
-TrueNAS should be installed in BIOS mode until this is resolved.
-See FreeBSD reference [ESXi VM does not boot in UEFI mode](https://freebsd.1045724.x6.nabble.com/ESXi-VM-does-not-boot-in-UEFI-mode-from-20190906-snapshot-ISO-td6350284.html).
-{{< /expand >}}
-
 {{< expand "Networking checks for VMware" "v">}}
 When installing TrueNAS in a VMware VM, double check the virtual switch and VMware port group.
 Network connection errors for plugins or jails inside the TrueNAS VM can be caused by a misconfigured virtual switch or VMware port group.
@@ -177,12 +170,12 @@ For most hypervisors, the procedure for creating a TrueNAS VM is the same:
 1. Create a new Virtual Machine as usual, taking note of the following settings.
 2. The virtual hardware has a bootable CD/DVD device pointed to the TrueNAS SCALE installer image (this is usually an <file>.iso</file>).
 3. The virtual network card is configured so it can be reached from your network. **bridged** mode is optimal as this treats the network card as if it is plugged into a simple switch on the existing network.
-4. Some products require identifying the OS being installed on the VM. The ideal option is *FreeBSD 12 64 bit*. If this is not available, try options like *FreeBSD 12*, *FreeBSD 64 bit*, *64 bit OS*, or *Other*. **Do not choose a Windows or Linux related OS type.**
+4. Some products require identifying the OS being installed on the VM. The ideal option is *Debian 11 64 bit*. If this is not available, try options like *Debian 11*, *Debian 64 bit*, *64 bit OS*, or *Other*. **Do not choose a Windows, Mac or BSD related OS type.**
 5. For VMWare hypervisors, install in BIOS mode.
 6. The VM has sufficient memory and disk space. TrueNAS needs at least *8 GB* RAM and *20 GB* disk space. Not all hypervisors allocate enough memory by default.
 7. Boot the VM and install TrueNAS as usual.
 8. When installation is complete, shut down the VM instead of rebooting, and disconnect the CD/DVD from the VM before rebooting the VM.
-9. After rebooting into TrueNAS, install VM tools if applicable for your VM, and if they exist for FreeBSD 12, or ensure they are loaded on boot.
+9. After rebooting into TrueNAS, install VM tools if applicable for your VM, and if they exist for Debian 11, or ensure they are loaded on boot.
 
 ## Example installation for VMWare Player 15.5
 

--- a/content/SCALE/Introduction/SCALEHardwareGuide.md
+++ b/content/SCALE/Introduction/SCALEHardwareGuide.md
@@ -143,7 +143,7 @@ Because SATA DOMs and motherboards with m.2 slots are not as common as the other
 {{< tab "Hot Swapability" >}}
 TrueNAS systems come in all shapes and sizes, but having external access to all storage devices for efficient replacement if issues occur is highly desirable.
 Most “hot swap” drive bays require a proprietary drive tray into which each drive is installed.
-These bay and tray combinations also often include convenient features like activity and identification lights to both visualize activity and illuminate a failed drive with [sesutil(8)](https://www.freebsd.org/cgi/man.cgi?query=sesutil&sektion=8).
+These bay and tray combinations also often include convenient features like activity and identification lights to both visualize activity and illuminate a failed drive with [sesutil in sg3_utils(8)](https://manpages.debian.org/testing/sg3-utils/sg3_utils.8.en.html).
 TrueNAS Mini systems ship with four or more hot swap bays and TrueNAS R-Series systems can support dozens of drives in their head units and external expansion shelves.
 Pre-owned or repurposed hardware is popular among TrueNAS users, so pay attention to the maximum performance offered by the hot swap backplanes of a given system and watch for at least 6 Gbps SATA III support.
 Note that TrueNAS does not currently support hot-swapping PCIe NVMe devices.
@@ -288,8 +288,7 @@ Exactly what CPU to choose can come down to a short list of key factors:
 * Watch for VT-d/AMD-Vi device virtualization support on the CPU and motherboard to pass PCIe devices to virtual machines.
 * Be aware if a given CPU contains a GPU or requires an external one. Also, note that many server motherboards include a BMC chip with a built-in GPU. See below for more details on BMCs.
 
-AMD CPUs are making a comeback thanks to the Ryzen and EPYC (Naples/Rome) lines but support for these platforms has been relatively limited on FreeBSD and, by extension, TrueNAS.
-They will work, but there has been less run time and performance tuning.
+AMD CPUs are making a comeback thanks to the Ryzen and EPYC (Naples/Rome) lines have substantial Linux support and should work without issue.
 
 ### Remote Management: IPMI
 
@@ -343,7 +342,6 @@ The “Network” in “Network Attached Storage” is just as important as Stor
 
 * Simplicity is often the secret to reliability with network configurations.
 * Faster individual interfaces such as 10/25/40/100GbE are preferred to aggregating slower interfaces.
-* Intel and Chelsio interfaces are the best [supported options](https://www.freebsd.org/releases/11.3R/hardware.html#ethernet).
 * Only consider a “jumbo frames” [MTU](https://en.wikipedia.org/wiki/Maximum_transmission_unit) with dedicated connections such as between servers or video editors and TrueNAS that are not likely to experience packet fragmentation.
 * Interfaces with [LRO](https://en.wikipedia.org/wiki/Large_receive_offload) and [LSO](https://en.wikipedia.org/wiki/Large_send_offload) offload features will generally alleviate the need for jumbo frames and their use can result in lower CPU overhead.
 
@@ -369,7 +367,7 @@ Direct Attached Copper (DAC) cables could create interoperability issues between
 Finally, the ultimate TrueNAS hardware question is whether to use actual hardware at all or go with a virtualization solution.
 TrueNAS developers [virtualize TrueNAS every day](https://www.ixsystems.com/blog/yes-you-can-virtualize-freenas/) as part of their work, and cloud services are popular among users of all sizes.
 The fact remains, however, that OpenZFS at the heart of TrueNAS has been designed from day one to work directly with physical storage devices, fully aware of their strengths and compensating for their weaknesses.
-Also, at the heart of TrueNAS is FreeBSD, which offers exemplary hardware performance and health reporting.
+Also, at the heart of TrueNAS is Linux, which offers exemplary hardware performance and health reporting.
 When the need arises to virtualize TrueNAS:
 
 * Pass hardware disks or the entire storage controller to the FreeNAS VM if possible (requires VT-d/AMD-Vi support)
@@ -378,7 +376,6 @@ When the need arises to virtualize TrueNAS:
 * Remember to provide one or more 8GB or larger boot devices 
 * Provide the FreeNAS VM with adequate RAM, as per its usual requirements
 * Consider “jumbo frame” networking if supported by all devices
-* Be prepared that the “guest tools” in FreeBSD may lack features found in other guest operating systems
 * Enable MAC address spoofing on virtual interfaces and enable “promiscuous mode” to use Plugins
 
 Follow these rules when buying or building your next TrueNAS system to achieve maximum reliability, performance, and manageability.

--- a/content/SCALE/Shares/NFS.md
+++ b/content/SCALE/Shares/NFS.md
@@ -93,9 +93,9 @@ NFS service settings can be configured by clicking <i class="fa fa-pen" aria-hid
 | Require Kerberos for NFSv4        | checkbox  | Set to force NFS shares to fail if the Kerberos ticket is unavailable. |
 | Serve UDP NFS clients             | checkbox  | Set if NFS clients need to use the User Datagram Protocol (UDP). |
 | Support >16 groups                | checkbox  | Set when a user is a member of more than 16 groups. This assumes group membership is configured correctly on the NFS server. |
-| mountd(8) bind port               | integer   | Enter a number to bind [mountd](https://www.freebsd.org/cgi/man.cgi?query=mountd) only to that port. |
-| rpc.statd(8) bind port            | integer   | Enter a number to bind [rpc.statd](https://www.freebsd.org/cgi/man.cgi?query=rpc.statd) only to that port. |
-| rpc.lockd(8) bind port            | integer   | Enter a number to bind [rpc.lockd](https://www.freebsd.org/cgi/man.cgi?query=rpc.lockd) only to that port. |
+| mountd(8) bind port               | integer   | Enter a number to bind [mountd](https://manpages.debian.org/testing/nfs-kernel-server/mountd.8.en.html) only to that port. |
+| rpc.statd(8) bind port            | integer   | Enter a number to bind [rpc.statd](https://manpages.debian.org/testing/nfs-common/statd.8.en.html) only to that port. |
+| rpc.lockd(8) bind port            | integer   | Enter a number to bind [rpc.lockd](https://manpages.debian.org/testing/nfs-kernel-server/rpc.nfsd.8.en.html) only to that port. |
 
 Unless a specific setting is needed, it is recommended to use the default settings for the NFS service.
 When TrueNAS is already connected to [Active Directory]({{< relref "ActiveDirectory.md" >}}), setting *NFSv4* and *Require Kerberos for NFSv4* also requires a [Kerberos Keytab]({{< relref "Kerberos.md#kerberos-keytabs" >}}).

--- a/content/SCALE/Storage/PermissionsSCALE.md
+++ b/content/SCALE/Storage/PermissionsSCALE.md
@@ -133,7 +133,7 @@ getfacl /mnt/path/to/dataset
 | Field | Description |
 |------|-------------|
 | Add | Adds a new ACE to the Access Control List. |
-| Who | Access Control Entry (ACE) user or group. Select a specific User or Group for this entry, owner@ to apply this entry to the user that owns the dataset, group@ to apply this entry to the group that owns the dataset, or everyone@ to apply this entry to all users and groups. See [setfacl(1) NFSv4 ACL ENTRIES](https://www.freebsd.org/cgi/man.cgi?query=setfacl). |
+| Who | Access Control Entry (ACE) user or group. Select a specific User or Group for this entry, owner@ to apply this entry to the user that owns the dataset, group@ to apply this entry to the group that owns the dataset, or everyone@ to apply this entry to all users and groups. See [nfs4_setfacl(1) NFSv4 ACL ENTRIES](https://manpages.debian.org/testing/nfs4-acl-tools/nfs4_setfacl.1.en.html). |
 | ACL Type | How the Permissions are applied to the chosen Who. Choose Allow to grant the specified permissions and Deny to restrict the specified permissions. |
 | Permissions Type | Choose the type of permissions. Basic shows general permissions. Advanced shows each specific type of permission for finer control. |
 | Permissions | Select permissions to apply to the chosen Who. Choices change depending on the Permissions Type. |

--- a/content/SCALE/SystemSettings/AdvancedSettings.md
+++ b/content/SCALE/SystemSettings/AdvancedSettings.md
@@ -9,7 +9,7 @@ weight: 30
 The TrueNAS SCALE Advanced Settings section provides configuration options for the Console, Syslog, Sysctl, Kernel, Cron Jobs, Init/Shutdown Scripts, System Dataset Pool, and Isolated GPU Device(s).
 
 {{< hint warning >}} 
-Advanced Settings have reasonable defaults in place. Changing advanced settings can be dangerous when done incorrectly. Please use caution before saving. Make sure you are comfortable with ZFS, FreeBSD, and system [configuration backup and restoration]({{< relref "GeneralSettings.md" >}}) before making any changes. 
+Advanced Settings have reasonable defaults in place. Changing advanced settings can be dangerous when done incorrectly. Please use caution before saving. Make sure you are comfortable with ZFS, Linux, and system [configuration backup and restoration]({{< relref "GeneralSettings.md" >}}) before making any changes. 
 {{< /hint >}}
 
 ![AdvancedSettingsSCALE](/images/SCALE/AdvancedSettingsSCALE.png "SCALE Advanced Settings Screen")
@@ -60,7 +60,7 @@ The *Kernel* window contains options for system optimization and kernel debuggin
 
 ## Cron Jobs
 
-The *Cron Jobs* window allows users to configure jobs that run specific commands or scripts on a regular schedule using [cron(8)](https://man.openbsd.org/cron.8 "Cron Man Page"). Cron Jobs help run repetitive tasks.
+The *Cron Jobs* window allows users to configure jobs that run specific commands or scripts on a regular schedule using [cron(8)](https://manpages.debian.org/testing/cron/cron.8.en.html "Cron Man Page"). Cron Jobs help run repetitive tasks.
 
 | Name | Description |
 |------|-------------|
@@ -81,7 +81,7 @@ The *Init/Shutdown Scripts* window allows users to schedule commands or scripts 
 | Description | Comments about this script. |
 | Type | Select Command for an executable or Script for an executable script. |
 | Command | Enter the command with any options. |
-| Script | Select the script. The script will be run using [sh(1)](https://www.freebsd.org/cgi/man.cgi?query=sh "SH(1) Page"). |
+| Script | Select the script. The script will be run using [dash(1)](https://manpages.debian.org/testing/dash/sh.1.en.html "dash(1) Page"). |
 | When | Select when the command or script runs:
 *Pre Init* is early in the boot process, after mounting filesystems and starting networking.
 *Post Init* is at the end of the boot process, before FreeNAS services start.


### PR DESCRIPTION
Fixing a few more BSD refs:

- Removing a VMWare/FreeBSD specific bug
- Changing info on how to set up a VM to match Linux base
- Changing manpages to Debian 'Testing' URLs as Debian 11/Bulleseye is not released yet

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
