### PR TITLE
PD-246 Create CLI App Namespace Articles

### DIFF
--- a/content/SCALE/SCALECLIReference/App/CLICatalog.md
+++ b/content/SCALE/SCALECLIReference/App/CLICatalog.md
@@ -1,0 +1,17 @@
+---
+title: "Catalog"
+description: "Provides information about the app catalog namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 10
+aliases:
+draft: false
+tags:
+- scalecliapp
+- scalecatalog
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scalecliapp" limit="10" title="Related CLI App Articles" >}}
+{{< taglist tag="scalecatalog" limit="10" title="Related Catalog Articles" >}}

--- a/content/SCALE/SCALECLIReference/App/CLIChartRelease.md
+++ b/content/SCALE/SCALECLIReference/App/CLIChartRelease.md
@@ -1,0 +1,16 @@
+---
+title: "Chart_Release"
+description: "Provides information about the app chart_release namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 20
+aliases:
+draft: false
+tags:
+- scalecliapp
+- scalechart
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scalecliapp" limit="10" title="Related CLI App Articles" >}}

--- a/content/SCALE/SCALECLIReference/App/CLIContainer.md
+++ b/content/SCALE/SCALECLIReference/App/CLIContainer.md
@@ -1,0 +1,15 @@
+---
+title: "Container"
+description: "Provides information about the app container namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 30
+aliases:
+draft: false
+tags:
+- scalecliapp
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scalecliapp" limit="10" title="Related CLI App Articles" >}}

--- a/content/SCALE/SCALECLIReference/App/CLIDocker.md
+++ b/content/SCALE/SCALECLIReference/App/CLIDocker.md
@@ -1,0 +1,17 @@
+---
+title: "Docker"
+description: "Provides information about the app docker namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 40
+aliases:
+draft: false
+tags:
+- scalecliapp
+- scaledocker
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scalecliapp" limit="10" title="Related CLI App Articles" >}}
+{{< taglist tag="scalecdocker" limit="10" title="Related Docker Articles" >}}

--- a/content/SCALE/SCALECLIReference/App/CLIDocker.md
+++ b/content/SCALE/SCALECLIReference/App/CLIDocker.md
@@ -14,4 +14,4 @@ tags:
 {{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
 
 {{< taglist tag="scalecliapp" limit="10" title="Related CLI App Articles" >}}
-{{< taglist tag="scalecdocker" limit="10" title="Related Docker Articles" >}}
+{{< taglist tag="scaledocker" limit="10" title="Related Docker Articles" >}}

--- a/content/SCALE/SCALECLIReference/App/CLIKubernetes.md
+++ b/content/SCALE/SCALECLIReference/App/CLIKubernetes.md
@@ -1,0 +1,17 @@
+---
+title: "Kubernetes"
+description: "Provides information about the app kubernetes namespace in the TrueNAS CLI. Includes command syntax and common commands."
+weight: 50
+aliases:
+draft: false
+tags:
+- scalecliapp
+- scalekubernetes
+---
+
+{{< toc >}}
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< taglist tag="scalecliapp" limit="10" title="Related CLI App Articles" >}}
+{{< taglist tag="scaleckubernetes" limit="10" title="Related Kubernetes Articles" >}}

--- a/content/SCALE/SCALECLIReference/App/CLIKubernetes.md
+++ b/content/SCALE/SCALECLIReference/App/CLIKubernetes.md
@@ -14,4 +14,4 @@ tags:
 {{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
 
 {{< taglist tag="scalecliapp" limit="10" title="Related CLI App Articles" >}}
-{{< taglist tag="scaleckubernetes" limit="10" title="Related Kubernetes Articles" >}}
+{{< taglist tag="scalekubernetes" limit="10" title="Related Kubernetes Articles" >}}

--- a/content/SCALE/SCALECLIReference/App/_index.md
+++ b/content/SCALE/SCALECLIReference/App/_index.md
@@ -3,9 +3,24 @@ title: "App"
 geekdocCollapseSection: true
 description: "Introduces the TrueNAS CLI app namespace, used to access child namespaces and commands including catalog, chart_release, container, docker, and kubernetes." 
 weight: 10
-draft: true
+draft: False
 ---
 
 {{< toc >}}
 
-Coming soon!
+
+{{< include file="/_includes/CLIGuideWIP.md" type="page" >}}
+
+{{< include file="/_includes/SCALECLIIntroduction.md" type="page" >}}
+
+## App Namespace
+
+The **app** namespace has five child namespaces and is based on functions found in the SCALE API and web UI. 
+It provides access to application configuration methods through the child namespaces and their command.
+
+You can enter commands from the main CLI prompt or from the **app** namespace prompts.
+
+## App Child Namespace Contents
+The following articles provide information on **app** child authentication namespaces:
+
+{{< children depth="2" description="true" >}}

--- a/content/SCALE/SCALECLIReference/App/_index.md
+++ b/content/SCALE/SCALECLIReference/App/_index.md
@@ -16,7 +16,7 @@ draft: False
 ## App Namespace
 
 The **app** namespace has five child namespaces and is based on functions found in the SCALE API and web UI. 
-It provides access to application configuration methods through the child namespaces and their command.
+It provides access to application configuration methods through the child namespaces and their commands.
 
 You can enter commands from the main CLI prompt or from the **app** namespace prompts.
 

--- a/content/SCALE/SCALECLIReference/App/_index.md
+++ b/content/SCALE/SCALECLIReference/App/_index.md
@@ -21,6 +21,6 @@ It provides access to application configuration methods through the child namesp
 You can enter commands from the main CLI prompt or from the **app** namespace prompts.
 
 ## App Child Namespace Contents
-The following articles provide information on **app** child authentication namespaces:
+The following articles provide information on **app** child namespaces:
 
 {{< children depth="2" description="true" >}}

--- a/content/SCALE/SCALETutorials/Apps/UsingCatalogs.md
+++ b/content/SCALE/SCALETutorials/Apps/UsingCatalogs.md
@@ -4,12 +4,9 @@ description: "Provides basic information on adding or managing application catal
 weight: 5
 aliases: /scale/scaleuireference/apps/usingcatalogs/
 tags:
- - scaleapps
- - scaledocker
- - scaleminio
- - scalenextcloud
- - scalechia
- - scaleplex
+- scaleapps
+- scaledocker
+- scalecatalog
 ---
 
 {{< toc >}}
@@ -61,3 +58,4 @@ Finially, enter the git repository branch TrueNAS should use for the catalog in 
 Click **Save**. 
 
 {{< taglist tag="scaleapps" limit="10" >}}
+{{< taglist tag="scalecatalog" limit="10" title="Related Catalog Articles" >}}


### PR DESCRIPTION
This PR updates the SCALECLIReference/App/_index.md article and makes it visible. Adds the placeholder child namespace articles.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
