### PR TITLE
Error fix - legacy 3rd gen mini doc

### DIFF
--- a/content/Hardware/LegacyHardware/MiniSeries/TrueNAS Minis (3rd Gen)/MiniBSG(Legacy).md
+++ b/content/Hardware/LegacyHardware/MiniSeries/TrueNAS Minis (3rd Gen)/MiniBSG(Legacy).md
@@ -1,8 +1,9 @@
 ---
-title: "2nd Generation Mini Family Basic Setup Guide (Legacy)"
+title: "3rd Gen Mini Family Basic Setup Guide (Legacy)"
+description: "This document shows the initial offering of TrueNAS Mini Products, including some that are now end of life."
 weight: 10
 ---
 
-<object data="https://www.truenas.com/docs/files/MiniFamily2.0.pdf" type="application/pdf" width="95%" height="1000">
-  There was an error displaying this PDF, <a href="https://www.truenas.com/docs/files/MiniFamily2.0.pdf">please click here to download the file.</a>
+<object data="https://www.truenas.com/docs/files/MiniFamily3.1.pdf" type="application/pdf" width="95%" height="1000">
+  There was an error displaying this PDF, <a href="https://www.truenas.com/docs/files/MiniFamily3.1.pdf">please click here to download the file.</a>
 </object>


### PR DESCRIPTION
This was my error - this doc is supposed to show the initial 3rd gen Mini family, including some of the Mini E / E+ products that are end of life. I've uploaded the archival copy of this doc to the web server and adjusted the link to point to it.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
