### PR TITLE
Update and rename 12.0-U5.md to 12.0U5.md

### DIFF
--- a/content/ReleaseNotes/CORE/12.0U5.md
+++ b/content/ReleaseNotes/CORE/12.0U5.md
@@ -1,6 +1,9 @@
 ---
 title: "12.0-U5"
 weight: 3
+aliases:
+  - /releasenotes/core/12.0-u5/
+  - /releasenotes/core/12.0u5/
 ---
 
 {{< include file="static/includes/LifecyleTable.html.part" html="true" >}}


### PR DESCRIPTION
Add aliases so that the previous incorrect path still allows people to go to the new, correct location.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
