### PR TITLE
DOCS-3527: Core HA to SCALE HA Upgrades are not possible

### DIFF
--- a/content/SCALE/GettingStarted/MigratingFromCORE.md
+++ b/content/SCALE/GettingStarted/MigratingFromCORE.md
@@ -7,6 +7,7 @@ weight: 11
 
 {{< hint danger >}}
 Migrating TrueNAS from CORE to SCALE is a one-way operation. Attempting to activate or roll back to a CORE boot environment can break the system.
+CORE systems with High Availability enabled (HA) can not be upgraded to SCALE HA.
 {{< /hint >}}
 
 {{< hint danger >}}

--- a/content/TrueNASUpgrades/_index.md
+++ b/content/TrueNASUpgrades/_index.md
@@ -36,6 +36,7 @@ See [CORE Updates]({{< relref "/content/CORE/System/Update/_index.md" >}}) for m
 
 {{< hint danger >}}
 SCALE is still pre-release software.
+CORE HA systems to SCALE HA upgrades are not possible.
 It is not suitable for TrueNAS Enterprise customers and CORE users should always exercise caution and back up their data and system configuration before starting an upgrade.
 {{< /hint >}}
 

--- a/content/TrueNASUpgrades/_index.md
+++ b/content/TrueNASUpgrades/_index.md
@@ -36,7 +36,7 @@ See [CORE Updates]({{< relref "/content/CORE/System/Update/_index.md" >}}) for m
 
 {{< hint danger >}}
 SCALE is still pre-release software.
-CORE HA systems to SCALE HA upgrades are not possible.
+CORE systems with High Availability enabled (HA) can not be upgraded to SCALE with HA.
 It is not suitable for TrueNAS Enterprise customers and CORE users should always exercise caution and back up their data and system configuration before starting an upgrade.
 {{< /hint >}}
 

--- a/content/TrueNASUpgrades/_index.md
+++ b/content/TrueNASUpgrades/_index.md
@@ -35,7 +35,7 @@ See [CORE Updates]({{< relref "/content/CORE/System/Update/_index.md" >}}) for m
 ## Migrating from CORE to SCALE
 
 {{< hint danger >}}
-SCALE is still pre-release software.
+SCALE is a new and maturing software.
 CORE systems with High Availability enabled (HA) can not be upgraded to SCALE with HA.
 It is not suitable for TrueNAS Enterprise customers and CORE users should always exercise caution and back up their data and system configuration before starting an upgrade.
 {{< /hint >}}


### PR DESCRIPTION

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
