### PR TITLE
DOCS-2467: Enable Commenting system on the Docs Hub

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -38,6 +38,8 @@
                 {{ partial "page-footer" . }}
             </div>
         </main>
+		<script defer src="https://cdn.commento.io/js/commento.js"></script>
+		<div id="commento"></div>
 
         {{ partial "site-footer" . }}
     </div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -38,8 +38,6 @@
                 {{ partial "page-footer" . }}
             </div>
         </main>
-		<script defer src="https://cdn.commento.io/js/commento.js"></script>
-		<div id="commento"></div>
 
         {{ partial "site-footer" . }}
     </div>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -6,5 +6,7 @@
         	{{ partial "reading-time.html" . }}
     	{{ end }}
         {{ partial "content" . }}
+		<script defer src="https://cdn.commento.io/js/commento.js"></script>
+		<div id="commento"></div>
     </article>
 {{ end }}


### PR DESCRIPTION
Enable comment threads on each article of the Docs Hub.
The website is using https://commento.io/ on the back end to handle the comment system. Readers can comment and log in using their GitHub or Google account logins and moderation tools are available for the website maintainers.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
