### PR TITLE
Fixed Example

### DIFF
--- a/content/CORE/Sharing/WebDAV/WebDAVShare.md
+++ b/content/CORE/Sharing/WebDAV/WebDAVShare.md
@@ -57,7 +57,7 @@ Be sure to click *SAVE* after making any changes.
 WebDAV shared data is accessible from a web browser.
 To see the shared data, open a new browser tab and enter `{PROTOCOL}://{TRUENASIP}:{PORT}/{SHAREPATH}`.
 Replace the elements in curly brackets `{}` with your chosen settings from the WebDAV share and service.
-Example: `https://10.2.1.1:8081/mnt/corepool1/newdataset`
+Example: `https://10.2.1.1:8081/newdataset`
 
 When the *Authentication* WebDAV service option is set to either *Basic* or *Digest*, a user name and password is required.
 Enter the user name *webdav* and the password defined in the WebDAV service.


### PR DESCRIPTION
The example was `https://10.2.1.1:8081/mnt/corepool1/newdataset` - this will show the 404 Not Found error page
When modified `https://10.2.1.1:8081/newdataset' this works ok.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
