### PR TITLE
DOCS-3167: Update release schedule

### DIFF
--- a/content/ReleaseNotes/ReleaseSchedule.md
+++ b/content/ReleaseNotes/ReleaseSchedule.md
@@ -3,40 +3,76 @@ title: "Software Release Schedule"
 weight: 5
 ---
 
-This is the latest roadmap for major TrueNAS and TrueCommand releases.
+This is the roadmap for upcoming software releases.
+
+{{< hint warning >}}
 All release dates listed are **tentative and are subject to change**.
+The items in this list might not show every deadline or testing cycle that iXsystems uses to manage internal effort.
+{{< /hint >}}
 
 The progress and specific work is being tracked through tickets opened in Jira.
-If you have a feature suggestion or bug report, create a Jira account and file a ticket in the [TrueNAS](https://jira.ixsystems.com/projects/NAS "TrueNAS Jira Project"), [TrueCommand](https://jira.ixsystems.com/projects/TC "TrueCommand Jira Project"), or [TrueNAS vCenter Plugin](https://jira.ixsystems.com/secure/RapidBoard.jspa?rapidView=26&projectKey=VCP "TrueNAS vCenter Plugin Project") projects.
+If you have a feature suggestion or bug report, create a Jira account and file a ticket in the [TrueNAS](https://jira.ixsystems.com/projects/NAS "TrueNAS Jira Project") or  [TrueCommand](https://jira.ixsystems.com/projects/TC "TrueCommand Jira Project") projects.
 TrueNAS SCALE tickets are also tracked in the TrueNAS Jira Project.
 
 {{< tabs "Roadmaps" >}}
 {{< tab "TrueNAS CORE" >}}
 
-| Version                                                                   | Scheduled Release Date |
-|---------------------------------------------------------------------------|------------------------|
-|                                                                           |                        |
+| Version | Checkpoint | Scheduled Date |
+|---------|------------|----------------|
+| 12.0-U8 | Code-freeze | 10 January 2022 |
+| 12.0-U8 | Internal Testing Sprints | 11 January > 01 February 2022 |
+| 12.0-U8 | Tag | 02 February 2022 |
+| 12.0-U8 | Release | 02 February 2022 |
+| 13.0-BETA.1 | Code-freeze | 19 January 2022 |
+| 13.0-BETA.1 | Internal Testing Sprints | 24 January > 04 February 2022 |
+| 13.0-BETA.1 | Tag | 07 February 2022 |
+| 13.0-BETA.1 | Release | 08 February 2022 |
+| 13.0-RC.1 | Code-freeze | 23 February 2022 |
+| 13.0-RC.1 | Internal Testing Sprints | 28 February > 04 March 2022 |
+| 13.0-RC.1 | Tag | 07 March 2022 |
+| 13.0-RC.1 | Release | 08 March 2022 |
+| 13.0-RELEASE | Code-freeze | 30 March 2022 |
+| 13.0-RELEASE | Internal Testing Sprints | 04 April > 08 April 2022 |
+| 13.0-RELEASE | Tag | 11 April 2022 |
+| 13.0-RELEASE | Release | 12 April 2022 |
+| 13.0-U1 | Code-freeze | 20 April 2022 |
+| 13.0-U1 | Internal Testing Sprints | 25 April > 29 April 2022 |
+| 13.0-U1 | Tag | 02 May 2022 |
+| 13.0-U1 | Release | 03 May 2022 |
+| 13.0-U2 | Code-freeze | 15 June 2022 |
+| 13.0-U2 | Internal Testing Sprints | 20 June > 24 June 2022 |
+| 13.0-U2 | Tag | 27 June 2022 |
+| 13.0-U2 | Release | 28 June 2022 |
 
 {{< /tab >}}
 {{< tab "TrueNAS SCALE" >}}
 
-| Version                                                                                | Scheduled Release Date |
-|----------------------------------------------------------------------------------------|------------------------|
-|                                                                                        |  |
+| Version | Checkpoint | Scheduled Date |
+|---------|------------|----------------|
+| SCALE 22.02.0 | Code-freeze | 02 February 2022 |
+| SCALE 22.02.0 | Internal Testing Sprints | 07 February > 18 February 2022 |
+| SCALE 22.02.0 | Tag | 21 February 2022 |
+| SCALE 22.02.0 | Release | 22 February 2022 |
+| SCALE 22.02.1 | Code-freeze | 06 April 2022 |
+| SCALE 22.02.1 | Internal Testing Sprints | 11 April > 22 April 2022 |
+| SCALE 22.02.1 | Tag | 25 April 2022 |
+| SCALE 22.02.1 | Release | 26 April 2022 |
+| SCALE 22.02.2 | Code-freeze | 08 June 2022 |
+| SCALE 22.02.2 | Internal Testing Sprints | 13 June > 17 June 2022 |
+| SCALE 22.02.2 | Tag | 20 June 2022 |
+| SCALE 22.02.2 | Release | 21 June 2022 |
 
 {{< /tab >}}
 {{< tab "TrueCommand" >}}
 
-| Version                                                                  | Scheduled Release Date |
-|--------------------------------------------------------------------------|------------------------|
-| [TrueCommand 2.1](https://jira.ixsystems.com/projects/TC/versions/12202) | Q4 2021 |
-
-{{< /tab >}}
-{{< tab "TrueNAS vCenter Plugin" >}}
-
-| Version                                                                      | Scheduled Release Date |
-|------------------------------------------------------------------------------|------------------------|
-| [vCenter Plugin 4.0](https://jira.ixsystems.com/projects/VCP/versions/12108) | TBD |
+| Version | Checkpoint | Scheduled Date |
+|---------|------------|----------------|
+| 2.1.1   | Release    | TBD            |
+| 2.2.0-BETA.1 | Internal Testing Sprints | 04 April > 08 April 2022 |
+| 2.2.0-RC.1 | Internal Testing Sprints | 25 April > 29 April 2022 |
+| 2.2.0 | Code-freeze | 27 April 2022 |
+| 2.2.0 | Internal Testing Sprints | 02 May 2022 > 06 May 2022 |
+| 2.2.0 | Release | 17 May 2022 |
 
 {{< /tab >}}
 {{< /tabs >}}


### PR DESCRIPTION
Fill in checkpoints for every software release scheduled during Q1 and Q2 2022
Add larger warning about tentative dates and separate internal iXsystems effort.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
