### PR TITLE
Pd 251 create cli sharing namespace articles

### DIFF
--- a/content/SCALE/SCALECLIReference/Sharing/CLINFS.md
+++ b/content/SCALE/SCALECLIReference/Sharing/CLINFS.md
@@ -13,4 +13,5 @@ tags:
 
 {{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
 
-{{< taglist tag="scalecliauth" limit="10" title="Related CLI Auth Articles" >}}
+{{< taglist tag="scaleclisharing" limit="10" title="Related CLI Sharing Articles" >}}
+{{< taglist tag="scalenfs" limit="10" title="Related NFS Articles" >}}

--- a/content/SCALE/SCALECLIReference/Sharing/CLINFS.md
+++ b/content/SCALE/SCALECLIReference/Sharing/CLINFS.md
@@ -1,0 +1,16 @@
+---
+title: "NFS"
+description: "Provides information about the sharing nfs namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 30
+aliases:
+draft: false
+tags:
+- scaleclisharing
+- scalenfs
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scalecliauth" limit="10" title="Related CLI Auth Articles" >}}

--- a/content/SCALE/SCALECLIReference/Sharing/CLISMB.md
+++ b/content/SCALE/SCALECLIReference/Sharing/CLISMB.md
@@ -13,4 +13,5 @@ tags:
 
 {{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
 
-{{< taglist tag="scalecliauth" limit="10" title="Related CLI Auth Articles" >}}
+{{< taglist tag="scaleclisharing" limit="10" title="Related CLI Sharing Articles" >}}
+{{< taglist tag="scalesmb" limit="10" title="Related SMB Articles" >}}

--- a/content/SCALE/SCALECLIReference/Sharing/CLISMB.md
+++ b/content/SCALE/SCALECLIReference/Sharing/CLISMB.md
@@ -1,0 +1,16 @@
+---
+title: "SMB"
+description: "Provides information about the sharing smb namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 30
+aliases:
+draft: false
+tags:
+- scaleclisharing
+- scalesmb
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scalecliauth" limit="10" title="Related CLI Auth Articles" >}}

--- a/content/SCALE/SCALECLIReference/Sharing/CLIWebdav.md
+++ b/content/SCALE/SCALECLIReference/Sharing/CLIWebdav.md
@@ -1,0 +1,16 @@
+---
+title: "Webdav (Deprecated)"
+description: "Provides information about the deprecated sharing webdav namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 30
+aliases:
+draft: false
+tags:
+- scaleclisharing
+- scalewebdav
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scalecliauth" limit="10" title="Related CLI Auth Articles" >}}

--- a/content/SCALE/SCALECLIReference/Sharing/CLIWebdav.md
+++ b/content/SCALE/SCALECLIReference/Sharing/CLIWebdav.md
@@ -1,7 +1,7 @@
 ---
 title: "Webdav (Deprecated)"
 description: "Provides information about the deprecated sharing webdav namespace in the TrueNAS CLI. Includes command syntax and common commands."
-weight: 30
+weight: 40
 aliases:
 draft: false
 tags:
@@ -13,4 +13,5 @@ tags:
 
 {{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
 
-{{< taglist tag="scalecliauth" limit="10" title="Related CLI Auth Articles" >}}
+{{< taglist tag="scaleclisharing" limit="10" title="Related CLI Sharing Articles" >}}
+{{< taglist tag="scalewebdav" limit="10" title="Related WebDAV Articles" >}}

--- a/content/SCALE/SCALECLIReference/Sharing/CLIiSCSI.md
+++ b/content/SCALE/SCALECLIReference/Sharing/CLIiSCSI.md
@@ -1,0 +1,16 @@
+---
+title: "iSCSI"
+description: "Provides information about the sharing iscsi namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 10
+aliases:
+draft: false
+tags:
+- scaleclisharing
+- scaleiscsi
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scalecliauth" limit="10" title="Related CLI Auth Articles" >}}

--- a/content/SCALE/SCALECLIReference/Sharing/CLIiSCSI.md
+++ b/content/SCALE/SCALECLIReference/Sharing/CLIiSCSI.md
@@ -13,4 +13,5 @@ tags:
 
 {{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
 
-{{< taglist tag="scalecliauth" limit="10" title="Related CLI Auth Articles" >}}
+{{< taglist tag="scaleclisharing" limit="10" title="Related CLI Sharing Articles" >}}
+{{< taglist tag="scaleiscsi" limit="10" title="Related iSCSI Articles" >}}

--- a/content/SCALE/SCALECLIReference/Sharing/_index.md
+++ b/content/SCALE/SCALECLIReference/Sharing/_index.md
@@ -3,9 +3,25 @@ title: "Sharing"
 geekdocCollapseSection: true
 description: "Introduces the TrueNAS CLI sharing namespace, used to access child namespaces and commands including iscsi, nfs, smb, and webdav." 
 weight: 40
-draft: true
+draft: false
 ---
 
 {{< toc >}}
 
-Coming soon!
+
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< include file="/_includes/SCALECLIIntroduction.md" type="page" >}}
+
+## Sharing Namespace
+
+The **sharing** namespace has four child namespaces and is based on functions found in the SCALE API and web UI. 
+It provides access to network configuration methods through the child namespaces and their command.
+
+You can enter commands from the main CLI prompt or from the **sharing** namespace prompts.
+
+## Network Child Namespace Contents
+The following articles provide information on **sharing** child namespaces:
+
+{{< children depth="2" description="true" >}}

--- a/content/SCALE/SCALECLIReference/Sharing/_index.md
+++ b/content/SCALE/SCALECLIReference/Sharing/_index.md
@@ -17,7 +17,7 @@ draft: false
 ## Sharing Namespace
 
 The **sharing** namespace has four child namespaces and is based on functions found in the SCALE API and web UI. 
-It provides access to network configuration methods through the child namespaces and their command.
+It provides access to share configuration methods through the child namespaces and their commands.
 
 You can enter commands from the main CLI prompt or from the **sharing** namespace prompts.
 

--- a/content/SCALE/SCALECLIReference/Sharing/_index.md
+++ b/content/SCALE/SCALECLIReference/Sharing/_index.md
@@ -17,11 +17,11 @@ draft: false
 ## Sharing Namespace
 
 The **sharing** namespace has four child namespaces and is based on functions found in the SCALE API and web UI. 
-It provides access to share configuration methods through the child namespaces and their commands.
+It provides access to configure shares through the child namespaces and their commands.
 
 You can enter commands from the main CLI prompt or from the **sharing** namespace prompts.
 
-## Network Child Namespace Contents
+## Sharing Child Namespace Contents
 The following articles provide information on **sharing** child namespaces:
 
 {{< children depth="2" description="true" >}}


### PR DESCRIPTION
This PR updates the SCALECLIReferences/Sharing/_index.md content with child namespace article information and makes it visible.

It creates the placeholder child namespace articles.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
