### PR TITLE
Fix up "Edit Page" links at top of pages.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -86,6 +86,7 @@ enable = true
   # and path must point to 'content' directory of repo.
   # You can also specify this parameter per page in front matter.
   geekdocEditPath = "edit/master/content"
+  pageheadEditPath = "edit/master"
 
   # (Optional, default true) Enables search function with flexsearch.
   # Index is built on the fly and might slowdown your website.

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -1,5 +1,6 @@
 {{ $geekdocRepo := default (default false .Site.Params.GeekdocRepo) .Page.Params.GeekdocRepo }}
 {{ $geekdocEditPath := default (default false .Site.Params.GeekdocEditPath) .Page.Params.GeekdocEditPath }}
+{{ $pageheadEditPath := default (default false .Site.Params.PageheadEditPath) .Page.Params.PageheadEditPath }}
 {{ if .File }}
   {{ $.Scratch.Set "geekdocFilePath" (default (path.Join (default "content" .Site.Params.contentDir) .File.Path) .Page.Params.GeekdocFilePath) }}
 {{ else }}
@@ -19,7 +20,7 @@
 {{ end }}
 
 {{ $showBreadcrumb := (and (default true .Page.Params.GeekdocBreadcrumb) (default true .Site.Params.GeekdocBreadcrumb)) }}
-{{ $showEdit := (and ($.Scratch.Get "geekdocFilePath") $geekdocRepo $geekdocEditPath) }}
+{{ $showEdit := (and ($.Scratch.Get "geekdocFilePath") $geekdocRepo $geekdocEditPath $pageheadEditPath) }}
 <div
   class="gdoc-page__header flex flex-wrap
   {{ if $showBreadcrumb }}
@@ -47,7 +48,7 @@
       <span class="editpage">
         <svg class="gdoc-icon gdoc_code"><use xlink:href="#gdoc_code"></use></svg>
         <a
-          href="{{ $geekdocRepo }}/{{ path.Join $geekdocEditPath ($.Scratch.Get "geekdocFilePath") }}"
+          href="{{ $geekdocRepo }}/{{ path.Join $pageheadEditPath ($.Scratch.Get "geekdocFilePath") }}"
         >
           {{ i18n "edit_page" }}
         </a>


### PR DESCRIPTION
Switch parameter to allow edit page links at bottom to continue to work as well.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
