### PR TITLE
Fix typo in SMB1Advisory.md

### DIFF
--- a/content/CORE/CoreSecurityReports/SMB1Advisory.md
+++ b/content/CORE/CoreSecurityReports/SMB1Advisory.md
@@ -3,7 +3,7 @@ title: "SMB1 Security Advisory"
 weight: 10
 ---
 
-**Do not use SBM1**
+**Do not use SMB1**
 
 SMB1, also known as SMBv1, is an early version of the Windows SMB file-sharing protocol. [Microsoft has deprecated the SMB1 protocol for security reasons and strongly recommends removing SMB1](https://support.microsoft.com/en-us/help/4034314/smbv1-is-not-installed-by-default-in-windows). SMB1 is disabled by default in FreeNAS and TrueNAS. Current SMB networking clients use later versions of the SMB protocol.
 


### PR DESCRIPTION
Found a tiny typo while reading TrueNAS CORE security doc:
'Do not use SBM1' -> 'Do not use SMB1'


Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
