### PR TITLE
PD-251 Update Sharing _index.md Heading

### DIFF
--- a/content/SCALE/SCALECLIReference/Sharing/_index.md
+++ b/content/SCALE/SCALECLIReference/Sharing/_index.md
@@ -21,7 +21,7 @@ It provides access to configure shares through the child namespaces and their co
 
 You can enter commands from the main CLI prompt or from the **sharing** namespace prompts.
 
-## Sharing Child Namespace Contents
+## Sharing Child Namespace Articles
 The following articles provide information on **sharing** child namespaces:
 
 {{< children depth="2" description="true" >}}

--- a/content/SCALE/SCALECLIReference/Sharing/_index.md
+++ b/content/SCALE/SCALECLIReference/Sharing/_index.md
@@ -21,7 +21,7 @@ It provides access to configure shares through the child namespaces and their co
 
 You can enter commands from the main CLI prompt or from the **sharing** namespace prompts.
 
-## Sharing Child Namespace Articles
+## Sharing Namespaces
 The following articles provide information on **sharing** child namespaces:
 
 {{< children depth="2" description="true" >}}


### PR DESCRIPTION
This PR changes the child namespace section heading to Sharing Child Namespace Articles



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
