### PR TITLE
PD-382 add deprecation notice to service articles

### DIFF
--- a/content/SCALE/SCALETutorials/SystemSettings/Services/DDNSServiceSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Services/DDNSServiceSCALE.md
@@ -11,6 +11,9 @@ tags:
 
 {{< toc >}}
 
+{{< include file="/content/_includes/SCALEServiceDepricationNotice.md" type="page" >}}
+
+
 [Dynamic Domain Name Service (DDNS)](https://tools.ietf.org/html/rfc2136) is useful when you connect TrueNAS to an Internet service provider (ISP) that periodically changes the system's IP address.
 With Dynamic DNS, the system automatically associates its current IP address with a domain name and continues to provide access to TrueNAS even if the system IP address changes.
 

--- a/content/SCALE/SCALETutorials/SystemSettings/Services/DDNSServiceSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Services/DDNSServiceSCALE.md
@@ -11,7 +11,7 @@ tags:
 
 {{< toc >}}
 
-{{< include file="/content/_includes/SCALEServiceDepricationNotice.md" type="page" >}}
+{{< include file="content/_includes/SCALEServiceDeprecationNotice.md" type="page" >}}
 
 
 [Dynamic Domain Name Service (DDNS)](https://tools.ietf.org/html/rfc2136) is useful when you connect TrueNAS to an Internet service provider (ISP) that periodically changes the system's IP address.

--- a/content/SCALE/SCALETutorials/SystemSettings/Services/S3ServiceSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Services/S3ServiceSCALE.md
@@ -12,7 +12,7 @@ tags:
 
 {{< toc >}}
 
-{{< include file="/content/_includes/SCALEServiceDepricationNotice.md" type="page" >}}
+{{< include file="content/_includes/SCALEServiceDeprecationNotice.md" type="page" >}}
 
 S3 allows you to connect to TrueNAS from a networked client system with the MinIO browser, s3cmd, or S3 browser.
 

--- a/content/SCALE/SCALETutorials/SystemSettings/Services/S3ServiceSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Services/S3ServiceSCALE.md
@@ -12,7 +12,7 @@ tags:
 
 {{< toc >}}
 
-
+{{< include file="/content/_includes/SCALEServiceDepricationNotice.md" type="page" >}}
 
 S3 allows you to connect to TrueNAS from a networked client system with the MinIO browser, s3cmd, or S3 browser.
 

--- a/content/SCALE/SCALETutorials/SystemSettings/Services/TFTPServiceSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Services/TFTPServiceSCALE.md
@@ -10,7 +10,7 @@ tags:
 {{< toc >}}
 
 
-{{< include file="/content/_includes/SCALEServiceDepricationNotice.md" type="page" >}}
+{{< include file="content/_includes/SCALEServiceDeprecationNotice.md" type="page" >}}
 
 
 The [File Transfer Protocol (FTP)](https://tools.ietf.org/html/rfc959) is a simple option for data transfers.

--- a/content/SCALE/SCALETutorials/SystemSettings/Services/TFTPServiceSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Services/TFTPServiceSCALE.md
@@ -10,6 +10,9 @@ tags:
 {{< toc >}}
 
 
+{{< include file="/content/_includes/SCALEServiceDepricationNotice.md" type="page" >}}
+
+
 The [File Transfer Protocol (FTP)](https://tools.ietf.org/html/rfc959) is a simple option for data transfers.
 The SSH and Trivial FTP options provide secure or simple config file transfer methods respectively.
 

--- a/content/SCALE/SCALETutorials/SystemSettings/Services/WebDAVServiceSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Services/WebDAVServiceSCALE.md
@@ -10,6 +10,8 @@ tags:
 
 {{< toc >}}
 
+{{< include file="/content/_includes/SCALEServiceDepricationNotice.md" type="page" >}}
+
 The **Services > WebDAV** configuration screen displays settings to customize the TrueNAS WebDAV service.
 
 You can access it from **System Settings > Services** screen. Locate **WebDAV** and click <i class="material-icons" aria-hidden="true" title="Configure">edit</i> to open the screen, or use the **Config Service** option on the **WebDAV** widget options menu found on the main **Sharing** screen.

--- a/content/SCALE/SCALETutorials/SystemSettings/Services/WebDAVServiceSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Services/WebDAVServiceSCALE.md
@@ -10,7 +10,7 @@ tags:
 
 {{< toc >}}
 
-{{< include file="/content/_includes/SCALEServiceDepricationNotice.md" type="page" >}}
+{{< include file="content/_includes/SCALEServiceDeprecationNotice.md" type="page" >}}
 
 The **Services > WebDAV** configuration screen displays settings to customize the TrueNAS WebDAV service.
 

--- a/content/SCALE/SCALEUIReference/SystemSettings/Services/DDNSServiceScreenSCALE.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/Services/DDNSServiceScreenSCALE.md
@@ -10,6 +10,8 @@ tags:
 
 {{< toc >}}
 
+{{< include file="content/_includes/SCALEServiceDeprecationNotice.md" type="page" >}}
+
 The **Services > DynamicDNS** screen settings specify settings so the system can automatically associate its current IP address with a domain name and continues to provide access to TrueNAS even if the system IP address changes.
 
 To configure Dynamic DNS, go to **System Settings > Services** and find **DynamicDNS**, then click <i class="material-icons" aria-hidden="true" title="Configure">edit</i>.

--- a/content/SCALE/SCALEUIReference/SystemSettings/Services/S3ServiceScreen.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/Services/S3ServiceScreen.md
@@ -13,6 +13,9 @@ tags:
 {{< toc >}}
 
 
+{{< include file="/content/_includes/SCALEServiceDepricationNotice.md" type="page" >}}
+
+
 The **Services > S3** screen allows you to specify settings to connect to TrueNAS from a networked client system with the Minio browser, s3cmd, or S3 browser.
 
 ![S3ServiceSettingsTLS](/images/SCALE/22.12/S3ServiceSettingsTLS.png "S3 Service Options")

--- a/content/SCALE/SCALEUIReference/SystemSettings/Services/S3ServiceScreen.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/Services/S3ServiceScreen.md
@@ -13,7 +13,7 @@ tags:
 {{< toc >}}
 
 
-{{< include file="/content/_includes/SCALEServiceDepricationNotice.md" type="page" >}}
+{{< include file="content/_includes/SCALEServiceDeprecationNotice.md" type="page" >}}
 
 
 The **Services > S3** screen allows you to specify settings to connect to TrueNAS from a networked client system with the Minio browser, s3cmd, or S3 browser.

--- a/content/SCALE/SCALEUIReference/SystemSettings/Services/TFTPServiceScreen.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/Services/TFTPServiceScreen.md
@@ -11,6 +11,9 @@ tags:
 {{< toc >}}
 
 
+{{< include file="/content/_includes/SCALEServiceDepricationNotice.md" type="page" >}}
+
+
 The [File Transfer Protocol (FTP)](https://tools.ietf.org/html/rfc959) is a simple option for data transfers.
 The SSH and Trivial FTP options provide secure or simple config file transfer methods respectively.
 

--- a/content/SCALE/SCALEUIReference/SystemSettings/Services/TFTPServiceScreen.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/Services/TFTPServiceScreen.md
@@ -11,7 +11,7 @@ tags:
 {{< toc >}}
 
 
-{{< include file="/content/_includes/SCALEServiceDepricationNotice.md" type="page" >}}
+{{< include file="content/_includes/SCALEServiceDeprecationNotice.md" type="page" >}}
 
 
 The [File Transfer Protocol (FTP)](https://tools.ietf.org/html/rfc959) is a simple option for data transfers.

--- a/content/SCALE/SCALEUIReference/SystemSettings/Services/WebDAVServiceScreen.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/Services/WebDAVServiceScreen.md
@@ -10,6 +10,9 @@ tags:
 
 {{< toc >}}
 
+{{< include file="/content/_includes/SCALEServiceDepricationNotice.md" type="page" >}}
+
+
 ## WebDAV Service Screen
 The **Services > WebDAV** configuration screen displays settings to customize the TrueNAS WebDAV service.
 
@@ -34,7 +37,7 @@ To prevent unauthorized access to the shared data, set the **HTTP Authentication
 | **HTTP Port** | Enter a port number for unencrypted connections. The default **8080** is not recommended. Do not reuse a port number. |
 | **HTTP Authentication** | Select the authentication method from the dropdown list. Select **Basic Authentication** for unencrypted or **Digest Authentication** for encrypted. **No Authentication** to not use any authentication method. |
 | **WebDAV Password** | Enter a password. **davtest** is the default password, but you should change this as it is a known password. |
-| **Confirm Password** | Reenter the password to confirm it. |
+| **Confirm Password** | Re-enter the password to confirm it. |
 {{< /truetable >}}
 
 {{< taglist tag="scalewebdav" limit="10" title="Related WebDAV Articles" >}}

--- a/content/SCALE/SCALEUIReference/SystemSettings/Services/WebDAVServiceScreen.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/Services/WebDAVServiceScreen.md
@@ -10,7 +10,7 @@ tags:
 
 {{< toc >}}
 
-{{< include file="/content/_includes/SCALEServiceDepricationNotice.md" type="page" >}}
+{{< include file="content/_includes/SCALEServiceDeprecationNotice.md" type="page" >}}
 
 
 ## WebDAV Service Screen

--- a/content/_includes/SCALEServiceDeprecationNotice.md
+++ b/content/_includes/SCALEServiceDeprecationNotice.md
@@ -4,5 +4,5 @@
 {{< hint type=info >}}
 SCALE 22.12.3 deprecates this service. 
 SCALE 23.10 deletes this service completely and provides access to new applications to perform this role.
-New migration articles are planned and will be accessible from the Documenation Hub with Cobia release to allow you to move from this service to the new applications.
+New migration articles are planned and will be accessible from the Documentation Hub with Cobia release to allow you to move from this service to the new applications.
 {{< /hint >}}

--- a/content/_includes/SCALEServiceDeprecationNotice.md
+++ b/content/_includes/SCALEServiceDeprecationNotice.md
@@ -1,0 +1,8 @@
+---
+---
+
+{{< hint type=info >}}
+SCALE 22.12.3 deprecates this service. 
+SCALE 23.10 deletes this service completely and provides access to new applications to perform this role.
+New migration articles are planned and will be accessible from the Documenation Hub with Cobia release to allow you to move from this service to the new applications.
+{{< /hint >}}


### PR DESCRIPTION
This PR creates a snippet for the deprecated service notice and adds to to the service tutorial and UI reference articles for the services deprecated in 22.12.3.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
