### PR TITLE
DOCS-3223: Error and Alert ABORT Buttons Changed to Close

### DIFF
--- a/content/SCALE/GettingStarted/FirstTimeLogin.md
+++ b/content/SCALE/GettingStarted/FirstTimeLogin.md
@@ -106,7 +106,7 @@ The Directory Services Monitor displays the status of Active Directory and LDAP.
 {{< /tab >}}
 
 {{< tab "Task Manager" >}}
-The Task Manager displays all running and failed jobs/processes. 
+The Task Manager displays all running and failed jobs/processes. Error and Alert dialog boxes that were manually closed can be accessed in the Task Manager.
 
 ![TaskManagerSCALE](/images/SCALE/TaskManagerSCALE.png "TrueNAS SCALE Task Manager")
 


### PR DESCRIPTION
Added blurb about the ability to close an Error or Alert Dialog box and recover it in the Task Manager.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
