### PR TITLE
Update Security.md

### DIFF
--- a/content/Solutions/Optimizations/Security.md
+++ b/content/Solutions/Optimizations/Security.md
@@ -69,13 +69,6 @@ For example, when selecting *Private SMB Datasets and Shares* from the list, Tru
 To fully customize the share settings, select *No presets* for the *Purpose*.
 Unless a specific purpose for the share is required, it is recommended to select *Default share parameters* as the *Purpose*.
 
-SMB Server Signing is recommended.
-To enable Server Signing, go to **Services > SMB > Edit > Auxiliary Parameters** and add this string to the *Auxilary Parameters* field:
-
-`server signing = mandatory`
-
-Then save, stop, and restart the SMB service.
-
 ## SSH
 
 Using Secure Shell (SSH) to connect to your TrueNAS is very helpful when issuing commands through the CLI.


### PR DESCRIPTION
Remove recommendation about adding an auxiliary parameter to require server signing. According to SMB SME, Samba already has this enabled by default and adding any auxiliary parameters is not a best practice.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
