### PR TITLE
DOCS-2551 Convert Legacy HTML docs to PDF and reupload to Docs Hub

### DIFF
--- a/content/Archive.md
+++ b/content/Archive.md
@@ -2,7 +2,7 @@
 title: "Documentation Archive"
 ---
 
-Welcome to the Documentation Archive! TEST CHANGE
+Welcome to the Documentation Archive!
 
 {{< hint warning >}}
 All documentation provided here is End of Life (EoL) and no longer receives **any** updates.
@@ -31,8 +31,10 @@ All documentation provided here is End of Life (EoL) and no longer receives **an
     <a href="https://www.ixsystems.com/documentation/freenas/11.2-U8/FreeNAS-11.2-U8-User-Guide_screen.pdf">11.2 (New GUI)</a>
     <a href="https://www.ixsystems.com/documentation/freenas/11.2-U8-legacy/FreeNAS-11.2-U8-Legacy-User-Guide_screen.pdf">11.2 (Legacy GUI)</a>
     <a href="https://www.ixsystems.com/documentation/freenas/11.1/FreeNAS.pdf">11.1</a>
-    <a href="https://www.ixsystems.com/documentation/freenas/9.10/freenas.html">9.10</a>
-    <a href="https://www.ixsystems.com/documentation/freenas/9.3/freenas.html">9.3</a>
+    <a href="https://www.ixsystems.com/documentation/freenas/9.10/freenas.html">9.10 (HTML)</a>
+    <a href="https://www.truenas.com/docs/files/freenas9.10.2_guide.pdf">9.10 (PDF)</a>
+    <a href="https://www.ixsystems.com/documentation/freenas/9.3/freenas.html">9.3 (HTML)</a>
+    <a href="https://www.truenas.com/docs/files/freenas9.3_guide.pdf">9.3 (PDF)</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.2.1/freenas9.2.1_guide.pdf">9.2</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.1.1/freenas9.1.1_guide.pdf">9.1</a>
     <a href="https://www.ixsystems.com/documentation/freenas/8.3.1/freenas8.3.1_guide.pdf">8.3</a>

--- a/content/Archive.md
+++ b/content/Archive.md
@@ -32,7 +32,7 @@ All documentation provided here is End of Life (EoL) and no longer receives **an
     <a href="https://www.ixsystems.com/documentation/freenas/11.2-U8-legacy/FreeNAS-11.2-U8-Legacy-User-Guide_screen.pdf">11.2 (Legacy GUI)</a>
     <a href="https://www.ixsystems.com/documentation/freenas/11.1/FreeNAS.pdf">11.1</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.10/freenas.html">9.10</a>
-    <a href="https://www.ixsystems.com/documentation/freenas/9.3/freenas.html">9.3</a>
+    9.3 <a href="https://www.ixsystems.com/documentation/freenas/9.3/freenas.html">HTML</a> <a href="https://www.ixsystems.com/documentation/freenas/9.2.1/freenas9.2.1_guide.pdf">PDF</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.2.1/freenas9.2.1_guide.pdf">9.2</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.1.1/freenas9.1.1_guide.pdf">9.1</a>
     <a href="https://www.ixsystems.com/documentation/freenas/8.3.1/freenas8.3.1_guide.pdf">8.3</a>

--- a/content/Archive.md
+++ b/content/Archive.md
@@ -32,7 +32,8 @@ All documentation provided here is End of Life (EoL) and no longer receives **an
     <a href="https://www.ixsystems.com/documentation/freenas/11.2-U8-legacy/FreeNAS-11.2-U8-Legacy-User-Guide_screen.pdf">11.2 (Legacy GUI)</a>
     <a href="https://www.ixsystems.com/documentation/freenas/11.1/FreeNAS.pdf">11.1</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.10/freenas.html">9.10</a>
-    9.3 <a href="https://www.ixsystems.com/documentation/freenas/9.3/freenas.html">HTML</a> <a href="https://www.ixsystems.com/documentation/freenas/9.2.1/freenas9.2.1_guide.pdf">PDF</a>
+    9.3 
+    <a href="https://www.ixsystems.com/documentation/freenas/9.3/freenas.html">HTML</a> <a href="https://www.ixsystems.com/documentation/freenas/9.2.1/freenas9.2.1_guide.pdf">PDF</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.2.1/freenas9.2.1_guide.pdf">9.2</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.1.1/freenas9.1.1_guide.pdf">9.1</a>
     <a href="https://www.ixsystems.com/documentation/freenas/8.3.1/freenas8.3.1_guide.pdf">8.3</a>

--- a/content/Archive.md
+++ b/content/Archive.md
@@ -2,7 +2,7 @@
 title: "Documentation Archive"
 ---
 
-Welcome to the Documentation Archive!
+Welcome to the Documentation Archive! TEST CHANGE
 
 {{< hint warning >}}
 All documentation provided here is End of Life (EoL) and no longer receives **any** updates.
@@ -25,7 +25,7 @@ All documentation provided here is End of Life (EoL) and no longer receives **an
 </div>
 
 <div class="dropdown">
-  <button class="dropbtn">Legacy FreeNAS TEST CHANGE</button>
+  <button class="dropbtn">Legacy FreeNAS</button>
   <div class="dropdown-content">
     <a href="https://www.ixsystems.com/documentation/freenas/11.3-U5/FreeNAS-11.3-U5-User-Guide_screen.pdf">11.3</a>
     <a href="https://www.ixsystems.com/documentation/freenas/11.2-U8/FreeNAS-11.2-U8-User-Guide_screen.pdf">11.2 (New GUI)</a>

--- a/content/Archive.md
+++ b/content/Archive.md
@@ -8,4 +8,45 @@ Welcome to the Documentation Archive!
 All documentation provided here is End of Life (EoL) and no longer receives **any** updates.
 {{< /hint >}}
 
+<div class="dropdown">
+  <button class="dropbtn">TrueNAS (Unified)</button>
+  <div class="dropdown-content">
+    <a href=".">Coming Soon!</a>
+  </div>
+</div>
 
+<div class="dropdown">
+  <button class="dropbtn">Legacy TrueNAS</button>
+  <div class="dropdown-content">
+    <a href="https://www.truenas.com/docs/files/TrueNAS-11.3-U5-User-Guide.pdf">11.3</a>
+    <a href="https://www.ixsystems.com/documentation/truenas/11.2-U8-legacy/TrueNAS-11.2-U8-Legacy-User-Guide_screen.pdf">11.2</a>
+    <a href="https://www.ixsystems.com/documentation/truenas/11.1/TrueNAS.pdf">11.1</a>
+  </div>
+</div>
+
+<div class="dropdown">
+  <button class="dropbtn">Legacy FreeNAS</button>
+  <div class="dropdown-content">
+    <a href="https://www.ixsystems.com/documentation/freenas/11.3-U5/FreeNAS-11.3-U5-User-Guide_screen.pdf">11.3</a>
+    <a href="https://www.ixsystems.com/documentation/freenas/11.2-U8/FreeNAS-11.2-U8-User-Guide_screen.pdf">11.2 (New GUI)</a>
+    <a href="https://www.ixsystems.com/documentation/freenas/11.2-U8-legacy/FreeNAS-11.2-U8-Legacy-User-Guide_screen.pdf">11.2 (Legacy GUI)</a>
+    <a href="https://www.ixsystems.com/documentation/freenas/11.1/FreeNAS.pdf">11.1</a>
+    <a href="https://www.ixsystems.com/documentation/freenas/9.10/freenas.html">9.10</a>
+    <a href="https://www.ixsystems.com/documentation/freenas/9.3/freenas.html">9.3</a>
+    <a href="https://www.ixsystems.com/documentation/freenas/9.2.1/freenas9.2.1_guide.pdf">9.2</a>
+    <a href="https://www.ixsystems.com/documentation/freenas/9.1.1/freenas9.1.1_guide.pdf">9.1</a>
+    <a href="https://www.ixsystems.com/documentation/freenas/8.3.1/freenas8.3.1_guide.pdf">8.3</a>
+    <a href="https://www.ixsystems.com/documentation/freenas/8.2/freenas8.2_guide.pdf">8.2</a>
+    <a href="https://www.ixsystems.com/documentation/freenas/8.0.3/freenas8.0.3_guide.pdf">8.0</a>
+  </div>
+</div>
+
+<div class="dropdown">
+  <button class="dropbtn">TrueCommand</button>
+  <div class="dropdown-content">
+    <a href="https://www.truenas.com/docs/files/TrueCommand1.3Docs.pdf">1.3</a>
+    <a href="https://www.ixsystems.com/documentation/truecommand/1.2/TrueCommand-Guide-1.2_screen.pdf">1.2</a>
+    <a href="https://www.ixsystems.com/documentation/truecommand/1.1/TrueCommand-Guide-1.1_screen.pdf">1.1</a>
+    <a href="https://www.ixsystems.com/documentation/truecommand/1.0/TrueCommand-Guide-1.0-RELEASE.pdf">1.0</a>
+  </div>
+</div>

--- a/content/Archive.md
+++ b/content/Archive.md
@@ -25,7 +25,7 @@ All documentation provided here is End of Life (EoL) and no longer receives **an
 </div>
 
 <div class="dropdown">
-  <button class="dropbtn">Legacy FreeNAS Bootie</button>
+  <button class="dropbtn">Legacy FreeNAS TEST CHANGE</button>
   <div class="dropdown-content">
     <a href="https://www.ixsystems.com/documentation/freenas/11.3-U5/FreeNAS-11.3-U5-User-Guide_screen.pdf">11.3</a>
     <a href="https://www.ixsystems.com/documentation/freenas/11.2-U8/FreeNAS-11.2-U8-User-Guide_screen.pdf">11.2 (New GUI)</a>

--- a/content/Archive.md
+++ b/content/Archive.md
@@ -32,7 +32,6 @@ All documentation provided here is End of Life (EoL) and no longer receives **an
     <a href="https://www.ixsystems.com/documentation/freenas/11.2-U8-legacy/FreeNAS-11.2-U8-Legacy-User-Guide_screen.pdf">11.2 (Legacy GUI)</a>
     <a href="https://www.ixsystems.com/documentation/freenas/11.1/FreeNAS.pdf">11.1</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.10/freenas.html">9.10</a>
-    <a href="https://www.ixsystems.com/documentation/freenas/9.3/freenas.html">9.3</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.2.1/freenas9.2.1_guide.pdf">9.2</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.1.1/freenas9.1.1_guide.pdf">9.1</a>
     <a href="https://www.ixsystems.com/documentation/freenas/8.3.1/freenas8.3.1_guide.pdf">8.3</a>

--- a/content/Archive.md
+++ b/content/Archive.md
@@ -32,8 +32,6 @@ All documentation provided here is End of Life (EoL) and no longer receives **an
     <a href="https://www.ixsystems.com/documentation/freenas/11.2-U8-legacy/FreeNAS-11.2-U8-Legacy-User-Guide_screen.pdf">11.2 (Legacy GUI)</a>
     <a href="https://www.ixsystems.com/documentation/freenas/11.1/FreeNAS.pdf">11.1</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.10/freenas.html">9.10</a>
-    9.3 
-    <a href="https://www.ixsystems.com/documentation/freenas/9.3/freenas.html">HTML</a> <a href="https://www.ixsystems.com/documentation/freenas/9.2.1/freenas9.2.1_guide.pdf">PDF</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.2.1/freenas9.2.1_guide.pdf">9.2</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.1.1/freenas9.1.1_guide.pdf">9.1</a>
     <a href="https://www.ixsystems.com/documentation/freenas/8.3.1/freenas8.3.1_guide.pdf">8.3</a>

--- a/content/Archive.md
+++ b/content/Archive.md
@@ -8,44 +8,4 @@ Welcome to the Documentation Archive!
 All documentation provided here is End of Life (EoL) and no longer receives **any** updates.
 {{< /hint >}}
 
-<div class="dropdown">
-  <button class="dropbtn">TrueNAS (Unified)</button>
-  <div class="dropdown-content">
-    <a href=".">Coming Soon!</a>
-  </div>
-</div>
 
-<div class="dropdown">
-  <button class="dropbtn">Legacy TrueNAS</button>
-  <div class="dropdown-content">
-    <a href="https://www.truenas.com/docs/files/TrueNAS-11.3-U5-User-Guide.pdf">11.3</a>
-    <a href="https://www.ixsystems.com/documentation/truenas/11.2-U8-legacy/TrueNAS-11.2-U8-Legacy-User-Guide_screen.pdf">11.2</a>
-    <a href="https://www.ixsystems.com/documentation/truenas/11.1/TrueNAS.pdf">11.1</a>
-  </div>
-</div>
-
-<div class="dropdown">
-  <button class="dropbtn">Legacy FreeNAS</button>
-  <div class="dropdown-content">
-    <a href="https://www.ixsystems.com/documentation/freenas/11.3-U5/FreeNAS-11.3-U5-User-Guide_screen.pdf">11.3</a>
-    <a href="https://www.ixsystems.com/documentation/freenas/11.2-U8/FreeNAS-11.2-U8-User-Guide_screen.pdf">11.2 (New GUI)</a>
-    <a href="https://www.ixsystems.com/documentation/freenas/11.2-U8-legacy/FreeNAS-11.2-U8-Legacy-User-Guide_screen.pdf">11.2 (Legacy GUI)</a>
-    <a href="https://www.ixsystems.com/documentation/freenas/11.1/FreeNAS.pdf">11.1</a>
-    <a href="https://www.ixsystems.com/documentation/freenas/9.10/freenas.html">9.10</a>
-    <a href="https://www.ixsystems.com/documentation/freenas/9.2.1/freenas9.2.1_guide.pdf">9.2</a>
-    <a href="https://www.ixsystems.com/documentation/freenas/9.1.1/freenas9.1.1_guide.pdf">9.1</a>
-    <a href="https://www.ixsystems.com/documentation/freenas/8.3.1/freenas8.3.1_guide.pdf">8.3</a>
-    <a href="https://www.ixsystems.com/documentation/freenas/8.2/freenas8.2_guide.pdf">8.2</a>
-    <a href="https://www.ixsystems.com/documentation/freenas/8.0.3/freenas8.0.3_guide.pdf">8.0</a>
-  </div>
-</div>
-
-<div class="dropdown">
-  <button class="dropbtn">TrueCommand</button>
-  <div class="dropdown-content">
-    <a href="https://www.truenas.com/docs/files/TrueCommand1.3Docs.pdf">1.3</a>
-    <a href="https://www.ixsystems.com/documentation/truecommand/1.2/TrueCommand-Guide-1.2_screen.pdf">1.2</a>
-    <a href="https://www.ixsystems.com/documentation/truecommand/1.1/TrueCommand-Guide-1.1_screen.pdf">1.1</a>
-    <a href="https://www.ixsystems.com/documentation/truecommand/1.0/TrueCommand-Guide-1.0-RELEASE.pdf">1.0</a>
-  </div>
-</div>

--- a/content/Archive.md
+++ b/content/Archive.md
@@ -25,13 +25,14 @@ All documentation provided here is End of Life (EoL) and no longer receives **an
 </div>
 
 <div class="dropdown">
-  <button class="dropbtn">Legacy FreeNAS</button>
+  <button class="dropbtn">Legacy FreeNAS Bootie</button>
   <div class="dropdown-content">
     <a href="https://www.ixsystems.com/documentation/freenas/11.3-U5/FreeNAS-11.3-U5-User-Guide_screen.pdf">11.3</a>
     <a href="https://www.ixsystems.com/documentation/freenas/11.2-U8/FreeNAS-11.2-U8-User-Guide_screen.pdf">11.2 (New GUI)</a>
     <a href="https://www.ixsystems.com/documentation/freenas/11.2-U8-legacy/FreeNAS-11.2-U8-Legacy-User-Guide_screen.pdf">11.2 (Legacy GUI)</a>
     <a href="https://www.ixsystems.com/documentation/freenas/11.1/FreeNAS.pdf">11.1</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.10/freenas.html">9.10</a>
+    <a href="https://www.ixsystems.com/documentation/freenas/9.3/freenas.html">9.3</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.2.1/freenas9.2.1_guide.pdf">9.2</a>
     <a href="https://www.ixsystems.com/documentation/freenas/9.1.1/freenas9.1.1_guide.pdf">9.1</a>
     <a href="https://www.ixsystems.com/documentation/freenas/8.3.1/freenas8.3.1_guide.pdf">8.3</a>


### PR DESCRIPTION
The Archive has two entries for previous versions that are still HTML:

https://www.ixsystems.com/documentation/freenas/9.3/freenas.html 
https://www.ixsystems.com/documentation/freenas/9.10/freenas.html 
These html docs need to be downloaded, coverted to PDF, and reuploaded to the Docs Hub and Archive links updated.
