### PR TITLE
Docs-3591 Update SED Article

### DIFF
--- a/content/CORE/CORETutorials/Storage/SED.md
+++ b/content/CORE/CORETutorials/Storage/SED.md
@@ -10,21 +10,25 @@ TrueNAS version 11.1-U5 introduced Self-Encrypting Drive (SED) support.
 
 ## Supported Specifications
 
-* Legacy interface for older ATA devices. **Not recommended for security-critical environments**.
-* [TCG Opal 1](https://trustedcomputinggroup.org/wp-content/uploads/Opal_SSC_1.00_rev3.00-Final.pdf) legacy specification.
-* [TCG OPAL 2](https://trustedcomputinggroup.org/wp-content/uploads/TCG_Storage-Opal_SSC_v2.01_rev1.00.pdf) standard for newer consumer-grade devices.
-* [TCG Opalite](https://trustedcomputinggroup.org/wp-content/uploads/TCG_Storage-Opalite_SSC_FAQ.pdf) is a reduced form of OPAL 2.
-* TCG Pyrite [Version 1](https://trustedcomputinggroup.org/wp-content/uploads/TCG_Storage-Pyrite_SSC_v1.00_r1.00.pdf) and [Version 2](https://trustedcomputinggroup.org/wp-content/uploads/TCG_Storage-Pyrite_SSC_v2.00_r1.00_PUB.pdf) are similar to Opalite, but hardware encryption is removed. Pyrite provides a logical equivalent of the legacy ATA security for non-ATA devices. Only the drive firmware is used to protect the device.
+* Legacy interface for older ATA devices (Not recommended for security-critical environments!)
+* [TCG Opal 1](https://trustedcomputinggroup.org/wp-content/uploads/Opal_SSC_1.00_rev3.00-Final.pdf) legacy specification
+* [TCG OPAL 2](https://trustedcomputinggroup.org/wp-content/uploads/TCG_Storage-Opal_SSC_v2.01_rev1.00.pdf) standard for newer consumer-grade devices
+* [TCG Opalite](https://trustedcomputinggroup.org/wp-content/uploads/TCG_Storage-Opalite_SSC_FAQ.pdf) which is a reduced form of OPAL 2
+* TCG Pyrite [Version 1](https://trustedcomputinggroup.org/wp-content/uploads/TCG_Storage-Pyrite_SSC_v1.00_r1.00.pdf) and 
+  [Version 2](https://trustedcomputinggroup.org/wp-content/uploads/TCG_Storage-Pyrite_SSC_v2.00_r1.00_PUB.pdf) are similar to Opalite, but with hardware encryption removed
+  Pyrite provides a logical equivalent of the legacy ATA security for non-ATA devices. Only the drive firmware is used to protect the device.
   {{< hint danger >}}
   Pyrite Version 1 SEDs do not have PSID support and can become unusable if the password is lost.
   {{< /hint >}}
-* [TCG Enterprise](https://trustedcomputinggroup.org/wp-content/uploads/TCG_Storage-SSC_Enterprise-v1.01_r1.00.pdf) is designed for systems with many data disks. These SEDs do not have the functionality to be unlocked before the operating system boots.
+* [TCG Enterprise](https://trustedcomputinggroup.org/wp-content/uploads/TCG_Storage-SSC_Enterprise-v1.01_r1.00.pdf) designed for systems with many data disks
+  These SEDs do not have the functionality to be unlocked before the operating system boots.
 
 See this Trusted Computing Group and NVM Express® [joint white paper](https://nvmexpress.org/wp-content/uploads/TCGandNVMe_Joint_White_Paper-TCG_Storage_Opal_and_NVMe_FINAL.pdf) for more details about these specifications.
 
 ## TrueNAS Implementation
 
-TrueNAS implements the security capabilities of [camcontrol](https://www.freebsd.org/cgi/man.cgi?query=camcontrol) for legacy devices and [sedutil-cli](https://www.mankier.com/8/sedutil-cli) for TCG devices. When managing a SED from the command line, it is recommended to use the `sedhelper` wrapper script for `sedutil-cli` to ease SED administration and unlock the full capabilities of the device. Examples of using these commands to identify and deploy SEDs are provided below.
+TrueNAS implements the security capabilities of [camcontrol](https://www.freebsd.org/cgi/man.cgi?query=camcontrol) for legacy devices and [sedutil-cli](https://www.mankier.com/8/sedutil-cli) for TCG devices. 
+When managing a SED from the command line, it is recommended to use the `sedhelper` wrapper script for `sedutil-cli` to ease SED administration and unlock the full capabilities of the device. Examples of using these commands to identify and deploy SEDs are provided [below](#deploying-seds).
 
 A SED can be configured before or after assigning the device to a pool.
 
@@ -33,12 +37,12 @@ By default, SEDs are not locked until the administrator takes ownership of them.
 A password-protected SED protects the data stored on the device when the device is physically removed from the system. This allows secure disposal of the device without having to first wipe the contents. Repurposing a SED on another system requires the SED password.
 
 {{< hint info >}}
-**For TrueNAS High Availability (HA) systems, SED drives are only unlocked on the active controller.**
+For TrueNAS High Availability (HA) systems, SED drives are only unlocked on the active controller!
 {{< /hint >}}
 
 ## Deploying SEDs
 
-Enter `sedutil-cli --scan` in the **Shell** to detect and list devices. The second column of the results identifies the drive type:
+Enter command `sedutil-cli --scan` in the **Shell** to detect and list devices. The second column of the results identifies the drive type:
 
 | Character | Standard   |
 |-----------|------------|
@@ -68,9 +72,11 @@ TrueNAS supports setting a global password for all detected SEDs or setting indi
 
 ### Setting a Global Password for SEDs
 
-Go to **System > Advanced > SED Password** and enter the password. **Record this password and store it in a safe place!**
-
-Now the SEDs must be configured with this password. Go to the **Shell** and enter `sedhelper setup <password>`, where `<password>` is the global password entered in **System > Advanced > SED Password**.
+Go to **System > Advanced > SED Password** and enter the password. 
+{{< hint "danger" >}}
+Record this password and store it in a safe place!
+{{< /hint >}}
+Now configure the SEDs with this password. Go to the **Shell** and enter command `sedhelper setup <password>`, where `<password>` is the global password entered in **System > Advanced > SED Password**.
 
 `sedhelper` ensures that all detected SEDs are properly configured to use the provided password:
 
@@ -81,7 +87,7 @@ da10                 [OK]
 da11                 [OK]
 ```
 
-Rerun `sedhelper setup <password>` every time a new SED is placed in the system to apply the global password to the new SED.
+Rerun command `sedhelper setup <password>` every time a new SED is placed in the system to apply the global password to the new SED.
 
 ### Creating Separate Passwords for Each SED
 
@@ -89,12 +95,13 @@ Go to **Storage > Disks**. Click the three dot menu (Options) for the confirmed 
 
 The **Storage > Disks** screen shows which disks have a configured SED password. The `SED Password` column shows a mark when the disk has a password. Disks that are not a SED or are unlocked using the global password are not marked in this column.
 
-The SED must be configured to use the new password. Go to the **Shell** and enter `sedhelper setup --disk <da1> <password>`, where `<da1>` is the SED to configure and `<password>` is the created password from **Storage > Disks > Edit Disks > SED Password**.
+The SED must be configured to use the new password. Go to the **Shell** and enter command `sedhelper setup --disk <da1> <password>`, where `<da1>` is the SED to configure and `<password>` is the created password from **Storage > Disks > Edit Disks > SED Password**.
 
-This process must be repeated for each SED and any SEDs added to the system in the future.
+Repeate this process for each SED and any SEDs added to the system in the future.
 
 {{< hint danger >}}
-Remember SED passwords! If the SED password is lost, SEDs cannot be unlocked and their data is unavailable. Always record SED passwords whenever they are configured or modified and store them in a secure place!
+Remember SED passwords! If the SED password is lost, SEDs cannot be unlocked and their data is unavailable. 
+Always record SED passwords whenever they are configured or modified and store them in a secure place!
 {{< /hint >}}
 
 ## Check SED Functionality
@@ -103,7 +110,7 @@ When SED devices are detected during system boot, TrueNAS checks for configured 
 
 Unlocking SEDs allows a pool to contain a mix of SED and non-SED devices. Devices with individual passwords are unlocked with their password. Devices without a device-specific password are unlocked using the global password.
 
-To verify SED locking is working correctly, go to the **Shell**. Enter `sedutil-cli --listLockingRange 0 <password> <dev/da1>`, where `<dev/da1>` is the SED and `<password>` is the global or individual password for that SED. The command returns `ReadLockEnabled: 1`, `WriteLockEnabled: 1`, and `LockOnReset: 1` for drives with locking enabled:
+To verify SED locking is working correctly, go to the **Shell**. Enter command `sedutil-cli --listLockingRange 0 <password> <dev/da1>`, where `<dev/da1>` is the SED and `<password>` is the global or individual password for that SED. The command returns `ReadLockEnabled: 1`, `WriteLockEnabled: 1`, and `LockOnReset: 1` for drives with locking enabled:
 
 ```
 root@truenas1:~ # sedutil-cli --listLockingRange 0 abcd1234 /dev/da9
@@ -121,7 +128,7 @@ Band[0]:
 
 ## Managing SED Passwords and Data
 
-This section contains command line instructions to manage SED passwords and data. The command used is [sedutil-cli(8)](https://www.mankier.com/8/sedutil-cli). Most SEDs are TCG-E (Enterprise) or TCG-Opal ([Opal v2.0](https://trustedcomputinggroup.org/wp-content/uploads/TCG_Storage-Opal_SSC_v2.01_rev1.00.pdf)). Commands are different for the different drive types, so the first step is identifying which type is being used.
+This section contains command line instructions to manage SED passwords and data. The command used is [sedutil-cli(8)](https://www.mankier.com/8/sedutil-cli). Most SEDs are TCG-E (Enterprise) or TCG-Opal ([Opal v2.0](https://trustedcomputinggroup.org/wp-content/uploads/TCG_Storage-Opal_SSC_v2.01_rev1.00.pdf)). Commands are different for the different drive types, so the first step is identifying which type is used.
 
 {{< hint warning >}}
 These commands can be destructive to data and passwords. Keep backups and use the commands with caution.
@@ -155,9 +162,11 @@ Scanning for Opal compliant disks
 No more disks present ending scan
 root@truenas:~ #
 ```
-{{< tabs "Instructions for Specific Drives" >}}
-{{< tab "TCG-Opal Instructions" >}}
-Reset the password without losing data: `sedutil-cli --revertNoErase <oldpassword> </dev/device>`
+{{< expand "Instructions for Specific Drives" >}}
+{{< expand "TCG-Opal Instructions" >}}
+Reset the password without losing data with command: 
+
+`sedutil-cli --revertNoErase <oldpassword> </dev/device>`
 
 Use **both** of these commands to change the password without destroying data:
 
@@ -166,15 +175,19 @@ sedutil-cli --setSIDPassword <oldpassword> <newpassword> </dev/device>
 sedutil-cli --setPassword <oldpassword> Admin1 <newpassword> </dev/device>
 ```
 
-Wipe data and reset password to default MSID: `sedutil-cli --revertTPer <oldpassword> </dev/device>`
+Wipe data and reset password to default MSID with this command: 
 
-Wipe data and reset password using the PSID: `sedutil-cli --yesIreallywanttoERASEALLmydatausingthePSID <PSINODASHED> </dev/device>` where <PSINODASHED> is the PSID located on the pysical drive with no dashes (-).
-{{< /tab >}}
-{{< tab "TCG-E Instructions" >}}
+`sedutil-cli --revertTPer <oldpassword> </dev/device>`
+
+Wipe data and reset password using the PSID with this command: 
+
+`sedutil-cli --yesIreallywanttoERASEALLmydatausingthePSID <PSINODASHED> </dev/device>` where <PSINODASHED> is the PSID located on the pysical drive with no dashes (-).
+{{< /expand >}}
+{{< expand "TCG-E Instructions" >}}
 ### Change or Reset the Password without Destroying Data
 
-These commands must be run for every *LockingRange* or *band* on the drive.
-To determine the number of bands on a drive, use `sedutil-cli -v --listLockingRanges </dev/device>`.
+Run these commands for every *LockingRange* or *band* on the drive.
+To determine the number of bands on a drive, use command `sedutil-cli -v --listLockingRanges </dev/device>`.
 Increment the `BandMaster` number and rerun the command with `--setPassword` for every band that exists.
 
 Use **all** of these commands to reset the password without losing data:
@@ -212,4 +225,5 @@ Reset using the PSID:
 If it fails use:
 
 `sedutil-cli --PSIDrevert <PSIDNODASHS>  /dev/<device>`
-{{< /tabs >}}
+{{< /expand >}}
+{{< /expand >}}


### PR DESCRIPTION
This commit updates the content in the SED.md article under CORETutorials.
It fixes style and grammar issues.
Local build tests links good.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
