### PR TITLE
Docs-4122 Update Articles with Alias or Static IP Address Content

### DIFF
--- a/content/SCALE/GettingStarted/Install/ConsoleSetupMenuScale.md
+++ b/content/SCALE/GettingStarted/Install/ConsoleSetupMenuScale.md
@@ -66,6 +66,8 @@ Enter `2` to display the Network Settings screen where you set up the host name,
 
 Enter `3` to display the Static Route Settings screen where you can set up any static routes. You can also add static routes in the web UI.
 
+{{< include file="/_includes/AliasOrStaticIP.md" type="page" >}}
+
 ### Configuring Required Network Settings 
 
 First, configure your primary network interface. The IP address assigned by DHCP displays in the Console setup menu screen. You can configure the default gateway, host name, domain and DNS name severs using the Console setup menu but you should use the web UI to configure these settings. Go the **Network** screen.

--- a/content/SCALE/SCALETutorials/Network/ConfigureStaticRoutes.md
+++ b/content/SCALE/SCALETutorials/Network/ConfigureStaticRoutes.md
@@ -10,6 +10,8 @@ tags:
 
 TrueNAS does not have defined static routes by default but TrueNAS administrators can use the **Static Routes** widget on the **Network** screen to manually enter routes so the router can send packets to a destination network.
 
+{{< include file="/_includes/AliasOrStaticIP.md" type="page" >}}
+
 {{< hint info >}}
 If you have a monitor and keyboard connected to the system you can use the [Console setup menu]({{< relref "SCALE/GettingStarted/Install/ConsoleSetupMenuSCALE.md" >}}) to configure static routes during the installation process, but we recommend using the web UI for all configuration tasks.
 {{< /hint >}}

--- a/content/SCALE/SCALETutorials/Network/Interfaces/ManagingInterfaces.md
+++ b/content/SCALE/SCALETutorials/Network/Interfaces/ManagingInterfaces.md
@@ -13,6 +13,7 @@ You can add new or edit existing network interfaces on the **Network** screen.
 {{< include file="/_includes/NetworkInterfaceTypes.md" type="page" >}}
 {{< /expand >}}
 
+{{< include file="/_includes/AliasOrStaticIP.md" type="page" >}}
 
 ## Adding an Interface
 

--- a/content/SCALE/SCALETutorials/Network/Interfaces/SettingUpStaticIPs.md
+++ b/content/SCALE/SCALETutorials/Network/Interfaces/SettingUpStaticIPs.md
@@ -19,6 +19,8 @@ You can lose your TrueNAS connection if you change the network interface that th
 You might need command line knowledge or physical access to the TrueNAS system to fix misconfigured network settings.
 {{< /hint >}}
 
+{{< include file="/_includes/AliasOrStaticIP.md" type="page" >}}
+
 ## Before you Begin
 
 Have the DNS name server addresses and the default gateway for the new IP address, and the new static IP address on hand to prevent lost communication with the server. 

--- a/content/_includes/AliasOrStaticIP.md
+++ b/content/_includes/AliasOrStaticIP.md
@@ -1,0 +1,13 @@
+---
+---
+
+{{< expand "Alias or Static IP Addresses?" "v" >}}
+When do you configure a static IP address? 
+Static IP addresses are use to set a fixed address for an interface that external devices or websites need to access or remember, such as for VPN access.
+
+Use aliases to add multiple internal IP address, representing containers or applications hosted in a VM, to an existing network interface without having to define a separate network interface. 
+
+In the UI, you can add aliases when you add an interface or edit an existing interface. Use the **Add** button in the **Static IP Address** widget to add a static IP address.
+
+From the Console setup menu, select option 2 to configure network settings and add alias IP addresses, or option 3 to add a static IP address.
+{{< /expand >}}


### PR DESCRIPTION
This commit adds a snippet to address the difference between an alias and static IP and when and where to configure them. It adds this snippet to the GettingStarted/Installation/ConsoleSetupMenu.md article and the Network tutorials for interfaces and static IPs.


Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
