### PR TITLE
DOCS-3811: Add shortcode and new ToC expandable to Guide introductions

### DIFF
--- a/content/CORE/CORETutorials/_index.md
+++ b/content/CORE/CORETutorials/_index.md
@@ -6,7 +6,9 @@ weight: 40
 
 {{< include file="/_includes/TutorialsIntro.md" type="page" >}}
 
-To display all tutorials in a linear HTML format, export it to PDF, or physically print it, please select **[⎙ Download or Print]({{< relref "CORETutorialsPrint.md" >}})** from the site **Navigation** menu on the left.
+{{< expand "Table of Contents (click to expand)" "v" >}}
+{{< children depth="2" >}}
+{{< /expand >}}
 
 ## CORE Documentation Sections
 

--- a/content/CORE/CoreSecurityReports/_index.md
+++ b/content/CORE/CoreSecurityReports/_index.md
@@ -6,6 +6,12 @@ weight: 175
 
 See the [TrueNAS Security Hub](https://security.truenas.com/products/truenas-12.0/) to get the latest information that you need to maintain the security, integrity, and availability of your data.
 
+---
+
+{{< expand "Table of Contents (click to expand)" "v" >}}
+{{< children depth="2" >}}
+{{< /expand >}}
+
 ## CORE Documentation Sections
 
 {{< include file="/_includes/COREDocsSections.md" type="page" >}}

--- a/content/CORE/GettingStarted/_index.md
+++ b/content/CORE/GettingStarted/_index.md
@@ -10,7 +10,11 @@ weight: 10
 
 </div>
 
-This section guides you through installing and accessing TrueNAS, storing and backing up data, sharing data over a network, and expanding TrueNAS with different applications solutions.
+This guide introduces TrueNAS and walks you through installing and accessing TrueNAS, storing and backing up data, sharing data over a network, and expanding TrueNAS with different applications solutions.
+
+{{< expand "Table of Contents (click to expand)" "v" >}}
+{{< children depth="2" >}}
+{{< /expand >}}
 
 ## CORE Documentation Sections
 

--- a/content/CORE/UIReference/_index.md
+++ b/content/CORE/UIReference/_index.md
@@ -6,7 +6,13 @@ geekdocCollapseSection: true
 
 {{< include file="/_includes/UIReferenceIntro.md" type="page" >}}
 
-## CORE Documentation Sections
+---
+
+{{< expand "Table of Contents (click to expand)" "v" >}}
+{{< children depth="2" >}}
+{{< /expand >}}
+
+## CORE Guides
 
 {{< include file="/_includes/COREDocsSections.md" type="page" >}}
 

--- a/content/SCALE/GettingStarted/_index.md
+++ b/content/SCALE/GettingStarted/_index.md
@@ -12,6 +12,10 @@ weight: 20
 
 This section guides you through installing and accessing TrueNAS SCALE, storing, backing up, and sharing data, and expanding TrueNAS with different applications solutions.
 
+{{< expand "Table of Contents (click to expand)" "v" >}}
+{{< children depth="2" >}}
+{{< /expand >}}
+
 ## SCALE Documentation Sections
 
 For more detailed interface reference articles, configuration instructions, and tuning recommendations, see the remaining sections in this topic.

--- a/content/SCALE/SCALETutorials/_index.md
+++ b/content/SCALE/SCALETutorials/_index.md
@@ -6,7 +6,9 @@ geekdocCollapseSection: true
 
 {{< include file="/_includes/TutorialsIntro.md" type="page" >}}
 
-To display all tutorials in a linear HTML format, export it to PDF, or physically print it, please select **[⎙ Download or Print]({{< relref "SCALETutorialsPrint.md" >}})** from the site **Navigation** menu on the left.
+{{< expand "Table of Contents (click to expand)" "v" >}}
+{{< children depth="2" >}}
+{{< /expand >}}
 
 ## SCALE Documentation Sections
 

--- a/content/SCALE/SCALEUIReference/_index.md
+++ b/content/SCALE/SCALEUIReference/_index.md
@@ -6,6 +6,10 @@ geekdocCollapseSection: true
 
 {{< include file="/_includes/UIReferenceIntro.md" type="page" >}}
 
+{{< expand "Table of Contents (click to expand)" "v" >}}
+{{< children depth="2" >}}
+{{< /expand >}}
+
 ## SCALE Documentation Sections
 
 {{< include file="/_includes/SCALEDocsSections.md" type="page" >}}

--- a/content/_includes/COREDocsSections.md
+++ b/content/_includes/COREDocsSections.md
@@ -1,4 +1,4 @@
-TrueNAS CORE/Enterprise documentation is divided into several sections or books:
+Each major section of TrueNAS CORE/Enterprise documentation is organized as a standalone book:
 
 * The [Getting Started Guide](/core/gettingstarted) provides the first steps for your experience with TrueNAS CORE/Enterprise:
   * Recommendations and considerations when selecting hardware for CORE.

--- a/content/_includes/TutorialsIntro.md
+++ b/content/_includes/TutorialsIntro.md
@@ -8,7 +8,12 @@
 </div>
 
 Welcome to TrueNAS tutorials!
-This section collects various how-tos for both simple and complex tasks using primarily the TrueNAS web interface.
-The section is loosely organized by topic and is continuously being updated with new or replacement tutorials.
+
+This guide collects various how-tos for both simple and complex tasks using primarily the TrueNAS web interface.
+It is loosely organized by topic and is continuously being updated with new or replacement tutorials.
+
+To display all tutorials in a linear HTML format, export it to PDF, or physically print it, please select **⎙ Download or Print**.
 
 If you are interested in writing a TrueNAS tutorial, see the [Contributing section]({{< relref "/Contributing/_index.md" >}}) for some guidance!
+
+---

--- a/content/_includes/UIReferenceIntro.md
+++ b/content/_includes/UIReferenceIntro.md
@@ -10,9 +10,4 @@
 Welcome to this Web Interface (UI) Reference Guide!
 This document shows and describes each screen and configurable option contained within the TrueNAS web interface.
 The document is arranged in a **parallel** manner to the UI, beginning with the top panel and then descending through each option in the left side menu.
-
-This guide provides reference material about the UI menus, including descriptions of the various options presented in the UI.
-A **Getting Started Guide** is the recommended starting point for researching, installing, and initially configuring TrueNAS on your system.
-For step-by-step tutorials for specific configuration procedures, please see a CORE or SCALE **Tutorials** section
-
-To display this document in a linear HTML format, export it to PDF, or physically print it, please select **[⎙ Print Preview]({{< relref "UIReferencePrint.md" >}})** from the site **Navigation** menu on the left.
+To display this document in a linear HTML format, export it to PDF, or physically print it, please select **⎙ Download or Print**.

--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -1,0 +1,100 @@
+<!-- Thanks to the Learn Theme for Hugo: https://learn.netlify.app/en/ -->
+{{ $_hugo_config := `{ "version": 1 }` }}
+{{ $showhidden := .Get "showhidden"}}
+{{ $style :=  .Get "style" | default "li" }}
+{{ $depth :=  .Get "depth" | default 1 }}
+{{ $withDescription :=  .Get "description" | default false }}
+{{ $sortTerm :=  .Get "sort" | default "Weight" }}
+
+<ul class="children children-{{$style}}">
+	{{ .Scratch.Set "pages" .Page.Pages }}
+
+	{{if .Page.IsHome}}
+		<!-- Add pages that are in root dir -->
+		{{ $rootPage := where .Page.Pages "Dir" "" }}
+		{{ .Scratch.Set "pages" (.Page.Sections | union $rootPage)}}
+	{{else}}
+		{{ if .Page.Sections}}
+			{{ .Scratch.Set "pages" (.Page.Pages | union .Page.Sections) }}
+		{{end}}
+	{{end}}
+
+	{{ $pages := (.Scratch.Get "pages") }}
+
+	{{if eq $sortTerm "Weight"}}
+		{{template "childs" dict "menu" $pages.ByWeight "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{else if eq $sortTerm "Name"}}
+		{{template "childs" dict "menu" $pages.ByTitle "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{else if eq $sortTerm "PublishDate"}}
+		{{template "childs" dict "menu" $pages.ByPublishDate "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{else if eq $sortTerm "Date"}}
+		{{template "childs" dict "menu" $pages.ByDate "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{else if eq $sortTerm "Length"}}
+		{{template "childs" dict "menu" $pages.ByLength "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{else}}
+		{{template "childs" dict "menu" $pages "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{end}}
+</ul>
+
+{{ define "childs" }}
+	{{ range .menu }}
+		{{ if and .Params.hidden (not $.showhidden) }}
+		{{else}}
+			{{if not .IsHome}}
+				{{if hasPrefix $.style "h"}}
+					{{$num := sub ( int (trim $.style "h") ) 1 }}
+					{{$numn := add $num $.count }}
+
+{{(printf "<h%d>" $numn)|safeHTML}}
+<a href="{{.RelPermalink}}" >{{ .Title }}</a>
+{{(printf "</h%d>" $numn)|safeHTML}}
+
+				{{else}}
+{{(printf "<%s>" $.style)|safeHTML}}
+<a href="{{.RelPermalink}}" >{{ .Title }}</a>
+{{(printf "</%s>" $.style)|safeHTML}}
+				{{end}}
+
+				{{if $.description}}
+					{{if .Description}}
+<p>{{.Description}}</p>
+					{{else}}
+<p>{{.Summary}}</p>
+					{{end}}
+				{{end}}
+			{{end}}
+			{{ if lt $.count $.depth}}
+
+				{{if eq $.style "li"}}
+<ul>
+				{{end}}
+
+				{{ if .Sections}}
+					{{ .Scratch.Set "pages" (.Pages | union .Sections) }}
+				{{else}}
+					{{ .Scratch.Set "pages" .Pages }}
+				{{end}}
+
+				{{ $pages := (.Scratch.Get "pages") }}
+
+				{{if eq $.sortTerm "Weight"}}
+					{{template "childs" dict "menu" $pages.ByWeight  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+				{{else if eq $.sortTerm "Name"}}
+					{{template "childs" dict "menu" $pages.ByTitle  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+				{{else if eq $.sortTerm "PublishDate"}}
+					{{template "childs" dict "menu" $pages.ByPublishDate  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+				{{else if eq $.sortTerm "Date"}}
+					{{template "childs" dict "menu" $pages.ByDate  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+				{{else if eq $.sortTerm "Length"}}
+					{{template "childs" dict "menu" $pages.ByLength  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+				{{else}}
+					{{template "childs" dict "menu" $pages  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+				{{end}}
+
+				{{if eq $.style "li"}}
+</ul>
+				{{end}}
+			{{end}}
+		{{end}}
+	{{end}}
+{{end}}


### PR DESCRIPTION
To help readers navigate and search the content inside a guide, I've ported over the children shortcode from the Hugo Learn theme (big thank-you to https://learn.netlify.app/en/) and began using it in the introductions to the major guides in the CORE and SCALE documentation sections.
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
