### PR TITLE
Remove keyfile warning from ref content

### DIFF
--- a/content/SCALE/SCALEUIReference/Storage/Datasets/EncryptionUISCALE.md
+++ b/content/SCALE/SCALEUIReference/Storage/Datasets/EncryptionUISCALE.md
@@ -26,14 +26,6 @@ The **Encryption** option on the **[Pool Manager]({{< relref "PoolManagerScreens
 
 ![DownloadPoolEncryptionKey](/images/SCALE/22.12/DownloadPoolEncryptionKey.png "Download Pool Encryption Key")
 
-{{< hint warning >}}
-All datasets created in an encrypted pool have encryption. You cannot create an unencrypted dataset in an encrypted pool.
-
-All pool-level encryption is key-based encryption. You cannot use passphrase encryption at the pool/root level.
-
-Keep the key file in a secure location where you can back it up and keep it protected. If you lose the encryption key you cannot unlock the pool and that can result in unrecoverable data.
-{{< /hint >}}
-
 ## Export Key Options 
 
 The **ZFS Encryption** widget for root datasets with encryption includes the **Export All Keys** and **Export Key** options but does not include the **Lock** option.


### PR DESCRIPTION
Leaving this in place in the related tutorial, but not needed in pure reference material.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
