### PR TITLE
PD-372 Update CORE to SCALE Migrate Content

### DIFF
--- a/content/SCALE/GettingStarted/Migrate/MigratingFromCORE.md
+++ b/content/SCALE/GettingStarted/Migrate/MigratingFromCORE.md
@@ -79,6 +79,7 @@ Click **INSTALL MANUAL UPDATE FILE**.
 
 Click **SAVE CONFIGURATION** to download a backup file that can restore the system configuration in the event something goes wrong with the migration.
 This is recommended but is not required.
+
 ![SCALEConfigSidegrade](/images/SCALE/SidegradeSaveConfig.png "Save the Config file")
 
 Select a **Temporary Storage Location** (either **Memory Device** or a **Pool**) for the manual update file.

--- a/content/SCALE/GettingStarted/Migrate/MigratingFromCORE.md
+++ b/content/SCALE/GettingStarted/Migrate/MigratingFromCORE.md
@@ -59,6 +59,10 @@ When TrueNAS SCALE boots, you might need to [use the Shell to configure networki
 
 ## Migrating using the CORE UI Manual Update 
 
+{{< hint type=warning >}}
+Upgrade CORE to the latest publicly-available release before attempting to migrate from CORE to SCALE!
+{{< /hint >}}
+
 This method of using the CORE UI Manual Update to migrate using a SCALE update file might fail if using CORE 13.0-U3 but if using CORE 13.0-U2 it should work. 
 If it fails, retry using the [iso file upgrade process](#migrating-using-an-iso-file-to-upgrade) in the section above.
 
@@ -73,7 +77,7 @@ Click **INSTALL MANUAL UPDATE FILE**.
 ![SCALEManualSidegrade](/images/SCALE/SidegeadeInstallManualUpdate.png "Install the Manual Upgrade")
 
 Click **SAVE CONFIGURATION** to download a backup file that can restore the system configuration in the event something goes wrong with the migration.
-This is recommended but it not required.
+This is recommended but is not required.
 ![SCALEConfigSidegrade](/images/SCALE/SidegradeSaveConfig.png "Save the Config file")
 
 Select a **Temporary Storage Location** (either **Memory Device** or a **Pool**) for the manual update file.

--- a/content/SCALE/GettingStarted/Migrate/MigratingFromCORE.md
+++ b/content/SCALE/GettingStarted/Migrate/MigratingFromCORE.md
@@ -74,6 +74,7 @@ Confirm that the TrueNAS CORE system is on the latest public release, 13.0-U3 or
 Click **CHECK FOR UPDATES** in the **System Information** card on the **Dashboard** or go to **System > Update**.
 
 Click **INSTALL MANUAL UPDATE FILE**.
+
 ![SCALEManualSidegrade](/images/SCALE/SidegeadeInstallManualUpdate.png "Install the Manual Upgrade")
 
 Click **SAVE CONFIGURATION** to download a backup file that can restore the system configuration in the event something goes wrong with the migration.

--- a/content/_includes/MigrateCOREtoSCALEWarning.md
+++ b/content/_includes/MigrateCOREtoSCALEWarning.md
@@ -4,6 +4,8 @@
 {{< hint type=warning >}}
 Migrating TrueNAS from CORE to SCALE is a one-way operation.
 Attempting to activate or roll back to a CORE boot environment can break the system.
+
+Upgrade your CORE system to the latest publically-available 13.0-U*x* release before attempting to migrate from CORE to SCALE.
 {{< /hint >}}
 
 {{< enterprise >}}

--- a/words-to-ignore.txt
+++ b/words-to-ignore.txt
@@ -936,6 +936,7 @@ GORM
 ui
 validator
 UX
+Ux
 validators
 cpu
 Caddyfile


### PR DESCRIPTION
This commit adds instructions to upgrade CORE to the latest publicly-available release before attempting to migrate CORE to SCALE. This is added to the MigrateCOREToSCALEWarning.md snippet file, and added in an admonition box in the UI migration section of the MigratingFromCORE.md article.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
