### PR TITLE
DOCS-4080: Add additional pointers to previous version docs

### DIFF
--- a/content/CORE/COREPreviousVersion.md
+++ b/content/CORE/COREPreviousVersion.md
@@ -1,0 +1,10 @@
+---
+title: 12.0 Documentation
+description: "This redirects to the static documentation for the previous major version of TrueNAS."
+weight: 2
+---
+
+You are being redirected to a PDF build of the 12.0 documentation.
+If there is an issue with the automatic redirect, the file is found at https://www.truenas.com/docs/files/CORE12.0Docs.pdf
+
+<meta http-equiv="Refresh" content="0; url='https://www.truenas.com/docs/files/CORE12.0Docs.pdf'" />

--- a/content/CORE/COREReleaseNotes.md
+++ b/content/CORE/COREReleaseNotes.md
@@ -1,6 +1,6 @@
 ---
 title: 13.0 Release Notes
-weight: 2
+weight: 3
 aliases:
   - /releasenotes/core/13.0beta1/
   - /releasenotes/core/13.0rc1/

--- a/content/_index.md
+++ b/content/_index.md
@@ -48,11 +48,11 @@ When combined with our high-availability hardware and [**TrueCommand**]({{< relr
 The Documentation Hub has all of the information you need to set up and manage your TrueNAS system.
 Documentation articles follow the latest supported software releases, with previous version documentation available in the [Docs Archive]({{< relref "Archive.md" >}}):
 
-| Software | Current Documented Version |
-|----------|-------------------------------|
-| TrueNAS CORE & Enterprise | 13.0 |
-| TrueNAS SCALE | 22.02 Angelfish |
-| TrueCommand | 2.2 |
+| Software | Current Documented Version | Previous Major Version |
+|----------|----------------------------|------------------------|
+| TrueNAS CORE & Enterprise | 13.0 | [12.0](https://www.truenas.com/docs/files/CORE12.0Docs.pdf) ([Release Notes]({{< relref "Archive.md#truenas-unified" >}})) |
+| TrueNAS SCALE | 22.02 Angelfish | N/A |
+| TrueCommand | 2.2 | [2.1](https://www.truenas.com/docs/files/TC2.1Docs.pdf)  |
   
 The navigation pane to the left is sorted into several topics that you can expand to find the specific knowledge you're looking for:
 

--- a/data/menu/more.yml
+++ b/data/menu/more.yml
@@ -6,7 +6,7 @@ more:
     external: true
     icon: "gdoc_shield"
   - name: Documentation Archive
-    ref: "https://truenas.com/docs/archive/"
+    ref: "/archive"
     external: true
     icon: "gdoc_bookmark"
   - name: "View Source"


### PR DESCRIPTION
- Updated the site home page with links to the archived docs for the previous major CORE and TrueCommand versions. No change for SCALE yet - Angelfish is the first major version.
- Added menu item inside CORE area that redirects to the 12.0 Docs PDF. Added some text and direct link to the PDF if the redirect doesn't work for some reason.
- Fixed the more menu .yml file to use the pathway ref to the archive instead of direct linking. This should help when local build testing archive changes.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
