### PR TITLE
DOCS-3681: Fix Korn Shell Links

### DIFF
--- a/content/CORE/Accounts/Users.md
+++ b/content/CORE/Accounts/Users.md
@@ -88,7 +88,7 @@ A specific [shell]({{< relref "Shell.md" >}}) can be set for the user from the *
 | tcsh	| [Enhanced C shell](https://www.tcsh.org) that includes editing and name completion. |
 | bash	| [Bourne Again shell](https://www.gnu.org/software/bash/manual/bash.html) for the GNU operating system. |
 | ksh93	| [Korn shell](http://www.kornshell.com) that incorporates features from both *csh* and *sh*. |
-| mksh	| [MirBSD Korn Shell](https://www.mirbsd.org/mksh.htm) |
+| mksh	| [MirBSD Korn Shell](https://github.com/MirBSD/mksh) |
 | rbash	| [Restricted bash](https://www.gnu.org/software/bash/manual/html_node/The-Restricted-Shell.html) |
 | rzsh	| [Restricted zsh](https://www.csse.uwa.edu.au/programming/linux/zsh-doc/zsh_14.html) |
 | scponly | [scponly](https://github.com/scponly/scponly/wiki) restricts the user's SSH usage to only the `scp` and `sftp` commands. |

--- a/content/SCALE/Credentials/LocalUsers.md
+++ b/content/SCALE/Credentials/LocalUsers.md
@@ -96,7 +96,7 @@ You can set a specific [shell]({{< relref "ScaleShell.md" >}}) for the user from
 | tcsh	| [Enhanced C shell](https://www.tcsh.org) that includes editing and name completion. |
 | bash	| [Bourne Again shell](https://www.gnu.org/software/bash/manual/bash.html) for the GNU operating system. |
 | ksh93	| [Korn shell](http://www.kornshell.com) that incorporates features from both *csh* and *sh*. |
-| mksh	| [MirBSD Korn Shell](https://www.mirbsd.org/mksh.htm) |
+| mksh	| [MirBSD Korn Shell](https://github.com/MirBSD/mksh) |
 | rbash	| [Restricted bash](https://www.gnu.org/software/bash/manual/html_node/The-Restricted-Shell.html) |
 | rzsh	| [Restricted zsh](https://www.csse.uwa.edu.au/programming/linux/zsh-doc/zsh_14.html) |
 | scponly | [scponly](https://github.com/scponly/scponly/wiki) restricts the user's SSH usage to only the `scp` and `sftp` commands. |


### PR DESCRIPTION
Links to mirbsd.org/mksh.htm are broken - using github links



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
