### PR TITLE
CORE\_index.md logo filename correction

### DIFF
--- a/content/CORE/_index.md
+++ b/content/CORE/_index.md
@@ -18,7 +18,7 @@ There are three editions of TrueNAS that enable a broad range of applications wh
 {{< columns >}}
 
 <p style="text-align:center;">
-<img src="/images/tn-core-logo.png" alt="TNCORELogo" style=width:50%;" />
+<img src="/images/truenas-core-logo.png" alt="TNCORELogo" style=width:50%;" />
 </p>
 
 **TrueNAS CORE** is free and Open Source and is the successor to the wildly popular FreeNAS.


### PR DESCRIPTION
The filename for the CORE logo in _index.md did not match the file in static\images and was displaying as broken. This PR corrects it.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
