### PR TITLE
PD-489 update dataset encryption content

### DIFF
--- a/content/SCALE/SCALETutorials/Storage/Datasets/EncryptionSCALE.md
+++ b/content/SCALE/SCALETutorials/Storage/Datasets/EncryptionSCALE.md
@@ -1,6 +1,6 @@
 ---
 title: "Storage Encryption"
-description: "Provides information on SCALE storage encryption for pools, datasets and zvols."
+description: "Provides information on SCALE storage encryption for pools, root datasets, datasets, and Zvols."
 weight: 50
 aliases: /scale/storage/encryptionscale/
 tags:
@@ -8,12 +8,11 @@ tags:
 - scaledatasets
 - scalepools
 - scalezovls
-- scalestorage
 ---
 
 {{< toc >}}
 
-TrueNAS SCALE offers ZFS encryption for your sensitive data in pools and datasets or zvols.
+TrueNAS SCALE offers ZFS encryption for your sensitive data in pools and datasets or Zvols.
 
 {{< include file="/_includes/EncryptionBackupKeys.md" type="page" >}}
 
@@ -26,26 +25,36 @@ The local TrueNAS system manages keys for data-at-rest.
 Users are responsible for storing and securing their keys.
 TrueNAS SCALE includes the [Key Management Interface Protocol (KMIP)](https://docs.oasis-open.org/kmip/spec/v1.1/os/kmip-spec-v1.1-os.html).
 
-## Pool Encryption
+## Pool and Dataset Encryption
 
 {{< include file="/_includes/EncryptionWarning.md" type="page" >}}
 
-Every pool has a *root* dataset that TrueNAS automatically generates when you create the pool. 
-This root dataset indicates the encryption status for the pool based on whether you select the **Encryption** option on the **[Pool Manager]({{< relref "PoolManagerScreens.md" >}})** screen when you create the pool. 
-If you select the **Encryption** option for the pool, it forces encryption for all datasets, zvols, and data contained in that pool, since they inherit encryption from the parent. 
+TrueNAS automatically generates a root dataset when you create a pool. 
+This root dataset inherits the encryption state of the pool based on the **Encryption** option on the **[Pool Manager]({{< relref "PoolManagerScreens.md" >}})** screen when you create the pool. 
+Because encryption is inherited from the parent, the data within that pool is encrypted. 
+Selecting the **Encryption** option for the pool (root dataset) forces encryption for all datasets and Zvols created within the root dataset. 
+
+As of SCALE 22.12.3, you can no longer create an unencrypted dataset within an encrypted pool or dataset. 
+This change does not affect existing datasets, only new datasets created in release 22.12.3 and later. 
+
+Leaving the **Encryption** option on the **Pool Manager** screen cleared creates an unencrypted pool root dataset. 
+You can create both unencrypted and encrypted datasets within this pool (root dataset), but if you create an encrypted dataset within an unencrypted root dataset any dataset or Zvol created within that encrypted dataset are automatically encrypted. 
+If you have only one pool on your system, do not select the **Encryption** option for this pool.
+
+{{< expand "Can I change dataset encryption?" "v" >}}
+You can change the type of encryption of an encrypted dataset (root or child dataset) from key to passphrase, but you cannot change an encrypted dataset to an unencrypted dataset after you save it.
+
+You can create an encrypted dataset on an unencrypted pool. 
+When creating a new dataset, changing the inheritance settings presents the option to change the type of encryption or to change from unencrypted to encrypted.
+{{< /expand >}}
+{{< expand "Can I unencrypt my data?" "v" >}}
+Yes, you can move encrypted data to an unencrypted pool or dataset using either rsync or replication. 
+You can also move data from an unencrypted pool or dataset to an encrypted dataset using rsync or replication.
+{{< /expand >}}
 
 {{< hint type=important >}}
-If your system loses power or you reboot the system, the datasets, zvols, and all data in an encrypted pool automatically lock to protect the data in that encrypted pool. 
+If your system loses power or you reboot the system, the datasets, Zvols, and all data in an encrypted pool automatically lock to protect the data in that encrypted pool. 
 {{< /hint >}}
-
-The pool and root dataset are unencrypted if you do not select the **Encryption** option on the **Pool Manager** screen. 
-
-You can create an unencrypted dataset on an encrypted pool. You can also create an encrypted dataset on an unencrypted pool if you need to protect data with encryption. 
-
-If you add an encrypted dataset under an unencrypted root dataset and then add child datasets under that encrypted dataset, it becomes an encrypted non-root parent to any dataset created under it. 
-You can let a nested child dataset inherit the encryption settings from the parent or change the settings for the child dataset.
-
-The other datasets created from the unencrypted root dataset can remain unencrypted unless you choose encryption when you create them.
 
 ### Encryption Visual Cues
 
@@ -55,7 +64,7 @@ Each icon displays text labels that explain the state of the dataset when you ho
 
 {{< include file="/_includes/EncryptionIconsSCALE.md" type="page" >}}
 
-If a dataset inherits encryption from either the root or a non-root parent dataset, the locking icons change to a different type, and the mouse hover-over label indicates the encryption is **Locked by ancestor** or **Unlocked by ancestor**. 
+If a dataset inherits encryption, the locking icons change to a different type and the mouse hover-over label indicates the encryption is **Locked by ancestor** or **Unlocked by ancestor**. 
 
 Each encrypted dataset includes the **ZFS Encryption** widget on the **Datasets** screen when you select the dataset.
 
@@ -63,15 +72,15 @@ The dataset encryption state is unlocked until you lock it using the **Lock** op
 
 ### Inherit Encryption
 
-Datasets *inherit* encryption, which means they use the encryption settings of the parent, whether the parent is the root dataset or a non-root parent dataset with child datasets nested under it.
+Datasets inherit encryption, which means they keep the encryption settings of the parent dataset whether the parent is the root dataset or a non-root parent dataset with child datasets nested under it.
 
-You can change inherited settings for a dataset when you add the dataset, or you can change inherited encryption settings for an existing dataset using the **Edit** option on the **ZFS Encryption** widget.
+You can change inherited settings for a dataset when you add the dataset using the **Edit** option on the **ZFS Encryption** widget.
 
 ## Implementing Encryption
 Before creating a pool with encryption make sure you want to encrypt all datasets and data stored on the pool. 
 
 {{< hint type=warning >}} 
-You cannot change a pool from encrypted to non-encrypted. You can only change the dataset encryption type in the encrypted pool.
+You cannot change a pool from encrypted to non-encrypted. You can only change the dataset encryption type (key or passphrase) for the encrypted pool.
 {{< /hint >}}
 If your system does not have enough disks to allow you to create a second storage pool, we recommend that you not use encryption at the pool level. 
 You can mix encrypted and unencrypted datasets on an unencrypted pool.
@@ -89,7 +98,7 @@ Read the warning, select **Confirm**, and then click **I UNDERSTAND**.
 
 A second dialog opens where you click **Download Encryption Key** for the pool encryption key. 
 
-![DownloadEncryptionKeyForPool](/images/SCALE/22.12/DownloadEncryptionKeyForPool.png "Download Encryption Key on Pool Manager") 
+{{< trueimage src="/images/SCALE/22.12/DownloadEncryptionKeyForPool.png" alt="Download Encryption Key on Pool Manager" id="1 Download Encryption Key on Pool Manager" >}}
 
 Click **Done** to close the window. 
 Move the encryption key to safe location where you can back up the file.
@@ -111,18 +120,18 @@ To add a dataset, enter a value in **Name**.
 Next, select the type of **Case Sensitivity** and **Share Type** for the dataset.
 
 To add encyrption to a dataset, select **Inherit** under **Encryption Options** to clear the checkbox. 
-This displays the **Encryption** checkbox preselected. 
+This displays the **Encryption** checkbox already preselected. 
 
-![AddDatasetEncryptionOptionsInheritCleared](/images/SCALE/22.12/AddDatasetEncryptionOptionsInheritCleared.png "Add Dataset Encryption Options Clear Inherit") 
+{{< trueimage src="/images/SCALE/22.12/AddDatasetEncryptionOptionsInheritCleared.png" alt="Add Dataset Encryption Options Clear Inherit" id="2 Add Dataset Encryption Options Clear Inherit" >}}
 
 Now decide if you want to use the default encryption type key and if you want to let the system generate the encryption key. 
 To use key encryption and your own key, clear the **Generate key** checkbox to display the **Key** field. Enter your key in this field.
 
-![AddDatasetEncryptionKeyfromNonEncrypted](/images/SCALE/22.12/AddDatasetEncryptionKeyfromNonEncrypted.png "Add Key Encryption") 
+{{< trueimage src="/images/SCALE/22.12/AddDatasetEncryptionKeyfromNonEncrypted.png" alt="Add Key Encryption" id="3 Add Key Encryption" >}}
 
 To change to passphrase encryption, click the down arrow and select **Passphrase** from the **Encryption Type** dropdown.
 
-![AddDatasetEncryptionOptionsPassphrase](/images/SCALE/22.12/AddDatasetEncryptionOptionsPassphrase.png "Add Passphrase Encryption") 
+{{< trueimage src="/images/SCALE/22.12/AddDatasetEncryptionOptionsPassphrase.png" alt="Add Passphrase Encryption" id="4 Add Passphrase Encryption" >}}
 
 You can select the encryption algorithm to use from the **Encryption Standard** dropdown list of options or use the recommended default. 
 Leave the default selection if you do not have a particular encryption standard you want use.  
@@ -132,7 +141,7 @@ These algorithms provide authenticated encryption with block ciphers.
 {{< /expand >}}
 
 {{< hint type=note >}}
-The passhrase must be longer than 8 and less than 512 characters.
+The passphrase must be longer than 8 and less than 512 characters.
 {{< /hint >}}
 
 {{< hint type=warning >}}
@@ -157,18 +166,18 @@ To change the encryption type, go to **Datasets**:
    
    If the dataset inherits encryption settings from a parent dataset, to change this, clear the **Inherit encryption properties from parent** checkbox to display the key type encryption setting options.
 
-   ![EditEncryptionOptionsInheritedSettings](/images/SCALE/22.12/EditEncryptionOptionsInheritedSettings.png "Edit Encryption Window - Inherited")
+   {{< trueimage src="/images/SCALE/22.12/EditEncryptionOptionsInheritedSettings.png" alt="Edit Encryption Window - Inherited" id="5 Edit Encryption Window - Inherited" >}}
 
 2. Change the encryption settings. Key type options are to change the type from **Key** to **Passphrase** or from a generated to a manually-entered encryption key.
    After clearing the **Inherits encryption properties from parent** the default settings display with **Encryption Type** set to **Key** and **Generate Key** pre-selected.
    To manually enter an encryption key, select **Generate Key** to clear the checkmark and display the **Key** field. Enter the new key in this field.
 
-   ![EditEncryptionOptionsWindowKeyType](/images/SCALE/22.12/EditEncryptionOptionsWindowKeyType.png "Edit Encryption Key Type") 
+   {{< trueimage src="/images/SCALE/22.12/EditEncryptionOptionsWindowKeyType.png" alt="Edit Encryption Key Type" id="6 Edit Encryption Key Type" >}}
 
 3. (Optional) Change the **Encryption Type** to **Passphrase** using the dropdown list of options. 
    The **Passphrase**  and **Confirm Passphrase** fields and other passphrase encryption fields display. 
    
-   ![EditEncryptionOptionsWindowPassphrase](/images/SCALE/22.12/EditEncryptionOptionsWindowPassphrase.png "Edit Encryption Window - Passphrase")
+   {{< trueimage src="/images/SCALE/22.12/EditEncryptionOptionsWindowPassphrase.png" alt="Edit Encryption Window - Passphrase" id="7 Edit Encryption Window - Passphrase" >}}
 
    Enter the passphrase twice. Use a complex passphrase that is not easy to guess. Store in a secure location subject to regular backups.
 
@@ -187,7 +196,7 @@ Before locking a dataset, verify that it is not currently in use.
 
 Select the dataset on the tree table, then click **Lock** on the **ZFS Encryption** widget to open the **Lock Dataset** dialog with the dataset full path name.
 
-![LockDatasetDialog](/images/SCALE/22.12/LockDatasetDialog.png "Lock Dataset")
+{{< trueimage src="/images/SCALE/22.12/LockDatasetDialog.png" alt="Lock Dataset" id="8 Lock Dataset" >}}
 
 Use the **Force unmount** option only if you are certain no one is currently accessing the dataset. 
 **Force unmount** boots anyone using the dataset (e.g. someone accessing a share) so you can lock it. 
@@ -202,7 +211,7 @@ You *cannot* use locked datasets.
 To unlock a dataset, go to **Datasets** then select the dataset on the tree table. 
 Click **Unlock** on the **ZFS Encryption** widget to open the **Unlock Dataset** screen.
 
-![UnlockDatasetsScreen](/images/SCALE/22.12/UnlockDatasetsScreen.png "Dataset Unlock Screen")
+{{< trueimage src="/images/SCALE/22.12/UnlockDatasetsScreen.png" alt="Dataset Unlock Screen" id="9 Dataset Unlock Screen" >}}
 
 Type the passphrase into **Dataset Passphrase** and click **Save**. 
 
@@ -211,7 +220,7 @@ Select **Unlock Child Encrypted Roots** to unlock all locked child datasets if t
 Select **Force** if the dataset mount path exists but is not empty. When this happens, the unlock operation fails. Using **Force** allows the system to rename the existing directory and file where the dataset should mount. This prevents the mount operation from failing. 
 A confirmation dialog displays. 
 
-![UnlockDatasetsContinueDialog](/images/SCALE/22.12/UnlockDatasetsContinueDialog.png "Continue Dataset Unlock Confirmation")
+{{< trueimage src="/images/SCALE/22.12/UnlockDatasetsContinueDialog.png" alt="Continue Dataset Unlock Confirmation" id="10 Continue Dataset Unlock Confirmation" >}}
 
 Click **CONTINUE** to confirm you want to unlock the datasets. Click **CLOSE** to exit and keep the datasets locked. 
 A second confirmation dialog opens confirming the datasets unlocked. 
@@ -223,30 +232,30 @@ TrueNAS displays the dataset with the unlocked icon.
 Encryption is for securing sensitive data. 
 
 {{< hint type=note >}}
-You can only encrypting a zvol if you create the zvol from a dataset with encryption.
+You can only encrypting a Zvol if you create the Zvol from a dataset with encryption.
 {{< /hint >}}
 
 {{< include file="/_includes/EncryptionBackupKeys.md" type="page" >}}
 
 Zvols inherit encryption settings from the parent dataset. 
 
-To encrypt a zvol, select a dataset configured with encryption and then [create a new zvol]({{< relref "AddManageZvols.md" >}}).
+To encrypt a Zvol, select a dataset configured with encryption and then [create a new Zvol]({{< relref "AddManageZvols.md" >}}).
 Next, click the <i class="material-icons" aria-hidden="true" title="Options">more_vert</i> icon to display the **Zvol Actions** options list and then click **Encryption Options**. 
 
-![EncryptedZvolActionsOptionss](/images/SCALE/22.02/EncryptedZvolActionsOptions.png "Zvol Actions Encryption Options")
+{{< trueimage src="/images/SCALE/22.02/EncryptedZvolActionsOptions.png" alt="Zvol Actions Encryption Options" id="11 Zvol Actions Encryption Options" >}}
 
-If you do not see **Encryption Options** on the **Zvol Action**s option list you created the zvol from an unencrypted dataset. Delete the zvol and start over.
+If you do not see **Encryption Options** on the **Zvol Action**s option list you created the Zvol from an unencrypted dataset. Delete the Zvol and start over.
 
 Click **Encryption Options**. The **Edit Encryption Options** dialog for the Zvol displays with **Inherit encryption properties from parent** selected. 
 
-![EditEncryptionDialogForZvol](/images/SCALE/22.02/EditEncryptionDialogForZvol.png "Edit Zvol Encryption")
+{{< trueimage src="/images/SCALE/22.02/EditEncryptionDialogForZvol.png" alt="Edit Zvol Encryption" id="12 Edit Zvol Encryption" >}}
 
 If not making changes, click **Confirm**, and then click **Save**. 
-The zvol is encrypted with settings inherited from its parent.
+The Zvol is encrypted with settings inherited from its parent.
 
 To change inherited encryption properties, clear the **Inherit encryption properties from parent** checkbox. The current encryption settings display. You can change from key to passphrase or change from a system-generated key to one of your choosing. 
 
-![EditEncryptionKeyType](/images/SCALE/22.02/EditEncryptionKeyType.png "Zvol Uncheck Inherit Encryption")
+{{< trueimage src="/images/SCALE/22.02/EditEncryptionKeyType.png" alt="Zvol Uncheck Inherit Encryption" id="13 Zvol Uncheck Inherit Encryption" >}}
 
 If **Encryption Type** is set to**Key**, type an encryption key into the **Key** field or select **Generate Key**. 
 If using **Passphrase**, it should be at least eight characters long. Use a passphrase complex enough to not easily guess. 
@@ -266,14 +275,14 @@ Creating a new encrypted pool automatically generates a new key file and prompts
 Always back up the key file to a safe and secure location.
 {{< /hint >}}
 
-![DownloadEncryptionKeysWarning](/images/SCALE/22.02/DownloadEncryptionKeysWarning.png "Download Encryption Keys")
+{{< trueimage src="/images/SCALE/22.02/DownloadEncryptionKeysWarning.png" alt="Download Encryption Keys" id="14 Download Encryption Keys" >}}
 
 To manually back up a root dataset key file, click the <span class="iconify" data-icon="mdi:database-cog"></span> icon to display the **Pool Actions** list of options, and select **Export Dataset Keys**.
 The keys download to your system.
 
 To change the key, click <i class="material-icons" aria-hidden="true" title="Options">more_vert</i> for the dataset, and then click **Encryption Options**. 
 
-![EditRootDatasetEncryptionOptions](/images/SCALE/22.02/EditRootDatasetEncryptionOptions.png "Edit Root Dataset Encryption Keys")
+{{< trueimage src="/images/SCALE/22.02/EditRootDatasetEncryptionOptions.png" alt="Edit Root Dataset Encryption Keys" id="15 Edit Root Dataset Encryption Keys" >}}
 
 See [Changing Dataset-Level Encryption](#changing-dataset-level-encryption) for more information on changing encryption settings. 
 
@@ -284,6 +293,9 @@ The **pbkdf2iters** is the number of password-based key derivation function 2 ([
 
 ## Unlocking a Replicated Encrypted Dataset or Zvol Without a Passphrase
 
-TrueNAS SCALE users should either replicate the dataset/Zvol without properties to disable encryption at the remote end or construct a special json manifest to unlock each child dataset/zvol with a unique key.
+TrueNAS SCALE users should either replicate the dataset/Zvol without properties to disable encryption at the remote end or construct a special json manifest to unlock each child dataset/Zvol with a unique key.
 
 {{< include file="/_includes/ReplicatedEncryptedUnlock.md" type="page" >}}
+
+{{< taglist tag="scaleencryption" limit="10"  >}}
+{{< taglist tag="scaledatasets" limit="10" title="Related Dataset Articles">}}

--- a/content/SCALE/SCALEUIReference/Storage/Datasets/DatasetsScreensScale.md
+++ b/content/SCALE/SCALEUIReference/Storage/Datasets/DatasetsScreensScale.md
@@ -14,14 +14,14 @@ tag:
 {{< toc >}}
 
 
-The **Datasets** screen and widgets display information about datasets, provide access to data management functions, indicate the dataset roles, list which services use the dataset, show the encryption status and the permissions the dataset has in place. 
+The **Datasets** screen and widgets display information about datasets, provide access to data management functions, indicate the dataset roles, list the services using the dataset, show the encryption status and the permissions the dataset has in place. 
 The screen focus is on managing data storage including user and group quotas, snapshots, and other data protection measures. 
 
 The **Datasets** screen displays **No Datasets** with a **Create Pool** button in the center of the screen until you add a pool and the first root dataset.
 
-![DatasetsScreenBeforeAddingAPool](/images/SCALE/22.12/DatasetsScreenBeforeAddingAPool.png "Datasets Screen Without a Pool") 
+{{< trueimage src="/images/SCALE/22.12/DatasetsScreenBeforeAddingAPool.png" alt="Datasets Screen Without a Pool" id="1 Datasets Screen Without a Pool" >}}
 
-After creating a dataset, the left side of the screen displays a tree table that lists parent or child datasets (or zvols). The **Details for *datasetname*** area on the right side of the screen displays a set of dataset widgets.
+After creating a dataset, the left side of the screen displays a tree table that lists parent or child datasets (or Zvols). The **Details for *datasetname*** area on the right side of the screen displays a set of dataset widgets.
 
 {{< hint type=note >}}
 Large petabyte systems might report storage numbers inaccurately. Storage configurations with more than 9,007,199,254,740,992 bytes round the last 4 digits.
@@ -29,7 +29,7 @@ Large petabyte systems might report storage numbers inaccurately. Storage config
 For example, a system with 18,446,744,073,709,551,615 bytes reports the number as 18,446,744,073,709,552,000 bytes.
 {{< /hint >}}
 
-![DatasetsScreenAfterAddingAPool](/images/SCALE/22.12/DatasetsScreenAfterAddingAPool.png "Datasets Screen With a Pool") 
+{{< trueimage src="/images/SCALE/22.12/DatasetsScreenAfterAddingAPool.png" alt="Datasets Screen With a Pool" id="2 Datasets Screen With a Pool" >}}
 
 **Import Data** opens the **[Import Data]({{< relref "ImportDataScreenSCALE.md" >}})** screen. 
 
@@ -39,12 +39,12 @@ For example, a system with 18,446,744,073,709,551,615 bytes reports the number a
 
 ## Dataset Tree Table
 
-The datasets tree table lists datasets in an expandable hierarchical structure with the root dataset first, which is followed by direct child or non-root parent datasets with their child datasets nested under them. 
+The datasets tree table lists datasets in an expandable hierarchical structure with the root dataset first, then each direct child or non-root parent dataset follows and with their child datasets nested under them. 
 {{< expand "Click Here for More Information" "v" >}}
 Click on any root or non-root parent dataset to expand the tree table.
 Click on any dataset to select it and display the dataset widgets for that dataset.
 
-![DatasetsScreenTreeTableExpanded](/images/SCALE/22.12/DatasetsScreenTreeTableExpanded.png "Dataset Tree Table")
+{{< trueimage src="/images/SCALE/22.12/DatasetsScreenTreeTableExpanded.png" alt="Dataset Tree Table" id="3 Dataset Tree Table" >}}
 
 The table includes used and available storage space for that dataset, encryption status (locked, unlocked, or unencrypted), the role of that dataset, and what service uses it (i.e., the system dataset, a share, virtual machine, or application). 
 
@@ -70,7 +70,8 @@ A dataset with an active task include an activity spinner when that task is in p
 {{< /expand >}}
 
 ## Dataset Widgets
-Each dataset has a set of information cards (widgets) that display in the **Details for *datasetname*** area of the screen and that provide information grouped by functional areas. 
+Each dataset has a set of information cards (widgets) that display in the **Details for *datasetname*** area of the screen. 
+These widgets provide information grouped by functional areas. 
 The set of widgets for a root or parent dataset differs from child datasets or datasets used by another service or with encryption.
 
 Dataset widgets are:
@@ -86,11 +87,11 @@ The **Dataset Details** widget lists information on dataset type, and the sync, 
 {{< expand "Click Here for More Information" "v" >}}
 A root dataset path displays the pool name alone.
 
-![DatasetDetailsWidgetRootDataset](/images/SCALE/22.12/DatasetDetailsWidgetRootDataset.png "Dataset Details Widget Root Dataset")
+{{< trueimage src="/images/SCALE/22.12/DatasetDetailsWidgetRootDataset.png" alt="Dataset Details Widget Root Dataset" id="4 Dataset Details Widget Root Dataset" >}}
 
 A child dataset path displays the root dataset (pool) name and parent dataset.
 
-![DatasetDetailsWidgetChildDataset](/images/SCALE/22.12/DatasetDetailsWidgetChildDataset.png "Dataset Details Widget Child Dataset")
+{{< trueimage src="/images/SCALE/22.12/DatasetDetailsWidgetChildDataset.png" alt="Dataset Details Widget Child Dataset" id="5 Dataset Details Widget Child Dataset" >}}
 
 **Edit** opens the **[Edit Dataset](#add-and-edit-dataset-screens)** screen for the selected dataset.
 
@@ -109,15 +110,15 @@ Non-root parent and child datasets include the **Delete** button.
 The **Delete** window for a parent dataset (non-root) includes information about snapshots, shares or other services such as Kubernetes or VMs that use the dataset.
 If it is a parent to other datasets, the window includes the services a child dataset of this parent dataset uses.
 
-![DeleteDatasetParentDataset](/images/SCALE/22.12/DeleteDatasetParentDataset.png "Delete Dataset Parent Dataset")
+{{< trueimage src="/images/SCALE/22.12/DeleteDatasetParentDataset.png" alt="Delete Dataset Parent Dataset" id="6 Delete Dataset Parent Dataset" >}}
 
 If a child dataset uses services the window displays them.
 
-![DeleteDatasetChildUsingAService](/images/SCALE/22.12/DeleteDatasetChildUsingAService.png "Delete Dataset Child Dataset Using a Service")
+{{< trueimage src="/images/SCALE/22.12/DeleteDatasetChildUsingAService.png" alt="Delete Dataset Child Dataset Using a Service" id="7 Delete Dataset Child Dataset Using a Service" >}}
 
 If a child dataset is not used by a service, it does not display a service.
 
-![DeleteDatasetChildDataset](/images/SCALE/22.12/DeleteDatasetChildDataset.png "Delete Dataset Child Dataset")
+{{< trueimage src="/images/SCALE/22.12/DeleteDatasetChildDataset.png" alt="Delete Dataset Child Dataset" id="8 Delete Dataset Child Dataset" >}}
 
 The window includes field where you type the path for the dataset and a **Confirm** option you must select to activate the **Delete Dataset** button.
 {{< /expand >}}
@@ -130,7 +131,7 @@ The widget donut graph provides at-a-glance information and numeric values for t
 This includes data written and space allocated to child datasets of this dataset. 
 It provides access to quota configuration options for the parent dataset and the child dataset of the parent, and for users and groups with access to the dataset.
 
-![DatasetSpaceManagementWidgetRootDataset](/images/SCALE/22.12/DatasetSpaceManagementWidgetRootDataset.png "Dataset Space Management Widget Root Dataset")
+{{< trueimage src="/images/SCALE/22.12/DatasetSpaceManagementWidgetRootDataset.png" alt="Dataset Space Management Widget Root Dataset" id="9 Dataset Space Management Widget Root Dataset" >}}
 
 **Edit** opens the **[Capacity Settings]({{< relref "CapacitySettingsSCALE.md" >}})** screen where you can set quotas for the dataset.
 
@@ -139,11 +140,11 @@ It provides access to quota configuration options for the parent dataset and the
 
 ### Data Protection Widget
 The **Data Protection** widget displays for all datasets. 
-This widget provides information on the number snapshots and other data protection related scheduled tasks (replication, cloud sync, rsync and snapshots) configured on the system. 
+It displays the number snapshots and other data protection related scheduled tasks (replication, cloud sync, rsync and snapshots) configured on the system. 
 {{< expand "Click Here for More Information" "v" >}}
-It provides access to the tasks found on the **Data Protection** screen through links. 
+The **Data Protection** widget links to the tasks found on the **Data Protection** screen. 
 
-![DataProtectionWidget](/images/SCALE/22.12/DataProtectionWidget.png "Data Protection Widget")
+{{< trueimage src="/images/SCALE/22.12/DataProtectionWidget.png" alt="Data Protection Widget" id="10 Data Protection Widget" >}}
 
 **Create Snapshot** opens the **[Add Snapshot]({{< relref "SnapshotsScreens.md" >}})** screen.
 
@@ -166,16 +167,16 @@ It indicates the type of ACL as either NFSv4 or Unix Permissions (POSIX) and lis
 Root dataset permissions are not editable. 
 Permission screen and widget options vary based on the ACL type. 
 
-![PermissionsWidgetRootDataset](/images/SCALE/22.12/PermissionsWidgetRootDataset.png "Permissions Widget Root Dataset")
+{{< trueimage src="/images/SCALE/22.12/PermissionsWidgetRootDataset.png" alt="Permissions Widget Root Dataset" id="11 Permissions Widget Root Dataset" >}}
 
 Parent and child dataset permissions are editable. 
 
-![PermissionsWidgetParentDataset](/images/SCALE/22.12/PermissionsWidgetParentDataset.png "Permissions Widget Parent or Child Dataset")
+{{< trueimage src="/images/SCALE/22.12/PermissionsWidgetParentDataset.png" alt="Permissions Widget Parent or Child Dataset" id="12 Permissions Widget Parent or Child Dataset" >}}
 
 If the ACL type is NFSv4 (the default ACL type) the widget turns the items listed on the **Permissions** widget into buttons that open a configuration are where you can edit the item from the **Permissions** widget. 
 The expanded item configuration area has both **Permissions Advanced** and **Flags Advanced** check-buttons you can select or deselect common NFSv4 permission options for each item type.
 
-![PermissionsWidgetOwnerNSFv4Options](/images/SCALE/22.12/PermissionsWidgetOwnerNSFv4Options.png "Permissions Widget Owner NFSv4 Options")
+{{< trueimage src="/images/SCALE/22.12/PermissionsWidgetOwnerNSFv4Options.png" alt="Permissions Widget Owner NFSv4 Options" id="13 Permissions Widget Owner NFSv4 Options" >}}
 
 A dataset with a POSIX ACL type, such as the ix-applications dataset, is only editable using the **Edit** button. 
 **Edit** opens the [permission edit screen]({{< relref "EditACLScreens.md" >}}) for ACL based on the type.
@@ -188,7 +189,7 @@ A parent dataset displays information on child datasets that a service uses.
 The **Roles** widget displays information about the service using the dataset and provides a link to manage whatever that service is. 
 The widget roles information corresponds to the roles information in the dataset tree table.
 
-![RolesWidgetRootDataset](/images/SCALE/22.12/RolesWidgetRootDataset.png "Roles Widget Root Dataset")
+{{< trueimage src="/images/SCALE/22.12/RolesWidgetRootDataset.png" alt="Roles Widget Root Dataset" id="14 Roles Widget Root Dataset" >}}
 
 {{< truetable >}}
 | Role | Link Included | Description |
@@ -197,28 +198,28 @@ The widget roles information corresponds to the roles information in the dataset
 | Apps | [Manage Apps Settings]({{< relref "AppsScreensSCALE.md" >}}) | Displays Kubernetes is using the dataset. Select the option to **Choose Pool** from the **Settings** dropdown list on the **Applications** screen. |
 | SMB share | [Manage SMB Shares]({{< relref "SMBSharesScreens.md" >}}) | Displays the name of the SMB share using the dataset. Select it on the **SMB Shares** screen to edit it. |
 | Other share | Link to the Share type screen | Displays the name of the share using the dataset. Select it on the share screen (NFS, iSCSI or WebDAV) to edit it. |
-| VM | [Manage VM Settings]({{< relref "VirtualizationScreens.md" >}}) | Displays the name of the VM using the dataset(zvol). Select it on the **Virtual Machines** screen to edit it. |
+| VM | [Manage VM Settings]({{< relref "VirtualizationScreens.md" >}}) | Displays the name of the VM using the dataset(Zvol). Select it on the **Virtual Machines** screen to edit it. |
 {{< /truetable >}}
 
 {{< /expand >}}
 
 ### ZFS Encryption Widget
 
-The **ZFS Encryption** widget displays for root, non-root parent, and child datasets configured with encryption but the options in the widget vary based on the type of dataset. 
+The **ZFS Encryption** widget displays for datasets configured with encryption but the options in the widget vary based on the type of dataset (root, non-root parent, or child dataset). 
 It includes the current state of the dataset encryption, the encryption root, type and algorithm used.
 {{< expand "Click Here for More Information" "v" >}}
 The **ZFS Encryption** widget displays the **Lock** or **Unlock** options are not available on the root dataset or a child dataset of a non-root parent it inherits encryption settings from. 
 The root dataset **ZFS Encryption** widget includes the **Export All Keys** and the **Export Key** options, and the **Edit** option to change encryption settings.
 
-![ZFSEncryptionWidgetRootDataset](/images/SCALE/22.12/ZFSEncryptionWidgetRootDataset.png "ZFS Encryption Widget Root Dataset")
+{{< trueimage src="/images/SCALE/22.12/ZFSEncryptionWidgetRootDataset.png" alt="ZFS Encryption Widget Root Dataset" id="15 ZFS Encryption Widget Root Dataset" >}}
 
 Parent or child dataset **ZFS Encryption** widgets include the options to **Lock** and **Unlock** the dataset and to **Edit** the encryption settings.
 
-![ZFSEncryptionWidgetChildDatasetUnlocked](/images/SCALE/22.12/ZFSEncryptionWidgetChildDatasetUnlocked.png "ZFS Encryption Widget Child Dataset Unlocked")
+{{< trueimage src="/images/SCALE/22.12/ZFSEncryptionWidgetChildDatasetUnlocked.png" alt="ZFS Encryption Widget Child Dataset Unlocked" id="16 ZFS Encryption Widget Child Dataset Unlocked" >}}
 
 Child dataset **ZFS Encryption** widgets include the **Go to Encryption Root** when you select **Inherit** as its **Encryption Options** setting. The non-root parent dataset controls the state of the child dataset.
 
-![ZFSEncryptionWidgetWithGoToEncryptionRoot](/images/SCALE/22.12/ZFSEncryptionWidgetWithGoToEncryptionRoot.png "ZFS Encryption Widget with Go To Encryption Root")
+{{< trueimage src="/images/SCALE/22.12/ZFSEncryptionWidgetWithGoToEncryptionRoot.png" alt="ZFS Encryption Widget with Go To Encryption Root" id="17 ZFS Encryption Widget with Go To Encryption Root" >}}
 
 **Edit** opens the **[Edit Encryption Options]({{< relref "EncryptionUISCALE.md" >}}) for *dataset*** window for the selected dataset.
 
@@ -243,7 +244,7 @@ These settings are common to both the **Basic Options** and **Advanced Options**
 Setting include name, path and other general settings.
 {{< expand "Click Here for More Information" "v" >}}
 
-![AddDatasetNameAndOptions](/images/SCALE/22.12/AddDatasetNameAndOptions.png "Add Dataset Name and Options") 
+{{< trueimage src="/images/SCALE/22.12/AddDatasetNameAndOptions.png" alt="Add Dataset Name and Options" id="18 Add Dataset Name and Options" >}}
 
 {{< truetable >}}
 | Setting | Description |
@@ -252,7 +253,7 @@ Setting include name, path and other general settings.
 | **Name** | Enter a unique identifier for the dataset. You cannot change the dataset name after clicking **Save**. TrueNAS does not allow dataset names to have trailing spaces. |
 | **Comments** | Enter notes about the dataset. |
 | **Sync** | Select the sync setting option from the dropdown list. **Standard** uses the sync settings requested by the client software. **Always** waits for data writes to complete, and **Disabled** never waits for writes to complete. |
-| **Compression level** | Select the compression algorithm to use from the dropdown list. Options encode information in less space than the original data occupies. It is recommended to choose a compression algorithm that balances disk performance with the amount of saved space.<br> **LZ4** is generally recommended as it maximizes performance and dynamically identifies the best files to compress.<br> **ZSTD** is the [Zstandard](https://tools.ietf.org/html/rfc8478) compression algorithm with several options for balancing speed and compression.<br> **Gzip** options range from **1** for least compression with best performance, through **9** for maximum compression with greatest performance impact.<br> **ZLE** is a fast algorithm that only eliminates runs of zeroes.<br>**LZJB** is a legacy algorithm that is not recommended for use. |
+| **Compression level** | Select the compression algorithm to use from the dropdown list. Options encode information in less space than the original data occupies. We recommend cchoosing a compression algorithm that balances disk performance with the amount of space saved. <br> **LZ4** is generally recommended as it maximizes performance and dynamically identifies the best files to compress.<br> **ZSTD** is the [Zstandard](https://tools.ietf.org/html/rfc8478) compression algorithm with several options for balancing speed and compression.<br> **Gzip** options range from **1** for least compression with best performance, through **9** for maximum compression with greatest performance impact.<br> **ZLE** is a fast algorithm that only eliminates runs of zeroes.<br>**LZJB** is a legacy algorithm that is not recommended for use. |
 | **Enable Atime**| Select the access time for files option from the dropdown list. Access time can result in significant performance gains. **Inherit** uses the access time setting of the parent or the root dataset. **On** updates the access time for files when they are read. **Off** disables creating log traffic when reading files to maximize performance. |
 {{< /truetable >}}
 {{< /expand >}}
@@ -269,7 +270,7 @@ To change encryption settings use the **Edit** button on the **ZFS Encryption** 
 The default setting is **Inherit** selected. Clearing the checkbox displays the key encryption options. 
 Clear the **Inherit(*non-encrypted*)** checkbox to display additional settings.
 
-![AddDatasetBasicEncryptionAndOtherOptions](/images/SCALE/22.12/AddDatasetBasicEncryptionAndOtherOptions.png "Add Dataset Encryption Options Clear Inherit") 
+{{< trueimage src="/images/SCALE/22.12/AddDatasetBasicEncryptionAndOtherOptions.png" alt="Add Dataset Encryption Options Clear Inherit" id="19 Add Dataset Encryption Options Clear Inherit" >}}
  
 Selecting other options changes the settings displayed.
 
@@ -291,12 +292,12 @@ See the list of Related Encryption Articles at the bottom of this article for mo
 The **Other Options** help tune the dataset for specific data sharing protocols, but the **Basic Options** settings only includes a small subset of the settings found on the **Advanced Options** screen.
 {{< expand "Click Here for More Information" "v" >}}
 
-![AddDatasetOtherOptions](/images/SCALE/22.12/AddDatasetOtherOptions.png "Add Dataset Basic  Other Options")
+{{< trueimage src="/images/SCALE/22.12/AddDatasetOtherOptions.png" alt="Add Dataset Basic  Other Options" id="20 Add Dataset Basic  Other Options" >}}
 
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **ZFS Deduplication** | Select the option from the dropdown list to transparently reuse a single copy of duplicated data to save space. Options are **Inherit** to use the parent or root dataset settings, **On** to use deduplication, **Off** to not use deduplication, or **Verify** to do a byte-to-byte comparison when two blocks have the same signature to verify the block contents are identical.<br> Deduplication can improve storage capacity, but is RAM intensive. Compressing data is recommended before using deduplication.<br> Deduplicating data is a one-way process. Deduplicated data cannot be undeduplicated! |
+| **ZFS Deduplication** | Select the option from the dropdown list to transparently reuse a single copy of duplicated data to save space. Options are **Inherit** to use the parent or root dataset settings, **On** to use deduplication, **Off** to not use deduplication, or **Verify** to do a byte-to-byte comparison when two blocks have the same signature to verify the block contents are identical.<br> Deduplication can improve storage capacity, but is RAM intensive. Compressing data is recommended before using deduplication.<br> Deduplicating data is a one-way process. You cannot undo deduplicated data! |
 | **Case Sensitivity** | Select the option from the dropdown list. **Sensitive** assumes file names are case sensitive. **Insensitive** assumes file names are not case sensitive. You cannot change case sensitivity after the saving the dataset. |
 | **Share Type** | Select the option from the dropdown list to define the type of data sharing the dataset uses to optimize the dataset for that sharing protocol. Select **SMB** if using with an SMB share and to optimize it for SMB shares. Select **Generic** for all other share types. Select **Apps** if creating a dataset to work an application and to optimize the dataset for use by any application. If you plan to deploy container applications, the system automatically creates the **ix-applications** dataset but this is not used for application data storage. You cannot change this setting after saving the dataset. |
 {{< /truetable >}}
@@ -309,7 +310,7 @@ These settings also display on the **[Capacity Settings]({{< relref "CapacitySet
 To apply the settings to only the parent dataset you are creating, enter settings in the **This Dataset** fields. 
 To apply settings to both the parent dataset and any new child datasets you create from this dataset, enter settings in the **This Dataset and Child Datasets** section. 
 
-![AddDatasetQuotasManagement](/images/SCALE/22.12/AddDatasetQuotasManagement.png "Add Dataset Advanced Quota Options") 
+{{< trueimage src="/images/SCALE/22.12/AddDatasetQuotasManagement.png" alt="Add Dataset Advanced Quota Options" id="21 Add Dataset Advanced Quota Options" >}}
 
 Setting a quota defines the maximum allowed space for the dataset or the dataset and child datasets.
 You can also reserve a defined amount of pool space to prevent automatically generated data like system logs from consuming all of the dataset space.
@@ -324,7 +325,7 @@ Many of the **Other Options** settings inherit their values from the parent data
 {{< expand "Click Here for More Information" "v" >}}
 The **Basic Options** screen shares the **ZFS Deduplication**, **Case Sensitivity** and **Share Type** settings. All other settings in this section are unique to the **Advanced Options** screen.
 
-![AddDatasetOtherOptionsAdvanced1](/images/SCALE/22.12/AddDatasetOtherOptionsAdvanced1.png "Add Dataset Advanced Other Options") 
+{{< trueimage src="/images/SCALE/22.12/AddDatasetOtherOptionsAdvanced1.png" alt="Add Dataset Advanced Other Options" id="22 Add Dataset Advanced Other Options" >}}
 
 {{< truetable >}}
 | Setting | Description |
@@ -334,10 +335,10 @@ The **Basic Options** screen shares the **ZFS Deduplication**, **Case Sensitivit
 | **Read-only** | Select the option to allow or prevent dataset modification from the dropdown list. **On** prevents modifying the dataset. **Off** allows users accessing the dataset to modify its contents. |
 | **Exec** | Select the option for executing processes from within the dataset from the dropdown list. **On** allows executing processes from within this dataset. **Off** prevents executing processes from with the dataset. We recommend setting it to **On**. |
 | **Snapshot directory** | Select the option to controls visibility of the <file>.zfs</file> directory on the dataset from the dropdown list. Select either **Visible** or **Invisible**. |
-| **Snapdev** | Select the option that controls whether the volume snapshot devices under /dev/zvol/*poolname* are hiddin or visible from the dropdown list. Options are **Inherit (hidden)**, **Visible** and **Hidden** (default value). |
+| **Snapdev** | Select the option that controls whether the volume snapshot devices under /dev/zvol/*poolname* are hidden or visible from the dropdown list. Options are **Inherit (hidden)**, **Visible** and **Hidden** (default value). |
 {{< /truetable >}}
 
-![AddDatasetOtherOptionsAdvanced2](/images/SCALE/22.12/AddDatasetOtherOptionsAdvanced2.png "Add Dataset Advanced Other Options 2") 
+{{< trueimage src="/images/SCALE/22.12/AddDatasetOtherOptionsAdvanced2.png" alt="Add Dataset Advanced Other Options 2" id="23 Add Dataset Advanced Other Options 2" >}}
 
 {{< truetable >}}
 | Setting | Description |

--- a/content/SCALE/SCALEUIReference/Storage/Datasets/EncryptionUISCALE.md
+++ b/content/SCALE/SCALEUIReference/Storage/Datasets/EncryptionUISCALE.md
@@ -16,7 +16,7 @@ tags:
 
 Datasets, root, non-root parent, and child, or zvols with encryption include the **[ZFS Encryption]({{< relref "DatasetsScreensSCALE.me" >}})** widget in the set of dataset widgets displayed on the **Datasets** screen.
 
-![DatasetTreeWithLockIcons](/images/SCALE/22.12/DatasetTreeWithLockIcons.png "Dataset Tree Table Encryption Icons")
+{{< trueimage src="/images/SCALE/22.12/DatasetTreeWithLockIcons.png" alt="Dataset Tree Table Encryption Icons" id="1 Dataset Tree Table Encryption Icons" >}}
 
 {{< include file="/_includes/EncryptionIconsSCALE.md" type="page" >}}
 
@@ -24,7 +24,7 @@ Datasets, root, non-root parent, and child, or zvols with encryption include the
 
 The **Encryption** option on the **[Pool Manager]({{< relref "PoolManagerScreens.md" >}})** screen sets encryption for the pool and root dataset. The **Download Encryption Key** warning window displays when you create the pool. It downloads a JSON file to your downloads folder. 
 
-![DownloadPoolEncryptionKey](/images/SCALE/22.12/DownloadPoolEncryptionKey.png "Download Pool Encryption Key")
+{{< trueimage src="/images/SCALE/22.12/DownloadPoolEncryptionKey.png" alt="Download Pool Encryption Key" id="2 Download Pool Encryption Key" >}}
 
 ## Export Key Options 
 
@@ -36,25 +36,24 @@ If a dataset is encrypted using a key, the **ZFS Encryption** widget for that da
 
 **Export All Keys** opens a confirmation dialog with the **Download Keys** option that exports a JSON file of all encryption keys to the system download folder. 
 
-![ExportAllKeysDialog](/images/SCALE/22.12/ExportAllKeysDialog.png "Export All Keys")
+{{< trueimage src="/images/SCALE/22.12/ExportAllKeysDialog.png" alt="Export All Keys" id="3 Export All Keys" >}}
 
 ### Export Key Dialog
 
 **Export Key** opens a dialog with the key for the selected dataset and the **Download Key** option that exports a JSON file with the encryption key to your system download folder.
 
-![ExportKeyDialog](/images/SCALE/22.12/ExportKeyDialog.png "Export Key")
+{{< trueimage src="/images/SCALE/22.12/ExportKeyDialog.png" alt="Export Key" id="4 Export Key" >}}
 
 ## Edit Encryption Options Window
 
-Encryption type and options are set for a dataset when it is first created. 
-Encryption is inherited from the root but you can change whether you inherit settings or change them. 
+Encryption type and options are set for a dataset when it is first created and are inherited from the root dataset.
 The **Edit Encryption Options for *datasetname*** displays the current encryption option settings for the selected encrypted dataset. 
-It allows you to change the encryption type from or to key or passphrase, and the related settings.
+Use to change the encryption type from or to key or passphrase, and the related settings.
 {{< expand "Click Here for More Information" "v" >}}
 The **Edit Encryption Options for *datasetname*** window opens with the current dataset encryption settings displayed. 
-The encryption setting options are the same as those provided on the **Add Dataset > Encryption Options**.
+The encryption setting options are the same as those found on **Add Dataset > Encryption Options**.
 
-![EditEncryptionOptionsKeyTypeWindow](/images/SCALE/22.12/EditEncryptionOptionsKeyTypeWindow.png "Encryption Options Key Type Window")
+{{< trueimage src="/images/SCALE/22.12/EditEncryptionOptionsKeyTypeWindow.png" alt="Encryption Options Key Type Window" id="5 Encryption Options Key Type Window" >}}
 
 {{< include file="/_includes/EncryptionSettings.md" type="page" >}}
 {{< /expand >}}
@@ -66,7 +65,7 @@ The locked icon for child datasets that inherit encryption is the locked by ance
 **Lock** opens the **Lock Dataset** confirmation dialog with the option to **Force unmount** and **Lock** the dataset. 
 **Force unmount** disconnects any client system that is accessing the dataset via sharing protocol. Do not select this option unless you are certain the dataset is not used or accessed by a share, application, or other system services.
 
-![LockDatasetDialog](/images/SCALE/22.12/LockDatasetDialog.png "Lock Dataset Dialog")
+{{< trueimage src="/images/SCALE/22.12/LockDatasetDialog.png" alt="Lock Dataset Dialog" id="6 Lock Dataset Dialog" >}}
 
 After locking a dataset, the **ZFS Encryption** screen displays **Locked** as the **Current State** and adds the **Unlock** option.
 {{< /expand >}}
@@ -77,11 +76,11 @@ After locking a dataset, the **ZFS Encryption** screen displays **Locked** as th
 {{< expand "Click Here for More Information" "v" >}}
 If you select a non-root parent dataset, the unlock screen includes two **Dataset Passphrase** fields for two datasets, the non-root parent and the child of that non-root parent, and the option to **Unlock Child Encrypted Roots** pre-selected.
 
-![UnlockDatasetsScreenNonRootParent](/images/SCALE/22.12/UnlockDatasetsScreenNonRootParent.png "Unlock Non-Root Parent and Child Datasets Screen")
+{{< trueimage src="/images/SCALE/22.12/UnlockDatasetsScreenNonRootParent.png" alt="Unlock Non-Root Parent and Child Datasets Screen" id="7 Unlock Non-Root Parent and Child Datasets Screen" >}}
 
 If you select a child dataset of the root dataset or of a non-root parent, the screen includes only the one **Dataset Passphrase** field, and the option to **Unlock Child Encrypted Roots** pre-selected.
 
-![UnlockDatasetsScreen](/images/SCALE/22.12/UnlockDatasetsScreen.png "Unlock Datasets Screen")
+{{< trueimage src="/images/SCALE/22.12/UnlockDatasetsScreen.png" alt="Unlock Datasets Screen" id="8 Unlock Datasets Screen" >}}
 
 {{< truetable >}}
 | Setting | Description |

--- a/content/Solutions/Optimizations/Security.md
+++ b/content/Solutions/Optimizations/Security.md
@@ -1,20 +1,36 @@
 ---
 title: "Security Recommendations"
-description: "Best practices when tuning TrueNAS to minimize security vulnerabilities."
+description: "Best practices to administrate TrueNAS securely."
 weight: 30
 aliases:
   - /core/solutions/optimizations/security/
 tags:
  - coressh
  - scalessh
+keywords:
+ - TrueNAS Security
 ---
 
 {{< toc >}}
 
-When using services on TrueNAS, especially services that allow outside connections, there are some best practices to follow to ensure your system is safe and secure.
-Several different system services are disscused in this article.
+Follow these best practices to administrate TrueNAS securely.
 
-## iSCSI
+## General Recommendations
+
+* Modifying  the base TrueNAS firmware image is unsupported and can create security issues.
+* Keep TrueNAS up to date with the most recent updates for your supported version.
+* Upgrade to new major releases in a timely manner consistent with the deployment use case.
+* Use complex passwords and Two-Factor Authentication (2FA) for all TrueNAS Root and Administrator accounts.
+* Restrict new TrueNAS user accounts to the most minimal set of permissions and access possible.
+* Grant TrueNAS user accounts (local or Directory Services added accounts) access to SSH or console shells only if  that account is explicitly trusted.
+* Disable any Network services not in use.
+* Restrict the TrueNAS web, IPMI, and any other management interfaces to private subnets away from untrusted users.
+* Review any plugin, App, or Virtual Machine (VM) deployment scenario for additional security exposure or vulnerabilities.
+    iXsystems cannot resolve security vulnerabilities introduced from within user-deployed virtualized environments.
+
+## Hardening Specific System Services
+
+### iSCSI
 
 Follow the iSCSI creation wizard unless a specific configuration is required.
 To create an iSCSI share, go to **Sharing > Block Shares (iSCSI)** and click *WIZARD*.
@@ -29,7 +45,7 @@ Entering a list of *Initiators* and *Authorized Networks* is also recommended.
 This allows defining which systems or networks can connect to the extent.
 When these options are empty, all initiators and all networks are allowed to connect to the extent.
 
-## NFS
+### NFS
 
 Network File System (NFS) is a sharing protocol that allows outside users to connect and view or modify shared data.
 
@@ -40,11 +56,11 @@ By default, all options are unset.
 Unless needed for a specific use case, keep the default NFS service settings.
 
 During [Share Creation]({{< relref "/CORE/CORETutorials/Sharing/NFSShare.md" >}}), define which systems are authorized for share connections.
-Leaving the **Authorized Networks** or **Authorized Hosts and IP addresses* lists empty allows any system to connect to the NFS share.
+Leaving the **Authorized Networks** or **Authorized Hosts and IP addresses** lists empty allows any system to connect to the NFS share.
 To define which systems can connect to the share, click the **Advanced Options** and enter all networks, hosts, and IP addresses to have share access.
 All other systems are denied access.
 
-## SMB
+### SMB
 
 Using Server Message Block (SMB) to share data is a very common situation for TrueNAS users.
 However, it allows outside connections to the system and must be properly use to avoid security concerns.
@@ -55,22 +71,22 @@ SMB service settings are in **Services** after clicking the <span class="iconify
 
 [Do not use SMB1.]({{< relref "/CORE/CoreSecurityReports/SMB1Advisory.md" >}})
 
-Do not use *NTLMv1 Auth* with an untrusted network.
+Do not use **NTLMv1 Auth** with an untrusted network.
 This encryption option is insecure and vulnerable.
 
-When using MacOS to connect to the SMB share, enable *Apple SMB2/3 Protocol Extensions*.
+When using MacOS to connect to the SMB share, enable **Apple SMB2/3 Protocol Extensions**.
 This improves connection stability between the share and the Apple system.
 
-If you need to add an *Administrators Group*, make sure the group members are correct.
-Members of the administration group have full permissions to modify or delete the share data.
+When an administrators group is required, make sure the group members are correct.
+Administration group members have full permissions to modify or delete the share data.
 
 During [Share Creation]({{< relref "/CORE/CORETutorials/Sharing/SMB/SMBShare.md" >}}), a *Purpose* can be selected.
 This changes the share configuration with one click.
-For example, when selecting *Private SMB Datasets and Shares* from the list, TrueNAS automatically tunes some settings so the share is set up for private use.
-To fully customize the share settings, select *No presets* for the *Purpose*.
-Unless a specific purpose for the share is required, it is recommended to select *Default share parameters* as the *Purpose*.
+For example, when selecting **Private SMB Datasets and Shares** from the list, TrueNAS automatically tunes some settings so the share is set up for private use.
+To fully customize the share settings, select **No presets** for the **Purpose**.
+Unless a specific purpose for the share is required, it is recommended to select **Default share parameters** as the **Purpose**.
 
-## SSH
+### SSH
 
 Using Secure Shell (SSH) to connect to your TrueNAS is very helpful when issuing commands through the CLI.
 SSH settings are in **Services** after clicking the <span class="iconify" data-icon="mdi:pencil"></span> (pencil).
@@ -110,15 +126,15 @@ Overwriting an SSH key pair cannot be undone.
 {{< /tab >}}
 {{< /tabs >}}
 
-Root account logins via SSH are never recommended.
+Root account logins using SSH are never recommended.
 Instead, create new TrueNAS user accounts with limited permissions and log in to these when using SSH.
 If it is a critical and unavoidable situation and root logins must be allowed, first set up two-factor authentication ([CORE 2FA]({{< relref "UsingTwoFactorAuthentication.md" >}}), [SCALE 2FA]({{< relref "/SCALE/SCALETutorials/Credentials/2FASCALE.md" >}})) as an additional layer of security.
 Disable the **Log in as Root with Password** setting as soon as the situation is resolved.
 
-Unless it is required, do not set *Allow TCP Port Forwarding*.
+Unless it is required, do not set **Allow TCP Port Forwarding**.
 
 Many SSH ciphers are outdated and vulnerable.
 It is not safe to enable any weak SSH ciphers.
-Block both the *CBC* and *Arcfour* ciphers by going to **Services > SSH > Edit > Advanced Options** and adding this line in the *Auxiliary Parameters*:
+Block both the **CBC** and **Arcfour** ciphers by going to **Services > SSH > Edit > Advanced Options** and adding this line in the **Auxiliary Parameters**:
 
 `Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com`

--- a/content/_includes/EncryptionWarning.md
+++ b/content/_includes/EncryptionWarning.md
@@ -1,10 +1,10 @@
 ---
 ---
 
-{{< hint type=note >}}
+{{< hint type=important >}}
 
 Encryption is for users storing sensitive data.
-Pool-level encryption does *NOT* apply to the storage pool or the disks in the pool. 
+Pool-level encryption does not apply to the storage pool or the disks in the pool. 
 It only applies to the root dataset that shares the same name as the pool. 
-Child datasets, or zvols, inherit encryption from the parent dataset unless you overwrite encryption when creating the child datasets or zvols.
+Child datasets or zvols inherit encryption from the parent dataset.
 {{< /hint >}}

--- a/content/_includes/ReplicatedEncryptedUnlock.md
+++ b/content/_includes/ReplicatedEncryptedUnlock.md
@@ -29,8 +29,10 @@ Uncheck properties when replicating so that the destination dataset is not encry
    Select the dataset encrypted with a key, then click **Export Key** on the **ZFS Encryption** widget to export the key for the dataset.
 
 2. Apply the JSON key file or key code to the dataset on the system you replicated the dataset to. 
-* Option 1: Download the key file and open it in a text editor. Change the *pool name/dataset* part of the string to the *pool name/dataset* for the receiving system. For example, replicating from *tank1/dataset1* on the replicate-from system to *tank2/dataset2* on the replicate-to system. 
-* Option 2: Copy the key code provided in the **Key for *dataset*** window.
+
+   Option 1: Download the key file and open it in a text editor. Change the *pool name/dataset* part of the string to the *pool name/dataset* for the receiving system. For example, replicating from *tank1/dataset1* on the replicate-from system to *tank2/dataset2* on the replicate-to system. 
+
+   Option 2: Copy the key code provided in the **Key for *dataset*** window.
 
 3. On the system receiving the replicated pool/dataset, select the receiving dataset and click **Unlock**. 
 


### PR DESCRIPTION
This PR updates the encryption content by removing information stating users can create an unencrypted dataset within an encrypted pool or dataset.

It fixes style issues, replaces the old image link with trueimage shortcodes. The icon image links embedded in the table of icons remain so they render correctly.

This PR merges into 22.12.3_docs branch.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
