### PR TITLE
Add introductory text to SCALE tutorials AFP index file.

### DIFF
--- a/content/SCALE/SCALETutorials/Shares/AFP/_index.md
+++ b/content/SCALE/SCALETutorials/Shares/AFP/_index.md
@@ -4,3 +4,10 @@ geekdocCollapseSection: true
 weight: 10
 ---
 
+AFP Sharing is not supported in TrueNAS SCALE, but there are options to create AFP compatible shares with the SMB protocol.
+This is used primarily to help migrate existing AFP shares configured in a TrueNAS CORE system into similar SMB shares in TrueNAS SCALE.
+
+The tutorials in this section provide more guidance about AFP compatible shares.
+
+## Articles in this Section
+{{< children depth="1" >}}


### PR DESCRIPTION
This is an incidental catch. This index file is normally not selectable, but search links or URLs pointed right to it shows an empty article. I'm proposing a simple change to add some introductory text and the children shortcode to point to the related article.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
