### PR TITLE
DOCS-2198: Change 2nd Column to MiB/s

### DIFF
--- a/content/References/Performance/InterconnectDataRates.md
+++ b/content/References/Performance/InterconnectDataRates.md
@@ -24,7 +24,7 @@ A best effort attempt has been made to exclude physical link encoding overheads 
     <th class="tg-1wig" colspan="4">Maximum Effective Data Rate (One Direction)</th>
   </tr>
   <tr>
-    <td class="tg-1wig">(1024<sup>2</sup> Bytes) MB/s</td>
+    <td class="tg-1wig">(1024<sup>2</sup> Bytes) MiB/s</td>
     <td class="tg-1wig">(1000<sup>2</sup> Bytes) MB/s</td>
     <td class="tg-1wig">(1000<sup>3</sup> Bytes) Gb/s</td>
     <td class="tg-1wig">Notes</td>
@@ -76,7 +76,7 @@ A best effort attempt has been made to exclude physical link encoding overheads 
     <th class="tg-1wig" colspan="4">Maximum Effective Data Rate (One Direction)</th>
   </tr>
   <tr>
-    <td class="tg-1wig">(1024<sup>2</sup> Bytes) MB/s</td>
+    <td class="tg-1wig">(1024<sup>2</sup> Bytes) MiB/s</td>
     <td class="tg-1wig">(1000<sup>2</sup> Bytes) MB/s</td>
     <td class="tg-1wig">(1000<sup>3</sup> Bytes) Gb/s</td>
     <td class="tg-1wig">Notes</td>
@@ -128,7 +128,7 @@ A best effort attempt has been made to exclude physical link encoding overheads 
     <th class="tg-1wig" colspan="4">Maximum Effective Data Rate (One Direction)</th>
   </tr>
   <tr>
-    <td class="tg-1wig">(1024<sup>2</sup> Bytes) MB/s</td>
+    <td class="tg-1wig">(1024<sup>2</sup> Bytes) MiB/s</td>
     <td class="tg-1wig">(1000<sup>2</sup> Bytes) MB/s</td>
     <td class="tg-1wig">(1000<sup>3</sup> Bytes) Gb/s</td>
   </tr>
@@ -162,7 +162,7 @@ A best effort attempt has been made to exclude physical link encoding overheads 
     <th class="tg-1wig" colspan="4">Maximum Effective Data Rate (One Direction)</th>
   </tr>
   <tr>
-    <td class="tg-1wig">(1024<sup>2</sup> Bytes) MB/s</td>
+    <td class="tg-1wig">(1024<sup>2</sup> Bytes) MiB/s</td>
     <td class="tg-1wig">(1000<sup>2</sup> Bytes) MB/s</td>
     <td class="tg-1wig">(1000<sup>3</sup> Bytes) Gb/s</td>
   </tr>
@@ -196,7 +196,7 @@ A best effort attempt has been made to exclude physical link encoding overheads 
     <th class="tg-1wig" colspan="4">Maximum Effective Data Rate (One Direction)</th>
   </tr>
   <tr>
-    <td class="tg-1wig">(1024<sup>2</sup> Bytes) MB/s</td>
+    <td class="tg-1wig">(1024<sup>2</sup> Bytes) MiB/s</td>
     <td class="tg-1wig">(1000<sup>2</sup> Bytes) MB/s</td>
     <td class="tg-1wig">(1000<sup>3</sup> Bytes) Gb/s</td>
   </tr>
@@ -230,7 +230,7 @@ A best effort attempt has been made to exclude physical link encoding overheads 
     <th class="tg-1wig" colspan="4">Maximum Effective Data Rate (One Direction)</th>
   </tr>
   <tr>
-    <td class="tg-1wig">(1024<sup>2</sup> Bytes) MB/s</td>
+    <td class="tg-1wig">(1024<sup>2</sup> Bytes) MiB/s</td>
     <td class="tg-1wig">(1000<sup>2</sup> Bytes) MB/s</td>
     <td class="tg-1wig">(1000<sup>3</sup> Bytes) Gb/s</td>
   </tr>
@@ -288,7 +288,7 @@ A best effort attempt has been made to exclude physical link encoding overheads 
     <th class="tg-1wig" colspan="4">Maximum Effective Data Rate (One Direction)</th>
   </tr>
   <tr>
-    <td class="tg-1wig">(1024<sup>2</sup> Bytes) MB/s</td>
+    <td class="tg-1wig">(1024<sup>2</sup> Bytes) MiB/s</td>
     <td class="tg-1wig">(1000<sup>2</sup> Bytes) MB/s</td>
     <td class="tg-1wig">(1000<sup>3</sup> Bytes) Gb/s</td>
   </tr>


### PR DESCRIPTION
Changes 1024^2 Column to MiB/s - Nick Wolff checked work and said it looks good.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
