### PR TITLE
PD-170: TC 2.0 relnotes alias update

### DIFF
--- a/content/_includes/TCReleaseNotes/2.0-Beta.md
+++ b/content/_includes/TCReleaseNotes/2.0-Beta.md
@@ -1,6 +1,8 @@
 ---
 title: "2.0-Beta"
 weight: 10
+aliases:
+  - /releasenotes/truecommand/2.0-beta/
 ---
 
 **May 4, 2021**

--- a/content/_includes/TCReleaseNotes/2.0.md
+++ b/content/_includes/TCReleaseNotes/2.0.md
@@ -1,6 +1,8 @@
 ---
 title: "2.0"
 weight: 9
+aliases:
+  - /releasenotes/truecommand/2.0/
 ---
 
 **June 8, 2021**


### PR DESCRIPTION
- Add aliases for previous URLs of TC 2.0-BETA and TC 2.0, 2.01, 2.02 release notes.
- This is to fix the links to this content from the https://portal.ixsystems.com/ website.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
