### PR TITLE
DOCS-3813: Add related content shortcode

### DIFF
--- a/content/CORE/CORETutorials/Services/ConfiguringFTP.md
+++ b/content/CORE/CORETutorials/Services/ConfiguringFTP.md
@@ -1,6 +1,8 @@
 ---
 title: "Configuring FTP"
 weight: 30
+tags:
+- coreftp
 ---
 
 
@@ -53,3 +55,5 @@ After connecting, you can create directories and upload or download files.
 ![FilezillaFTPConnect](/images/CORE/FilezillaFTPConnect.png "Filezilla FTP Connection")
 
 See [FTP Screen]({{< relref "/CORE/UIReference/Services/FTPScreen.md" >}}) for more information on the **FTP** service screen. 
+
+{{< taglist tag="coreftp" limit="10" title="Related FTP Articles" >}}

--- a/content/CORE/CORETutorials/Services/ConfiguringSFTP.md
+++ b/content/CORE/CORETutorials/Services/ConfiguringSFTP.md
@@ -1,6 +1,8 @@
 ---
 title: "Configuring SFTP"
 weight: 20
+tags:
+- coreftp
 ---
 
 

--- a/content/CORE/CORETutorials/Services/ConfiguringTFTP.md
+++ b/content/CORE/CORETutorials/Services/ConfiguringTFTP.md
@@ -1,6 +1,8 @@
 ---
-title: "Configuring TFTP "
+title: "Configuring TFTP"
 weight: 140
+tags:
+- coreftp
 ---
 
 

--- a/content/CORE/CORETutorials/Services/FTPTFTP.md
+++ b/content/CORE/CORETutorials/Services/FTPTFTP.md
@@ -2,6 +2,8 @@
 title: "FTP, SFTP, and TFTP"
 weight: 160
 aliases: /core/services/ftptftp/
+tags:
+- coreftp
 ---
 
 The [File Transfer Protocol (FTP)](https://tools.ietf.org/html/rfc959) is a simple option for data transfers.

--- a/content/CORE/UIReference/Services/FTPScreen.md
+++ b/content/CORE/UIReference/Services/FTPScreen.md
@@ -1,6 +1,8 @@
 ---
 title: "FTP Screen"
 weight: 30
+tags:
+- coreftp
 ---
 
 Use the **FTP** services screen to configure FTP service settings for your TrueNAS system.

--- a/content/CORE/UIReference/Services/TFTPScreen.md
+++ b/content/CORE/UIReference/Services/TFTPScreen.md
@@ -1,6 +1,8 @@
 ---
 title: "TFTP Screen"
 weight: 140
+tags:
+- coreftp
 ---
 
 The **TFTP** service screen configures the directory, connection, access and other auxillary parameters for TFPT service on the TrueNAS.

--- a/layouts/shortcodes/taglist.html
+++ b/layouts/shortcodes/taglist.html
@@ -1,0 +1,18 @@
+{{ $currPermalink := .Page.RelPermalink }}
+{{- $title := $.Params.title -}}
+{{- $tag := $.Params.tag -}}
+{{- $limit := int ($.Params.limit) -}}
+{{- $tags := (index site.Taxonomies.tags $tag) -}}
+{{- if (eq $limit -1) -}}
+  {{- $limit = len site.Taxonomies.tags -}}
+{{- end -}}
+<h2>{{- $title| default "Related Content" -}}</h2>
+<ul>
+{{- range (first $limit $tags.Pages) -}}
+  {{ if not (eq .RelPermalink $currPermalink) }}
+  <li>
+    <a href="{{- .Permalink -}}">{{- .Title -}}</a>
+  </li>
+  {{- end -}}
+{{- end -}}
+</ul>


### PR DESCRIPTION
This adds a taglist shortcode that can be used to link similar content articles to each other and help guide readers. Thank you to https://kollitsch.dev/blog/2022/hugo-shortcode-taglist/ for the guide!



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
