### PR TITLE
Docs 4039 typo in the migrating instructions

### DIFF
--- a/content/SCALE/GettingStarted/Migrate/MigratingFromCORE.md
+++ b/content/SCALE/GettingStarted/Migrate/MigratingFromCORE.md
@@ -1,6 +1,6 @@
 ---
 title: "Migrating from TrueNAS CORE"
-description: "This article provides instructions on migrating from TrueNAS CORE to SCALE. Migration methods include using an ISO file or amanual update file."
+description: "This article provides instructions on migrating from TrueNAS CORE to SCALE. Migration methods include using an ISO file or a manual update file."
 weight: 20
 aliases:
  - /scale/gettingstarted/migratingfromcore/

--- a/content/SCALE/GettingStarted/Migrate/_index.md
+++ b/content/SCALE/GettingStarted/Migrate/_index.md
@@ -6,7 +6,7 @@ weight: 40
 
 This section provides information for CORE users migrating to SCALE.
 
-Linux treates device names differently than FreeBSD so please read [Component Naming]({{< relref "ComponentNaming.md" >}}) for more information.
+Linux treats device names differently than FreeBSD so please read [Component Naming]({{< relref "ComponentNaming.md" >}}) for more information.
 
 The ZFS flag feature merged into the TrueNAS fork of OpenZFS for developers to test and integrage with other parts of the system on June 29,2021 is also removed. Please read [ZFS Feature Flags Removed]({{< relref "ScaleZFSFlagRemoval.md" >}}) for details on this change.
 


### PR DESCRIPTION
Minor typo fix in 2 articles re: migrating from CORE to SCALE.
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
