### PR TITLE
DOCS-4130 update typo in ManagingPools.md

### DIFF
--- a/content/CORE/CORETutorials/Storage/Pools/ManagingPools.md
+++ b/content/CORE/CORETutorials/Storage/Pools/ManagingPools.md
@@ -89,7 +89,7 @@ Before upgrading an existing pool, be aware of these caveats:
 
 The upgrade itself only takes a few seconds and is non-disruptive.
 It is not necessary to stop any sharing services to upgrade the pool.
-However, it is best to upgrade when the pool is in heavy use.
+However, it is best to upgrade when the pool is not in heavy use.
 The upgrade process suspends I/O for a short period, but is nearly instantaneous on a quiet pool.
 {{< /expand >}}
 


### PR DESCRIPTION
This ticket is a subtask of Docs 3753. This fixes the typo to read: "...pool is not in heavy use."



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
