### PR TITLE
PD-192 Update TNHardwareGuide Snippet

### DIFF
--- a/content/_includes/TNHardwareGuide.md
+++ b/content/_includes/TNHardwareGuide.md
@@ -371,12 +371,17 @@ iXsystems recommends using optical fiber over *direct attached copper* (DAC) cab
 iXsystems also recommends using optical fiber for any transceiver form factors mentioned when using fiber channels.
 Direct attached copper (DAC) cables could create interoperability issues between the NIC, cable, and switch.
 
-## Virtualized TrueNAS CORE
+## Virtualized TrueNAS 
 
-Finally, the ultimate TrueNAS hardware question is whether to use actual hardware or choose a virtualization solution.
-TrueNAS developers [virtualize TrueNAS every day](https://www.ixsystems.com/blog/yes-you-can-virtualize-freenas/) as part of their work, and cloud services are popular among users of all sizes.
+Finally, the ultimate TrueNAS hardware question is whether to use actual hardware or choose a virtualization solution. 
 At the heart of the TrueNAS design is OpenZFS. The design from day one works with physical storage devices. It is aware of their strengths and compensates for their weaknesses.
-When the need arises to virtualize TrueNAS:
+
+TrueNAS developers [virtualize TrueNAS every day](https://www.ixsystems.com/blog/yes-you-can-virtualize-freenas/) as part of their work and it is intended only for use as a development environment. 
+{{< hint warning >}}
+While possible to deploy TrueNAS in a virtual enviroment this is not recommended for regular deployment of TrueNAS whenever storing production or crtical data. 
+Virtualizing TrueNAS and using virtual disks for your zpool is fine for ad hoc proof-of-concept, but it is not a supported configuration and it might result in data corruption. 
+{{< /hint >}}
+When the need arises to virtualize TrueNAS (for ad hoc proof-of-concept):
 
 * Pass hardware disks or the entire storage controller to the TrueNAS VM if possible (requires VT-d/AMD-Vi support).
 * Disable automatic scrub pools on virtualized storage such as VMFS, and never scrub a pool while also running storage repair tasks on another layer.


### PR DESCRIPTION
This commit changes the TNHardwareGuide.md snippet used in both CORE and SCALE getting started section by: 
Changing the heading for Virtualized TrueNAS CORE to just Virtualized TrueNAS to make it generic for CORE and SCALE. 
Moves content around and adds a warning admonition box to emphasize deploying in a virtual environment is not a recommended or supported configuration for anything other than ad hoc proof-of-concept.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
