### PR TITLE
SystemAdvancedFields.md.part: fix Kernel options

### DIFF
--- a/static/includes/Reference/SystemAdvancedFields.md.part
+++ b/static/includes/Reference/SystemAdvancedFields.md.part
@@ -26,8 +26,8 @@
 
 | Name | Description |
 |------|-------------|
-| Show Console Messages | Display console messages in real time at the bottom of the browser. |
-| Show Advanced Fields by Default | Set to always show advanced fields, when available. |
+| Enable Autotune | Activates a tuning script which attempts to optimize the system depending on the installed hardware. **Warning:** Autotuning is only used as a temporary measure and is not a permanent fix for system hardware issues. |
+| Enable Debug Kernel | Set to boot a debug kernel after the next system reboot. |
 
 **Self-Encrypting Drive**
 


### PR DESCRIPTION
Fix for Kernel options having been duplicated from the GUI section.

---
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
