### PR TITLE
DOCS-4406: Add Passphrase length limit

### DIFF
--- a/content/CORE/CORETutorials/Storage/Pools/StorageEncryption.md
+++ b/content/CORE/CORETutorials/Storage/Pools/StorageEncryption.md
@@ -153,7 +153,7 @@ Change the **Encryption Type** from **Key** to **Passphrase**.
 Set the rest of the options:
 * **Passphrase** is a user-defined string used to decrypt the dataset.
   Can use instead of an encryption key.
-  Must be longer than 8 characters.  
+  Must be longer than 8 and less than 512 characters.  
 * **pbkdf2iters** is the number of password-based key derivation function 2 ([PBKDF2](https://tools.ietf.org/html/rfc2898#appendix-A.2)) iterations to use for reducing vulnerability to brute-force attacks.
   Entering a number greater than **100000** is required.
 {{< /expand >}}

--- a/content/SCALE/SCALETutorials/Storage/Datasets/EncryptionSCALE.md
+++ b/content/SCALE/SCALETutorials/Storage/Datasets/EncryptionSCALE.md
@@ -131,6 +131,10 @@ TrueNAS supports AES [Galois Counter Mode (GCM)](https://csrc.nist.gov/publicati
 These algorithms provide authenticated encryption with block ciphers.
 {{< /expand >}}
 
+{{< hint info>}}
+The passhrase must be longer than 8 and less than 512 characters.
+{{< /hint >}}
+
 {{< hint danger>}}
 Keep encryption keys and/or passphrases safeguarded in a secure and protected place. 
 Losing encryption keys or passphrases can result in permanent data loss!


### PR DESCRIPTION
Added 512 as the length limit.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
