### PR TITLE
Update upcoming Bluefin release dates and known issue cleanup.

### DIFF
--- a/content/SCALE/SCALE22.12.md
+++ b/content/SCALE/SCALE22.12.md
@@ -27,10 +27,14 @@ Want to get involved by collaborating on TrueNAS SCALE? Join our [Official Disco
 
 | Version | Checkpoint | Scheduled Date |
 |---------|------------|----------------|
-| SCALE 22.12.1 | Code-freeze | 18 January 2023 |
-| SCALE 22.12.1 | Internal Testing Sprints | 19 January 2023 - 03 February 2023 |
-| SCALE 22.12.1 | Tag | 06 February 2023 |
-| SCALE 22.12.1 | Release | 07 February 2023 |
+| SCALE 22.12.1 | Code-freeze | 25 January 2023 |
+| SCALE 22.12.1 | Internal Testing Sprints | 26 January 2023 - 11 February 2023 |
+| SCALE 22.12.1 | Tag | 13 February 2023 |
+| SCALE 22.12.1 | Release | 14 February 2023 |
+| SCALE 22.12.2 | Code-freeze | 08 March 2023 |
+| SCALE 22.12.2 | Internal Testing Sprints | 13 March 2023 - 24 March 2023 |
+| SCALE 22.12.2 | Tag | 27 March 2023 |
+| SCALE 22.12.2 | Release | 28 March 2023 |
 
 ## Obtaining the Release
 
@@ -1200,7 +1204,7 @@ Additional feature in future Bluefin releases:
 | 22.12-BETA.1 | <a href="https://ixsystems.atlassian.net/browse/NAS-118095" target="_blank">NAS-118095</a> | Core dumps on ctdb at startup | Traceback received that indicates ctdb core-dumps when starting nodes after a fresh install. | Unscheduled |
 | 22.02.1 |<a href="https://ixsystems.atlassian.net/browse/NAS-116473" target="_blank">NAS-116473</a> | Large Drive Count Issues | iX is investigating issues with booting SCALE on systems with more than 100 Disks. | 23.10-ALPHA.1 (Cobia) |
 | 22.02.0 | <a href="https://jira.ixsystems.com/browse/NAS-115238" target="_blank">NAS-115238</a> | Removed drive from pool does not degrade pool status (SCALE). | Issue is being investigated and a fix provided in a future release | 22.12-BETA.2 |
-|  |  | Unable to mount an NFS export after migrating from CORE > SCALE or updating to 22.02.0. | The <file>/etc/exports</file> file is no longer generated when the NFS configuration contains <i>mapall</i> or <i>maproot</i> entries for unknown users or groups. This can impact users who previously had a mapping group set to <i>wheel</i>, which does not exist in SCALE. If you are unable to mount an NFS export, review your NFS share configuration and change any <i>wheel</i> entries to something specific for your environment or <i>root</i>. |  |
+|  |  | Unable to mount an NFS export after migrating from CORE > SCALE or updating to 22.02.0. | The <file>/etc/exports</file> file is no longer generated when the NFS configuration contains <i>mapall</i> or <i>maproot</i> entries for unknown users or groups. If you are unable to mount an NFS export, review your NFS share configuration entries to something specific for your environment or <i>wheel</i> or <i>root</i>. |  |
 |  |  | SCALE Gluster/Cluster. | Gluster/Cluster features are still in testing.  Administrators should use caution when deploying and avoid use with critical data. |  |
 |  | <a href="https://jira.ixsystems.com/browse/NAS-110263" target="_blank">NAS-110263</a> | AFP sharing is removed from TrueNAS SCALE. The protocol is deprecated and no longer receives development effort or security fixes. | TrueNAS SCALE automatically migrates any existing AFP shares into an SMB configuration that is preset to function like an AFP share. | 21.06-BETA.1 |
 | 21.06-BETA.1 | <a href="https://jira.ixsystems.com/browse/NAS-111547" target="_blank">NAS-111547</a> | ZFS shouldn't count vdev IO errors on hotplug removal | Pool status isn't being updated immediately on disk exchange events. | Targeted 22.12 (Bluefin) |


### PR DESCRIPTION
Update with latest 22.12.1 dates
Add anticipated 22.12.2 dates
Clean up NFS config warning to reflect wheel group is available in SCALE now to help users work around the issue.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
