### PR TITLE
PD-182 Add Restoring a Hot Spare to Replacing Disk Articles

### DIFF
--- a/content/CORE/CORETutorials/Storage/Disks/DiskReplace.md
+++ b/content/CORE/CORETutorials/Storage/Disks/DiskReplace.md
@@ -1,6 +1,6 @@
 ---
 title: "Disk Replacement"
-description: "This article describes how to replace a disk in TrueNAS CORE."
+description: "This article describes how to replace a disk and restore the hot spare in TrueNAS CORE."
 weight: 20
 aliases: /core/storage/disks/diskreplace/
 tags:
@@ -33,7 +33,7 @@ The TrueNAS **Dashboard** shows when a disk failure degrades a pool.
 
 Click the <i class="material-icons" aria-hidden="true" title="Settings">settings</i> on the pool card to go to the **Storage > Pools > Pool Status** screen and locate the failed disk.
 
-### Offline the Failed Disk
+### Taking a Failed Disk Offline
 
 Clicking <i class="material-icons" aria-hidden="true" title="Options">more_vert</i> for the failed disk shows additional operations.
 
@@ -67,7 +67,7 @@ When the disk status shows as **Offline**, physically remove the disk from the s
 
 If the replacement disk is not already physically added to the system, add it now.
 
-### Online the New Disk
+### Brining a New Disk Online
 
 In the **Pool Status**, open the options for the offline disk and click **Replace**
 
@@ -87,6 +87,10 @@ For pools with large amounts of data, this can take a long time.
 When the resilver is complete, the pool status screen updates to show the new disk and the pool status returns to **Online**.
 
 ![Storage Pools Status Replace Complete](/images/CORE/12.0/StoragePoolsStatusReplaceComplete.png "Replacement Complete")
+
+### Restoring the Hot Spare
+
+{{< include file="/_includes/RestoreHotSpare.md" type="page" >}}
 
 {{< taglist tag="corerecovery" limit="10" >}}
 

--- a/content/CORE/CORETutorials/Storage/Disks/DiskReplace.md
+++ b/content/CORE/CORETutorials/Storage/Disks/DiskReplace.md
@@ -67,7 +67,7 @@ When the disk status shows as **Offline**, physically remove the disk from the s
 
 If the replacement disk is not already physically added to the system, add it now.
 
-### Brining a New Disk Online
+### Bringing a New Disk Online
 
 In the **Pool Status**, open the options for the offline disk and click **Replace**
 

--- a/content/SCALE/SCALETutorials/Storage/Pools/Disks/ReplacingDisks.md
+++ b/content/SCALE/SCALETutorials/Storage/Pools/Disks/ReplacingDisks.md
@@ -73,7 +73,8 @@ To replace a failed disk:
 
 ### Taking a Disk Offline 
 
-We recommend users off-line a disk before starting the physical disk replacement. Off-lining a disk removes the device from the pool and can prevent swap issues.
+We recommend users off-line a disk before starting the physical disk replacement. 
+Off-lining a disk removes the device from the pool and can prevent swap issues.
 
 {{< expand "Can I use a disk that is failing but still active?" "v" >}}
 There are situations where  you can leave a disk that has not completely failed online to provide additional redundancy during the replacement procedure.
@@ -103,6 +104,10 @@ When the scrub operation finishes, return to the **Devices** screen, click on th
    If the replacement disk is not already physically installed in the system, do it now.
 
 Use **[Replace](#replacing-a-failed-disk)** to bring the new disk online in the same VDEV.
+
+### Restoring the Hot Spare
+
+{{< include file="/_includes/RestoreHotSpare.md" type="page" >}}
    
 {{< taglist tag="scaledisks" limit="10" >}}
 {{< taglist tag="scaledevices" limit="10" title="Related Devices Articles" >}}

--- a/content/_includes/RestoreHotSpare.md
+++ b/content/_includes/RestoreHotSpare.md
@@ -1,5 +1,5 @@
 ---
 ---
 
-After a disk fails and the hot spare takes over, to restore the hot spare to a waiting status after you replace the failed drive, first remove the current hot spare from the pool, then add the spare disk back to the pool as a new hot spare.
+After a disk fails, the hot spare takes over. To restore the hot spare to waiting status after replacing the failed drive, remove the hot spare from the pool, then re-add it to the pool as a new hot spare.
 

--- a/content/_includes/RestoreHotSpare.md
+++ b/content/_includes/RestoreHotSpare.md
@@ -1,0 +1,5 @@
+---
+---
+
+After a disk fails and the hot spare takes over, to restore the hot spare to a waiting status after you replace the failed drive, first remove the current hot spare from the pool, then add the spare disk back to the pool as a new hot spare.
+


### PR DESCRIPTION
This commit creates a snippet to use in both CORE and SCALE Replacing a Disk articles that covers restoring a hot spare to operation.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
