### PR TITLE
DOCS-4129: Update head title builder

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,7 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="{{ partial "title" . }}">
 
-<title>{{ partial "title" . }} | {{ .Site.Title -}}</title>
+<title>Docs Hub | {{ partial "title" . }}</title>
 
 <link rel="icon" href="{{ "favicon/TN-favicon-32x32.png" | relURL }}" type="image/x-icon">
 


### PR DESCRIPTION
adjusted to use a static Docs Hub string as part of the title



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
