### PR TITLE
Removed warning about early development

### DIFF
--- a/content/SCALE/_index.md
+++ b/content/SCALE/_index.md
@@ -25,10 +25,6 @@ Unlike other HCI platforms, a user can get started with TrueNAS SCALE on a singl
 TrueNAS SCALE is true Disaggregated HCI, meaning storage and compute can be scaled independently.
 Each node can support Virtual Machines (with the KVM hypervisor) as well as Docker containers by using native Kubernetes.
 
-{{< hint warning >}}
-TrueNAS SCALE is in early development and is not recommended for production use.
-{{< /hint >}}
-
 {{< tabs "SCALE Features" >}}
 {{< tab "Open Source" >}}
 Free to download and use, TrueNAS SCALE welcomes developers and testers to contribute to its Open Source development model.


### PR DESCRIPTION
I believe with the SCALE 22.02 release is this warning obsolete.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
