### PR TITLE
DOCS-3816: Review all CORE index files and children shortcode usage

### DIFF
--- a/content/CORE/CORENextVersion.md
+++ b/content/CORE/CORENextVersion.md
@@ -1,5 +1,6 @@
 ---
 title: "Next Major Version"
+description: "This article contains development and release notes for the next major version of TrueNAS CORE."
 weight: 1000
 ---
 

--- a/content/CORE/COREReleaseNotes.md
+++ b/content/CORE/COREReleaseNotes.md
@@ -1,5 +1,6 @@
 ---
 title: 13.0 Release Notes
+description: "This article has notes for the current major version of TrueNAS CORE."
 weight: 3
 aliases:
   - /releasenotes/core/13.0beta1/

--- a/content/CORE/CORETutorials/CommunityGuides/_index.md
+++ b/content/CORE/CORETutorials/CommunityGuides/_index.md
@@ -6,3 +6,7 @@ weight: 30
 
 Because TrueNAS is both Open Source and complicated, the massive user community often creates recommendations for specific hardware or environments.
 User-created recommendations can be added in this location, but be aware these are provided "as-is" and are not officially supported by iXsystems, Inc.
+
+## Contents
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/CORETutorials/DirectoryServices/_index.md
+++ b/content/CORE/CORETutorials/DirectoryServices/_index.md
@@ -10,4 +10,5 @@ tags:
 - corenis
 - corekerberos
 ---
+
 {{< children depth="2" sort="Weight" description="true" >}}

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Jails/_index.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Jails/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Jails"
-description: "This article lists articles related to Jails, Plugins and Virtual Machines in TrueNAS CORE."
+description: "This section lists articles related to Jails, Plugins and Virtual Machines in TrueNAS CORE."
 geekdocCollapseSection: true
 weight: 10
 ---

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/_index.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/_index.md
@@ -1,10 +1,8 @@
 ---
 title: "Plugins"
-description: "This article lists the associated plugins articles in TrueNAS CORE."
+description: "This section lists the associated plugins articles in TrueNAS CORE."
 geekdocCollapseSection: true
 weight: 20 
 ---
-
-For more information on Plugins see:
 
 {{< children depth="2" description="true" >}}

--- a/content/CORE/CORETutorials/JailsPluginsVMs/VirtualMachines/SettingUpNPIV.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/VirtualMachines/SettingUpNPIV.md
@@ -7,7 +7,6 @@ tags:
 - coreiscsi
 ---
 
-
 ## NPIV (N_Port ID Virtualization)
 
 NPIV allows the administrator to use switch zoning to configure each virtual port as if it was a physical port in order to provide access control.

--- a/content/CORE/CORETutorials/JailsPluginsVMs/VirtualMachines/_index.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/VirtualMachines/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Virtual Machines"
+description: "This section contains tutorials about configuring virtual machines in SCALE."
 geekdocCollapseSection: true
 weight: 30
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/CORETutorials/JailsPluginsVMs/_index.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/_index.md
@@ -3,3 +3,5 @@ title: "Jails, Plugins and Virtual Machines"
 geekdocCollapseSection: true
 weight: 130
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/CORETutorials/Network/_index.md
+++ b/content/CORE/CORETutorials/Network/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Network"
+description: "This section contains tutorials related to configuring SCALE networking."
 geekdocCollapseSection: true
 weight: 80
 ---

--- a/content/CORE/CORETutorials/Services/_index.md
+++ b/content/CORE/CORETutorials/Services/_index.md
@@ -23,6 +23,6 @@ Click the <i class="material-icons" aria-hidden="true" title="Configure">edit</i
 
 Services related to data sharing or automated tasks are documented in their respective [Sharing]({{< relref "/CORE/UIReference/Sharing/_index.md" >}}) or [Tasks]({{< relref "/CORE/UIReference/Tasks/_index.md" >}}).  
 
-## Additional Services Articles ##
+## Additional Services Articles
 
 {{< children depth="2" sort="Name" description="true" >}}

--- a/content/CORE/CORETutorials/Sharing/AFP/_index.md
+++ b/content/CORE/CORETutorials/Sharing/AFP/_index.md
@@ -1,5 +1,0 @@
----
-title: "Apple Shares (AFP)"
-geekdocCollapseSection: true
-weight: 10
----

--- a/content/CORE/CORETutorials/Sharing/AFPShare.md
+++ b/content/CORE/CORETutorials/Sharing/AFPShare.md
@@ -2,7 +2,9 @@
 title: "AFP Share Creation"
 description: "This article provides information on how to create Apple Filing Protocol (AFP) shares on your TrueNAS."
 weight: 10
-aliases: /core/sharing/afp/afpshare/
+aliases:
+ - /core/sharing/afp/afpshare/
+ - /core/coretutorials/sharing/afp/afpshare/
 tags:
 - coreafp
 ---

--- a/content/CORE/CORETutorials/Sharing/NFS/_index.md
+++ b/content/CORE/CORETutorials/Sharing/NFS/_index.md
@@ -1,5 +1,0 @@
----
-title: "Unix Shares (NFS)"
-geekdocCollapseSection: true
-weight: 30
----

--- a/content/CORE/CORETutorials/Sharing/NFSShare.md
+++ b/content/CORE/CORETutorials/Sharing/NFSShare.md
@@ -1,8 +1,10 @@
 ---
 title: "NFS Share Creation"
 description: "This article provides information on how to create a Network File Share (NFS) on your TrueNAS."
-weight: 10
-aliases: /core/sharing/nfs/nfsshare/
+weight: 30
+aliases:
+ - /core/sharing/nfs/nfsshare/
+ - /core/coretutorials/sharing/nfs/nfsshare/
 tags:
 - corenfs
 ---

--- a/content/CORE/CORETutorials/Sharing/SMB/_index.md
+++ b/content/CORE/CORETutorials/Sharing/SMB/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Windows Shares (SMB)"
+description: "This section has tutorials for SMB sharing scenarios."
 geekdocCollapseSection: true
 weight: 50
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/CORETutorials/Sharing/WebDAV/_index.md
+++ b/content/CORE/CORETutorials/Sharing/WebDAV/_index.md
@@ -1,5 +1,0 @@
----
-title: "WebDAV Shares"
-geekdocCollapseSection: true
-weight: 40
----

--- a/content/CORE/CORETutorials/Sharing/WebDAVShare.md
+++ b/content/CORE/CORETutorials/Sharing/WebDAVShare.md
@@ -1,8 +1,10 @@
 ---
 title: "WebDav Share Creation"
 description: "This article contains information on how to create a Web-based Distributed Authoring and Versioning (WebDAV) share on your TrueNAS."
-weight: 10
-aliases: /core/sharing/webdav/webdavshare/
+weight: 40
+aliases:
+ - /core/sharing/webdav/webdavshare/
+ - /core/coretutorials/sharing/webdav/webdavshare/
 tags:
 - corewebdav
 ---

--- a/content/CORE/CORETutorials/Sharing/_index.md
+++ b/content/CORE/CORETutorials/Sharing/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Sharing"
+description: "This section contains tutorials for configuring different storage sharing protocols in TrueNAS."
 geekdocCollapseSection: true
 weight: 110
 ---
@@ -7,4 +8,6 @@ weight: 110
 File sharing is a core benefit of a NAS. TrueNAS helps foster collaboration between users through network shares.  
 TrueNAS can use AFP, iSCSI shares, Unix NFS shares, Windows SMB shares, and WebDAV shares. 
 
-{{< include file="static/includes/General/MenuNav.md.part" markdown="true" >}}
+## Contents
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/CORETutorials/Storage/Disks/_index.md
+++ b/content/CORE/CORETutorials/Storage/Disks/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Disks"
+description: "This section contains tutorials about managing disks in TrueNAS."
 geekdocCollapseSection: true
 weight: 40
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/CORETutorials/Storage/Pools/_index.md
+++ b/content/CORE/CORETutorials/Storage/Pools/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Pools"
+description: "This section has tutorials about managing storage pools in TrueNAS."
 geekdocCollapseSection: true
 weight: 10
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/CORETutorials/Storage/_index.md
+++ b/content/CORE/CORETutorials/Storage/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Storage"
+description: "This section contains tutorials about different TrueNAS storage management topics."
 geekdocCollapseSection: true
 weight: 90
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/CORETutorials/SystemConfiguration/CreatingCAsandCertificates/_index.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/CreatingCAsandCertificates/_index.md
@@ -1,11 +1,10 @@
 ---
 title: "Creating CAs and Certificates"
+description: "This section has articles about configuring certificates and certificate authorities in TrueNAS."
 weight: 140
 geekdocCollapseSection: true
 ---
 
 TrueNAS lets users create certificates and certificate authorities (CAs) that enable encrypted connections to the web interface.
 
-## [Creating Certificate Authorities (CAs)]({{< relref "CreatingCertificateAuthorities.md" >}})
-
-## [Creating Certificates]({{< relref "CreatingCertificates.md" >}})
+{{< children depth="2" description="true" >}}

--- a/content/CORE/CORETutorials/SystemConfiguration/_index.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/_index.md
@@ -1,5 +1,8 @@
 ---
 title: System Configuration
+description: "This section has tutorials about a wide variety of TrueNAS system management topics."
 geekdocCollapseSection: true
 weight: 20
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/CORETutorials/Tasks/CreatingReplicationTasks/_index.md
+++ b/content/CORE/CORETutorials/Tasks/CreatingReplicationTasks/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Creating Replication Tasks"
-description: "This article lists replication tasks articles on TrueNAS CORE."
+description: "This section contains TrueNAS CORE replication tutorials."
 geekdocCollapseSection: true
 weight: 60
 ---

--- a/content/CORE/CORETutorials/Tasks/_index.md
+++ b/content/CORE/CORETutorials/Tasks/_index.md
@@ -1,22 +1,10 @@
 ---
 title: "Tasks"
+description: "This section contains tutorial articles about a wide variety of TrueNAS system tasks."
 geekdocCollapseSection: true
 weight: 70
 ---
 
 TrueNAS includes an easy to use interface for common tasks a sysadmin needs to preform on a NAS on a regular basis.  These can roughly be broken down into three groups.
 
-**System level Tasks**
-* [Cron Jobs]({{< relref "/CORE/CORETutorials/Tasks/CreatingCronJobs.md" >}})
-* [Init and Shutdown Scripts]({{< relref "/CORE/CORETutorials/Tasks/CreatingInitShutdownScripts.md" >}})
-* [S.M.A.R.T. tests]({{< relref "/CORE/CORETutorials/Tasks/RunningSMARTTests.md" >}})
-
-**Data Backup Tasks**
-* [Rsync Tasks]({{< relref "/CORE/CORETutorials/Tasks/CreatingRsyncTasks.md" >}})
-* [Cloud Sync Tasks]({{< relref "/CORE/CORETutorials/Tasks/CreatingCloudSyncTasks.md" >}})
-
-**ZFS Tasks**
-* [Periodic Snapshot Tasks]({{< relref "/CORE/CORETutorials/Tasks/CreatingPeriodicSnapshotTasks.md" >}})
-* [Resilver Priority]({{< relref "/CORE/CORETutorials/Tasks/UsingResilverPriority.md" >}})
-* [Scrub Tasks]({{< relref "/CORE/CORETutorials/Tasks/CreatingScrubTasks.md" >}})
-* [Replication Tasks]({{< relref "/CORE/CORETutorials/Tasks/CreatingReplicationTasks/_index.md" >}})
+{{< children depth="2" description="true" >}} 

--- a/content/CORE/CORETutorials/UpdatingTrueNAS/_index.md
+++ b/content/CORE/CORETutorials/UpdatingTrueNAS/_index.md
@@ -1,7 +1,10 @@
 ---
 title: "Updating TrueNAS"
+description: "This section has tutorials for updating or upgrading a TrueNAS CORE system."
 geekdocCollapseSection: true
 weight: 900
 aliases:
  - /core/system/update/_index/
 ---
+
+{{< children depth="2" description="true" >}} 

--- a/content/CORE/CoreSecurityReports/_index.md
+++ b/content/CORE/CoreSecurityReports/_index.md
@@ -8,9 +8,9 @@ See the [TrueNAS Security Hub](https://security.truenas.com/products/truenas-12.
 
 ---
 
-{{< expand "Table of Contents (click to expand)" "v" >}}
+## Notices
+
 {{< children depth="2" >}}
-{{< /expand >}}
 
 ## CORE Documentation Sections
 

--- a/content/CORE/GettingStarted/UserAgreements/COREEULA.md
+++ b/content/CORE/GettingStarted/UserAgreements/COREEULA.md
@@ -1,5 +1,6 @@
 ---
 title: "TrueNAS CORE EULA"
+description: "End User License Agreement for TrueNAS CORE"
 weight: 1
 aliases:
   - /core/introduction/coreeula/

--- a/content/CORE/GettingStarted/UserAgreements/DataCollectionStatement.md
+++ b/content/CORE/GettingStarted/UserAgreements/DataCollectionStatement.md
@@ -1,5 +1,6 @@
 ---
 title: "TrueNAS Data Collection Statement"
+description: "TrueNAS CORE Data Collection Statement."
 weight: 5
 ---
 

--- a/content/CORE/GettingStarted/UserAgreements/EnterpriseEULA.md
+++ b/content/CORE/GettingStarted/UserAgreements/EnterpriseEULA.md
@@ -1,5 +1,6 @@
 ---
 title: "TrueNAS Enterprise EULA"
+description: "TrueNAS Enterprise End User License Agreement"
 weight: 2
 aliases:
   - /core/introduction/enterpriseeula/

--- a/content/CORE/GettingStarted/UserAgreements/SofDevLifecycle.md
+++ b/content/CORE/GettingStarted/UserAgreements/SofDevLifecycle.md
@@ -1,5 +1,6 @@
 ---
 title: "Software Development Life Cycle"
+description: "Description of the general process of development, release, and patching of TrueNAS CORE versions."
 weight: 4
 aliases:
   - /core/introduction/sofdevlifecycle/

--- a/content/CORE/GettingStarted/UserAgreements/_index.md
+++ b/content/CORE/GettingStarted/UserAgreements/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "User Agreements"
+description: "This section has different User agreement statements related to using TrueNAS."
 geekdocCollapseSection: true
 weight: 10
 ---
+
+{{< children depth="2" description="true" >}} 

--- a/content/CORE/UIReference/Dashboard/_index.md
+++ b/content/CORE/UIReference/Dashboard/_index.md
@@ -1,7 +1,23 @@
 ---
 title: Dashboard
+description: "CORE Dashboard reference"
 weight: 5
 geekdocCollapseSection: true
 ---
 
+{{< toc >}}
+
 The web interface dashboard provides system details and shortcuts to various configuration screens.
+
+![DashboardCORE](/images/CORE/12.0/DashboardCORE.png "TrueNAS CORE Dashboard")
+
+## Dashboard Cards
+
+| Card | Description |
+|------|-------------|
+| System Information | Shows simple system-level information about TrueNAS, including hardware name (with compatible systems), TrueNAS version, system hostname, and system uptime. Includes a button to update the installed version of TrueNAS. |
+| CPU | Shows current CPU utilization and heat (with compatible hardware). Includes a shortcut icon to the in-depth CPU reporting screen. |
+| Memory | Shows total memory available to the system and the current breakdown of memory usage. Includes a shortcut icon to the in-depth memory utilization screen. |
+| Pool | Shows details about a configured storage pool. One card is created for each storage pool on the system. Includes shortcut icons to the pool configuration and statistics screens. |
+| Interface | Shows details about system network interfaces, including current status and configuration details. Includes shortcut icons to the interface configuration and statistics screens. |
+| TrueNAS Help | Contains links to verious documentation and assistance portals. |

--- a/content/CORE/UIReference/DirectoryServices/_index.md
+++ b/content/CORE/UIReference/DirectoryServices/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Directory Services"
+description: "This section contains reference documentation of the Directory Services screens."
 geekdocCollapseSection: true
 weight: 100
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/UIReference/JailsPluginsVMs/VirtualMachines/_index.md
+++ b/content/CORE/UIReference/JailsPluginsVMs/VirtualMachines/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Virtual Machines"
+description: "This section has reference documentation for the Virtual Machines screens."
 geekdocCollapseSection: true
 weight: 30
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/UIReference/JailsPluginsVMs/_index.md
+++ b/content/CORE/UIReference/JailsPluginsVMs/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Jails, Plugins and Virtual Machines"
+description: "This section has reference documentation for the Jails, Plugins, and Virtual Machines screens."
 geekdocCollapseSection: true
 weight: 130
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/UIReference/Network/_index.md
+++ b/content/CORE/UIReference/Network/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Network"
+description: "This section has reference documentation of the various Network menu screens."
 geekdocCollapseSection: true
 weight: 80
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/UIReference/Sharing/AFP/_index.md
+++ b/content/CORE/UIReference/Sharing/AFP/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Apple Shares (AFP)"
+description: "This section contains reference documentation for the AFP Sharing screens."
 geekdocCollapseSection: true
 weight: 10
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/UIReference/Sharing/NFS/_index.md
+++ b/content/CORE/UIReference/Sharing/NFS/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Unix Shares (NFS)"
+description: "This section contains reference documentation for the NFS Sharing screens."
 geekdocCollapseSection: true
 weight: 30
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/UIReference/Sharing/SMB/_index.md
+++ b/content/CORE/UIReference/Sharing/SMB/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Windows Shares (SMB)"
+description: "This section contains reference documentation of the SMB Sharing screens."
 geekdocCollapseSection: true
 weight: 50
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/UIReference/Sharing/WebDAV/_index.md
+++ b/content/CORE/UIReference/Sharing/WebDAV/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "WebDAV Shares"
+description: "This section contains reference documentation of the WebDAV sharing screens."
 geekdocCollapseSection: true
 weight: 40
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/UIReference/Sharing/_index.md
+++ b/content/CORE/UIReference/Sharing/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Sharing"
+description: "This section contains reference documentation for all screens within the Sharing menu option."
 geekdocCollapseSection: true
 weight: 110
 ---
@@ -7,4 +8,4 @@ weight: 110
 File sharing is a core benefit of a NAS. TrueNAS helps foster collaboration between users through network shares.  
 TrueNAS can use AFP, iSCSI shares, Unix NFS shares, Windows SMB shares, and WebDAV shares. 
 
-{{< include file="static/includes/General/MenuNav.md.part" markdown="true" >}}
+{{< children depth="2" description="true" >}}

--- a/content/CORE/UIReference/Storage/Disks/_index.md
+++ b/content/CORE/UIReference/Storage/Disks/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Disks"
+description: "This section has reference documentation for the Disks screens."
 geekdocCollapseSection: true
 weight: 40
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/UIReference/Storage/_index.md
+++ b/content/CORE/UIReference/Storage/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Storage"
+description: "This section has reference documentation for the various screens within the Storage menu option."
 geekdocCollapseSection: true
 weight: 90
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/UIReference/System/Boot/_index.md
+++ b/content/CORE/UIReference/System/Boot/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Boot"
+description: "This section contains reference documentation for the Boot Environments screen."
 geekdocCollapseSection: true
 weight: 30
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/UIReference/System/_index.md
+++ b/content/CORE/UIReference/System/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "System"
+description: "This section has reference documentation for the screens within the System menu option."
 geekdocCollapseSection: true
 weight: 60
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/UIReference/Tasks/_index.md
+++ b/content/CORE/UIReference/Tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+description: "This section contains reference documentation of screens within the Tasks menu option."
 geekdocCollapseSection: true
 weight: 70
 aliases:
@@ -21,4 +22,6 @@ TrueNAS includes an easy to use interface for common tasks a sysadmin needs to p
    + Scrubs
    + Replication
 
-{{< include file="static/includes/General/MenuNav.md.part" markdown="true" >}}
+## Contents
+
+{{< children depth="2" description="true" >}}

--- a/content/CORE/UIReference/TopMenu/_index.md
+++ b/content/CORE/UIReference/TopMenu/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Top Menu
+description: "This section has reference documentation for the options panel that is at the top of the TrueNAS UI."
 weight: 2
 geekdocCollapseSection: true
 tags:
@@ -13,6 +14,6 @@ tags:
 
 {{< include file="/_includes/CORETopMenu.md" type="page" >}}
 
-## Additional Top Menu Articles ##
+## Additional Top Menu Articles
 
 {{< children depth="2" sort="Name" description="true" >}}

--- a/content/CORE/UIReference/_index.md
+++ b/content/CORE/UIReference/_index.md
@@ -1,5 +1,6 @@
 ---
 title: UI Reference Guide
+description: "This book contains descriptions of the various screens and fields available in the TrueNAS User Interface."
 weight: 50
 geekdocCollapseSection: true
 ---

--- a/content/Contributing/Documentation/NewArticles/_index.md
+++ b/content/Contributing/Documentation/NewArticles/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Adding a New Article"
-description: "This article describes how to contribute a new article to the TrueNAS documentation."
+description: "This article describes how to contribute a new article bundle to the TrueNAS documentation."
 weight: 20
 tags:
 - corecontributing

--- a/content/Contributing/Documentation/_index.md
+++ b/content/Contributing/Documentation/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Documentation"
+description: "This section has articles describing how to contribute documentation to the TrueNAS projects."
 geekdocCollapseSection: true
 weight: 20
 ---
+
+{{< children depth="2" description="true" >}}

--- a/content/Contributing/_index.md
+++ b/content/Contributing/_index.md
@@ -15,3 +15,7 @@ Please feel free to propose changes and add new content in these articles to hel
 Want to discuss your in-progress changes or other TrueNAS contributions?
 The TrueNAS contributors `#truenas-docs` Slack workspace is available for contributors to discuss their changes and help each other improve the software.
 You can request to join this workspace at `truenas.slack.com`.
+
+## Contents
+
+{{< children depth="2" description="true" >}}

--- a/content/Solutions/Optimizations/Security.md
+++ b/content/Solutions/Optimizations/Security.md
@@ -32,13 +32,13 @@ When these options are empty, all initiators and all networks are allowed to con
 
 Network File System (NFS) is a sharing protocol that allows outside users to connect and view or modify shared data.
 
-To create a share, see [NFS Share Creation]({{< relref "/CORE/CORETutorials/Sharing/NFS/NFSShare.md" >}}).
+To create a share, see [NFS Share Creation]({{< relref "/CORE/CORETutorials/Sharing/NFSShare.md" >}}).
 
 NFS service settings are in **Services** after clicking the <span class="iconify" data-icon="mdi:pencil"></span> (pencil).
 By default, all options are unset.
 Unless needed for a specific use case, keep the default NFS service settings.
 
-During [Share Creation]({{< relref "/CORE/CORETutorials/Sharing/NFS/NFSShare.md" >}}), define which systems are authorized for share connections.
+During [Share Creation]({{< relref "/CORE/CORETutorials/Sharing/NFSShare.md" >}}), define which systems are authorized for share connections.
 Leaving the *Authorized Networks* or *Authorized Hosts and IP addresses* lists empty allows any system to connect to the NFS share.
 To define which systems can connect to the share, click the *Advanced Options* and enter all networks, hosts, and IP addresses to have share access.
 All other systems are denied access.


### PR DESCRIPTION
1. Made sure _index.md files had the children shortcode and properly show articles within the section.
2. Added descriptions to every file in the CORE documentation area
3. Condensed a few tutorial sections and aliased the moved articles.
4. Added missing reference documentation for the CORE Dashboard cards.
Build tested and fixed a few references.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
