### PR TITLE
DOCS-3345 ES60 BSG PDF is unavailable

### DIFF
--- a/content/Hardware/ExpansionShelves/ES60BSG.md
+++ b/content/Hardware/ExpansionShelves/ES60BSG.md
@@ -3,6 +3,6 @@ title: "ES60 Basic Setup Guide"
 weight: 30
 ---
 
-<object data="https://www.truenas.com/docs/files/ES60BSGv1.91.pdf" type="application/pdf" width="95%" height="1000">
-  There was an error displaying this PDF, <a href="https://www.truenas.com/docs/files/ES60BSGv1.91.pdf">please click here to download the file.</a>
+<object data="https://www.truenas.com/docs/files/ES60BSG1.91.pdf" type="application/pdf" width="95%" height="1000">
+  There was an error displaying this PDF, <a href="https://www.truenas.com/docs/files/ES60BSG1.91.pdf">please click here to download the file.</a>
 </object>


### PR DESCRIPTION
Update the Docs Hub publish location to ensure the ES60 BSG is viewable and downloadable: https://www.truenas.com/docs/hardware/expansionshelves/es60bsg/ 