### PR TITLE
[12.0-U6.1] Update known issues to mention SMB core dump/non-serving

### DIFF
--- a/content/ReleaseNotes/CORE/12.0U6.1.md
+++ b/content/ReleaseNotes/CORE/12.0U6.1.md
@@ -71,6 +71,14 @@ TrueNAS Enterprise customers are encouraged to upgrade their systems to get the 
             <td>TrueNAS "root" user account cannot be an SMB user.</td>
 			<td>This is an intentional change to improve software security and suitability for deployment in a variety of environments. Update the SMB configuration to use a different user account.</td>
           </tr>
+          <tr>
+			<td>
+				<a href="https://jira.ixsystems.com/browse/NAS-113340" target="_blank">NAS-113340</a><br/>
+				<a href="https://jira.ixsystems.com/browse/NAS-113461" target="_blank">NAS-113461</a>
+		  	</td>
+            <td>Samba may fail in some circumstances.</td>
+			<td>Security updates to Samba in this release, involving big changes under the hood from 12.0-U6, have in some cases resulted in Samba (1) failing to start correctly, or (2) starting but failing to allow correct connections. To be resolved in the next release.</td>
+          </tr>
         </tbody>
       </table>
     </body>


### PR DESCRIPTION
Worth mentioning as an issue here, because it's apparently been reported an issue by quite a lot of users, and is quite severe for SMB users.

If this needs a JIRA ref, beyond the existing TrueNAS issue refs in the PR, let me know, I'll add a JIRA docs issue to match