### PR TITLE
DOCS-2600:  Add Interface Options Depreciation to 22.02-RC.0 Release …

### DIFF
--- a/content/ReleaseNotes/SCALE/22.02-RC.1.md
+++ b/content/ReleaseNotes/SCALE/22.02-RC.1.md
@@ -750,7 +750,8 @@ SCALE is developed as an appliance that uses specific Linux packages with each r
                	<tbody>  
 				<tr><td></td><td>ZFS feature flag has been removed in this release.</td><td>See <b>ZFS Feature Flag Removal</b> below for more information.</td></tr>
 				<tr><td></td><td>SCALE Gluster/Cluster.</td><td>Gluster/Cluster features are still in testing.  Administrators should use caution when deploying and avoid use with critical data.</td></tr>
-             	<tr><td><a href="https://jira.ixsystems.com/browse/NAS-110263" target="_blank">NAS-110263</a></td><td>AFP sharing is removed from TrueNAS SCALE. The protocol is deprecated and no longer receives development effort or security fixes.</td><td>TrueNAS SCALE automatically migrates any existing AFP shares into an SMB configuration that is preset to function like an AFP share.</td></tr>  
+				<tr><td><a href="https://jira.ixsystems.com/browse/NAS-112119" target="_blank">NAS-112119</a></td><td>Depreciate Custom "Options" for Interfaces on SCALE.</td><td>Specifying custom options for network interfaces in SCALE has been removed.</td></tr>
+				<tr><td><a href="https://jira.ixsystems.com/browse/NAS-110263" target="_blank">NAS-110263</a></td><td>AFP sharing is removed from TrueNAS SCALE. The protocol is deprecated and no longer receives development effort or security fixes.</td><td>TrueNAS SCALE automatically migrates any existing AFP shares into an SMB configuration that is preset to function like an AFP share.</td></tr>  
              	<tr><td><a href="https://jira.ixsystems.com/browse/NAS-111055" target="_blank">NAS-111055</a></td><td>UI Slowdowns from custom catalog installation</td><td>Due to the large repository, TrueCharts has performance issues when adding the repo to TrueNAS for the first time or adding after the upgrade. Users will need to refresh the Apps catalog and expect to wait a short time for the first sync to complete.</td></tr>
              	</tbody>
         	</table>


### PR DESCRIPTION
Added NAS-112119 as known issue (removal of interface options from SCALE)



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
