### PR TITLE
DOCS-3276: Add R50BM Network Interface Naming

### DIFF
--- a/content/Hardware/RSeries/RSeriesNetworkPortIDs.md
+++ b/content/Hardware/RSeries/RSeriesNetworkPortIDs.md
@@ -30,3 +30,6 @@ This table lists the default identification for R-Series systems and any add-on 
 |       | Port 1: `ixl1` | Port 1: `eno2` |
 | R50B  | Port 0: `ixl0` | Port 0: `eno1` |
 |       | Port 1: `ixl1` | Port 1: `eno2` |
+| R50BM | Port 0: `ixl0` | Port 0: `eno1` |
+|       | Port 1: `ixl1` | Port 1: `eno2` |
+


### PR DESCRIPTION
Added the R50BM Network Interface Naming.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
