### PR TITLE
Adjust Path for Edit this Page link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -76,7 +76,7 @@ enable = true
   # (Optional, default none) Enable 'Edit this page' links. Requires 'GeekdocRepo' param
   # and path must point to 'content' directory of repo.
   # You can also specify this parameter per page in front matter.
-  geekdocEditPath = "blob/master/content"
+  geekdocEditPath = "edit/master/content"
 
   # (Optional, default true) Enables search function with flexsearch.
   # Index is built on the fly and might slowdown your website.


### PR DESCRIPTION
The link now takes you directly to the edit form for the article, no need to click the pencil icon before beginning to edit. local build test worked correctly



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
