### PR TITLE
PD-252 Create Storage CLI Namespace Articles

### DIFF
--- a/content/SCALE/SCALECLIReference/Storage/CLIDataset.md
+++ b/content/SCALE/SCALECLIReference/Storage/CLIDataset.md
@@ -1,0 +1,26 @@
+---
+title: "Dataset"
+description: "Provides information about the storage dataset namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 10
+aliases:
+draft: false
+tags:
+- scaleclistorage
+- scaledatasets
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+
+## Listing Datasets
+
+To list all configured datasets, enter `storage dataset query`.
+
+![TrueNASCLIstoragedatasetquery](/images/SCALE/TrueNASCLIstoragedatasetquery.png "Dataset Query")
+
+Enter `q` to exit the query.
+
+{{< taglist tag="scaleclistorage" limit="10" title="Related CLI Storage Articles" >}}
+{{< taglist tag="scaledatasets" limit="10" title="Related Dataset Articles" >}}

--- a/content/SCALE/SCALECLIReference/Storage/CLIDisk.md
+++ b/content/SCALE/SCALECLIReference/Storage/CLIDisk.md
@@ -1,0 +1,17 @@
+---
+title: "Disk"
+description: "Provides information about the storage disk namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 15
+aliases:
+draft: false
+tags:
+- scaleclistorage
+- scaledisks
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scaleclistorage" limit="10" title="Related CLI Storage Articles" >}}
+{{< taglist tag="scaledisks" limit="10" title="Related Dataset Articles" >}}

--- a/content/SCALE/SCALECLIReference/Storage/CLIEnclosure.md
+++ b/content/SCALE/SCALECLIReference/Storage/CLIEnclosure.md
@@ -1,0 +1,18 @@
+---
+title: "Enclosure"
+description: "Provides information about the storage enclosure namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 20
+aliases:
+draft: false
+tags:
+- scaleclistorage
+- scaleenclosure
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scaleclistorage" limit="10" title="Related CLI Storage Articles" >}}
+{{< taglist tag="scaleenclosure" limit="10" title="Related Enclosure Articles" >}}
+{{< taglist tag="scaledisks" limit="10" title="Related Disks Articles" >}}

--- a/content/SCALE/SCALECLIReference/Storage/CLIFilesystem-Storage.md
+++ b/content/SCALE/SCALECLIReference/Storage/CLIFilesystem-Storage.md
@@ -1,0 +1,17 @@
+---
+title: "Filesystem (Storage)"
+description: "Provides information about the storage filesystem namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 25
+aliases:
+draft: false
+tags:
+- scaleclistorage
+- scaleacls
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scaleclistorage" limit="10" title="Related CLI Storage Articles" >}}
+{{< taglist tag="scaleacls" limit="10" title="Related ACL Articles" >}}

--- a/content/SCALE/SCALECLIReference/Storage/CLIPool.md
+++ b/content/SCALE/SCALECLIReference/Storage/CLIPool.md
@@ -1,0 +1,26 @@
+---
+title: "Pool"
+description: "Provides information about the storage pool namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 30
+aliases:
+draft: false
+tags:
+- scaleclistorage
+- scalepools
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+## Listing Storage Pools 
+
+To list all configured storage pools, enter `storage pool query`.
+
+![TrueNASCLIstoragepoolquery](/images/SCALE/TrueNASCLIstoragepoolquery.png "Pool Query")
+
+Enter `q` to exit the query.
+
+
+{{< taglist tag="scaleclistorage" limit="10" title="Related CLI Storage Articles" >}}
+{{< taglist tag="scalepools" limit="10" title="Related Pool Articles" >}}

--- a/content/SCALE/SCALECLIReference/Storage/CLIResilver.md
+++ b/content/SCALE/SCALECLIReference/Storage/CLIResilver.md
@@ -1,0 +1,16 @@
+---
+title: "Resilver"
+description: "Provides information about the storage resilver namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 35
+aliases:
+draft: false
+tags:
+- scaleclistorage
+- scaleresilver
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scaleclistorage" limit="10" title="Related CLI Storage Articles" >}}

--- a/content/SCALE/SCALECLIReference/Storage/CLIScrub.md
+++ b/content/SCALE/SCALECLIReference/Storage/CLIScrub.md
@@ -1,0 +1,16 @@
+---
+title: "Scrub"
+description: "Provides information about the storage scrub namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 40
+aliases:
+draft: false
+tags:
+- scaleclistorage
+- scalescrub
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scaleclistorage" limit="10" title="Related CLI Storage Articles" >}}

--- a/content/SCALE/SCALECLIReference/Storage/CLISnapshot.md
+++ b/content/SCALE/SCALECLIReference/Storage/CLISnapshot.md
@@ -1,0 +1,18 @@
+---
+title: "Snapshot"
+description: "Provides information about the storage snapshot namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 45
+aliases:
+draft: false
+tags:
+- scaleclistorage
+- scalesnapshots
+- scaledatasets
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scaleclistorage" limit="10" title="Related CLI Storage Articles" >}}
+{{< taglist tag="scalesnapshots" limit="10" title="Related Snapshot Articles" >}}

--- a/content/SCALE/SCALECLIReference/Storage/CLIVmware.md
+++ b/content/SCALE/SCALECLIReference/Storage/CLIVmware.md
@@ -1,0 +1,19 @@
+---
+title: "VMWare"
+description: "Provides information about the storage vmware namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 50
+aliases:
+draft: false
+tags:
+- scaleclistorage
+- scalesnapshots
+- scalevmware
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scaleclistorage" limit="10" title="Related CLI Storage Articles" >}}
+{{< taglist tag="scalesnapshots" limit="10" title="Related Snapshot Articles" >}}
+{{< taglist tag="scalevmware" limit="10" title="Related VMware Articles" >}}

--- a/content/SCALE/SCALECLIReference/Storage/_index.md
+++ b/content/SCALE/SCALECLIReference/Storage/_index.md
@@ -3,20 +3,24 @@ title: "Storage"
 geekdocCollapseSection: true
 description: "Introduces the TrueNAS CLI storage namespace, used to access child namespaces and commands including dataset, disk, enclosure, filesystem, pool, resilver, scrub, snapshot, and vmware." 
 weight: 45
+draft: false
 ---
 
 {{< toc >}}
 
-## Listing Storage Pools and Datasets
 
-To list all configured storage pools, enter `storage pool query`.
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
 
-![TrueNASCLIstoragepoolquery](/images/SCALE/TrueNASCLIstoragepoolquery.png "Pool Query")
+{{< include file="/_includes/SCALECLIIntroduction.md" type="page" >}}
 
-Enter `q` to exit the query.
+## Storage Namespace
 
-To list all configured datasets, enter `storage dataset query`.
+The **storage** namespace has nine child namespaces and is based on functions found in the SCALE API and web UI. 
+It provides access to storage configuration methods through the child namespaces and their commands.
 
-![TrueNASCLIstoragedatasetquery](/images/SCALE/TrueNASCLIstoragedatasetquery.png "Dataset Query")
+You can enter commands from the main CLI prompt or from the **storage** namespace prompts.
 
-Enter `q` to exit the query.
+## Storage Child Namespace Contents
+The following articles provide information on **storage** child namespaces:
+
+{{< children depth="2" description="true" >}}

--- a/content/SCALE/SCALEUIReference/SystemSettings/EnclosureScreensSCALE.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/EnclosureScreensSCALE.md
@@ -108,5 +108,6 @@ Click on a drive image in the system or expansion shelf image to display a drive
 The expansion shelf image varies based on the type of expansion shelf installed, but the disk information displayed is the same as for disks in other system disks.
 
 {{< taglist tag="scaleenterprise" limit="10" title="Related Enterprise Articles" >}}
+{{< taglist tag="scaleenclosure" limit="10" title="Related Enclosure Articles" >}}
 {{< taglist tag="scaledisks" limit="10" title="Related Disks Articles" >}}
 

--- a/content/_includes/SCALECLIIntroduction.md
+++ b/content/_includes/SCALECLIIntroduction.md
@@ -3,7 +3,7 @@
 
 Welcome to the TrueNAS SCALE Command Line Interface (CLI) guide!
 
-The **TrueNAS CLI Shell** in TrueNAS SCALE functions like a text-based version of the web UI with many functional areas grouped into parent and child namespaces that mirror the counterparts in the SCALE UI. 
+The **TrueNAS CLI** in TrueNAS SCALE functions like a text-based version of the web UI with many functional areas grouped into parent and child namespaces that mirror the counterparts in the SCALE UI. 
 
 The underlying structure of the CLI namespaces and commands closely follows that of the SCALE API. 
 For more information on API commands, arguments, options, and definitions go to **API Keys** and click on **API Docs** in the SCALE UI.


### PR DESCRIPTION
This PR updates the SCALECLIReference/Storage/_index.md file content, moves the pool and dataset query content to the child namespace articles. It creates work-in-progress articles for the storage child namespaces.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
