### PR TITLE
SMBShareScreen.md: fix checkbox description

### DIFF
--- a/content/CORE/UIReference/Sharing/SMB/SMBShareScreen.md
+++ b/content/CORE/UIReference/Sharing/SMB/SMBShareScreen.md
@@ -24,7 +24,7 @@ Use **CANCEL** to exit without saving and return to the main **SMB** screen.
 |---------|--------------|
 | **Path** | Use the file browser or click the **/mnt** to select the pool, dataset or directory to share. |
 | **Name** | Enter a name for the SMB share. |
-| **Purpose** | Select a preset configuration for the share to lock in predetermined values fo rthe share **Advanced Options**, including the **Path Suffix**. Select from the dropdown list. Options are **No presets**, **Default share parameters**, **Multi-user time machine**, **Multi-protocol (AFP/SMB) shares**, **Multi-protocol (NFSv3/SMB) shares**, **Private SMB Datasets and Shares** or **SMB WORM. Files become readonly via SMB after 5 minutes**. See "What do all the presets do?" for more information on presets.|
+| **Purpose** | Select a preset configuration for the share to lock in predetermined values fo rthe share **Advanced Options**, including the **Path Suffix**. Select from the dropdown list. Options are **No presets**, **Default share parameters**, **Multi-user time machine**, **Multi-protocol (AFP/SMB) shares**, **Multi-protocol (NFSv3/SMB) shares**, **Private SMB Datasets and Shares** or **SMB WORM. Files become readonly via SMB after 5 minutes**. See "What do all the presets do?" for more information on presets. |
 | **Description** |  |
 | **Enabled** |   |
 
@@ -66,8 +66,8 @@ Options are divided into **Access** and **Other Options** groups.
 | **Export Read Only** | Select to prohibit writes to the share. Leave checkbox clear allows writes to the share. |
 | **Browsable to Network Clients** | Select to determine whether this share name is included when browsing shares. Home shares are only visible to the owner regardless of this setting. |
 | **Allow Guest Access** | Select to make privileges the same as the guest account. Guest access is disabled by default in Windows 10 version 1709 and Windows Server version 1903. Additional client-side configuration is required to provide guest access to these clients.<br><br> **MacOS clients**: Attempting to connect as a user that does not exist in FreeNAS *does not* automatically connect as the guest account. The **Connect As: Guest** option must be specifically chosen in MacOS to log in as the guest account. See the [Apple documentation](https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/mac) for more details. |
-| **Access Based Share Enumeration** | checkbox | Select to restrict share visibility to users with read or write access to the share. See the [smb.conf](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html) manual page. |
-| **Hosts Allow** | Enter a list of allowed host names or IP addresses. Separate entries by pressing <kbd>Enter</kbd>. A more detailed description with examples see [here](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#HOSTSALLOW).
+| **Access Based Share Enumeration** | Select to restrict share visibility to users with read or write access to the share. See the [smb.conf](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html) manual page. |
+| **Hosts Allow** | Enter a list of allowed host names or IP addresses. Separate entries by pressing <kbd>Enter</kbd>. A more detailed description with examples see [here](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#HOSTSALLOW). |
 | **Hosts Deny** | Enter a list of denied host names or IP addresses. Separate entries by pressing <kbd>Enter</kbd>. |
 
 {{< expand "Host Allow and Hosts Deny Fields" >}}


### PR DESCRIPTION
Remove text that was causing text for Access Based Share Enumeration to be hidden.

---
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
