### PR TITLE
DOCS-2603: Fix sticky header placement

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -35,13 +35,19 @@ p,h1,h2,h3,h4,th,td,a {
 .sticky {
   position: fixed;
   top: 0;
-  left: 0;
+  left: 50%;
+    -ms-transform: translateX(-50%);
+    -moz-transform: translateX(-50%);
+    -webkit-transform: translateX(-50%);
+  transform: translateX(-50%);
   z-index: 5;
   margin: 0 auto;
   width: 100%;
   max-width: 90rem;
   padding-left: 1rem;
   padding-top: .5rem;
+  padding-bottom: .5rem;
+  border-radius: 5px;
 }
 .stickyelement {
 	background: white;
@@ -71,6 +77,7 @@ p,h1,h2,h3,h4,th,td,a {
 .gdoc-header {
 	background: #ffffff;
 	border: none;
+  padding-bottom: .5rem;
 }
 .truenas-menuitem {
 }


### PR DESCRIPTION
- Also add a little padding to the bottom of the sticky header and round the edges of the box to be a little friendlier for dark mode.
- Add a small amount of padding to the bottom of base header.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
