### PR TITLE
Remove surge.sh step

### DIFF
--- a/.github/workflows/build-external-contrib.yml
+++ b/.github/workflows/build-external-contrib.yml
@@ -38,18 +38,3 @@ jobs:
 
       - name: Build Hugo Site
         run: hugo -d public --gc --minify
-
-      - name: Preview
-        uses: afc163/surge-preview@v1
-        id: preview_step
-        with:
-          surge_token: ${{ secrets.QA_SURGE_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: public
-          teardown: 'true'
-          failOnError: 'true'
-          build: |
-            echo Deploying to surge.sh
-
-      - name: Get the preview_url
-        run: echo "url => ${{ steps.preview_step.outputs.preview_url }}"

--- a/.github/workflows/build-internal-contrib.yml
+++ b/.github/workflows/build-internal-contrib.yml
@@ -38,19 +38,3 @@ jobs:
 
       - name: Build Hugo Site
         run: hugo -d public --gc --minify
-
-      - name: Preview
-        uses: afc163/surge-preview@v1
-        id: preview_step
-        with:
-          surge_token: ${{ secrets.QA_SURGE_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: public
-          # teardown option remove the PR surge.sh after the PR is merged
-          teardown: 'false'
-          failOnError: 'true'
-          build: |
-            echo Deploying to surge.sh
-
-      - name: Get the preview_url
-        run: echo "url => ${{ steps.preview_step.outputs.preview_url }}"


### PR DESCRIPTION
This is no longer working for our use cases and needs to be removed. I'm setting up Netlify as a manual interim solution.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
