### PR TITLE
DOCS-2932: Add iconify for MDI icon support

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,14 +6,19 @@
 <title>{{ partial "title" . }} | {{ .Site.Title -}}</title>
 
 <link rel="icon" href="{{ "favicon/TN-favicon-32x32.png" | relURL }}" type="image/x-icon">
+
 <!-- Add Font Awesome and Material Design -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <link rel="stylesheet" href="https://use.typekit.net/tjl0ypy.css">
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 <link rel="stylesheet" href="//cdn.materialdesignicons.com/5.4.55/css/materialdesignicons.min.css">
 
+<!-- Add Iconify for MDI icon support -->
+<script src="https://code.iconify.design/2/2.1.0/iconify.min.js"></script>
+
 <!-- Support embedding videos using video.js -->
 <link rel="stylesheet" href="https://vjs.zencdn.net/7.15.4/video-js.css">
+
 <!-- Support IE8 for Video.js versions prior to v7 -->
 <script src="https://vjs.zencdn.net/ie8/1.1.2/videojs-ie8.min.js"></script>
 


### PR DESCRIPTION
Local build test allows a single <span> inject to call the MDI icon and add as an SVG to inline content.
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
