### PR TITLE
Add Known Issue about samba auxiliary parameters to 12.0-U6.1 Release Notes

### DIFF
--- a/content/ReleaseNotes/CORE/12.0U6.1.md
+++ b/content/ReleaseNotes/CORE/12.0U6.1.md
@@ -45,31 +45,37 @@ TrueNAS Enterprise customers are encouraged to upgrade their systems to get the 
       <table width="100%">
         <thead>
           <tr>
-			<th>Key</th>
-			<th>Summary</th>
-			<th>Workaround</th>
+            <th>Key</th>
+            <th>Summary</th>
+            <th>Workaround</th>
           </tr>
         </thead>
         <tbody>
-	  <tr>
-		  <td></td>
-		  <td>Asigra Plugin Upgrades</td>
-		  <td>Asigra users running version <b>14.2.0.2 or earlier</b> requires a TrueNAS CLI upgrade procedure to update to a new plugin version. In the TrueNAS web interface, open the **Shell** and enter <code>iocage upgrade asigra-plugin-name</code>, replacing <code>asigra-plugin-name</code> with whatever unique name was created for the plugin.</td>
           <tr>
-			<td><a href="https://jira.ixsystems.com/browse/NAS-106992" target="_blank">NAS-106992</a></td>
-			<td>Persistent L2ARC is disabled by default.</td>
-			<td>While the underlying issues have been fixed, this setting continues to be disabled by default for additional performance investigation. To manually reactivate persistent L2ARC, log in to the TrueNAS Web Interface, go to <b>System > Tunables</b>, and add a new tunable with these values:
-  			  <ul>
-			    <li>Type = <code>sysctl</code></li>
-			    <li>Variable = <code>vfs.zfs.l2arc.rebuild_enabled</code></li>
-			    <li>Value = <code>1</code></li>
-  			  </ul>
-			</td>
+            <td></td>
+            <td>Asigra Plugin Upgrades</td>
+            <td>Asigra users running version <b>14.2.0.2 or earlier</b> requires a TrueNAS CLI upgrade procedure to update to a new plugin version. In the TrueNAS web interface, open the **Shell** and enter <code>iocage upgrade asigra-plugin-name</code>, replacing <code>asigra-plugin-name</code> with whatever unique name was created for the plugin.</td>
           </tr>
           <tr>
-			<td></td>
+            <td><a href="https://jira.ixsystems.com/browse/NAS-106992" target="_blank">NAS-106992</a></td>
+            <td>Persistent L2ARC is disabled by default.</td>
+            <td>While the underlying issues have been fixed, this setting continues to be disabled by default for additional performance investigation. To manually reactivate persistent L2ARC, log in to the TrueNAS Web Interface, go to <b>System > Tunables</b>, and add a new tunable with these values:
+                <ul>
+                    <li>Type = <code>sysctl</code></li>
+                    <li>Variable = <code>vfs.zfs.l2arc.rebuild_enabled</code></li>
+                    <li>Value = <code>1</code></li>
+                </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
             <td>TrueNAS "root" user account cannot be an SMB user.</td>
-			<td>This is an intentional change to improve software security and suitability for deployment in a variety of environments. Update the SMB configuration to use a different user account.</td>
+            <td>This is an intentional change to improve software security and suitability for deployment in a variety of environments. Update the SMB configuration to use a different user account.</td>
+          </tr>
+          <tr>
+            <td><a href="https://jira.ixsystems.com/browse/NAS-113336" target="_blank">NAS-113336</a> and <a href="https://jira.ixsystems.com/browse/NAS-113326" target="_blank">NAS-113326</a></td>
+            <td>Custom configuration of SMB server with auxiliary parameters to enable vfs_full_audit or wide links might prevent SMB share access.</td>
+            <td>Disable these parameters in 12.0-U6.1. Updating to 12.0-U7 fixes this issue. Note that samba auxiliary parameters are available "as-is" and can vary in functionality between releases. Using the default configuration options is recommended.</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
Rebalance whitespace in Known Issues table.
Add new note about samba issues with custom widelink and vfs_full_audit parameters.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
