### PR TITLE
PD-252 Change Storage Index file Heading

### DIFF
--- a/content/SCALE/SCALECLIReference/Storage/_index.md
+++ b/content/SCALE/SCALECLIReference/Storage/_index.md
@@ -20,7 +20,7 @@ It provides access to storage configuration methods through the child namespaces
 
 You can enter commands from the main CLI prompt or from the **storage** namespace prompts.
 
-## Storage Child Namespace Articles
+## Storage Namespaces
 The following articles provide information on **storage** child namespaces:
 
 {{< children depth="2" description="true" >}}

--- a/content/SCALE/SCALECLIReference/Storage/_index.md
+++ b/content/SCALE/SCALECLIReference/Storage/_index.md
@@ -20,7 +20,7 @@ It provides access to storage configuration methods through the child namespaces
 
 You can enter commands from the main CLI prompt or from the **storage** namespace prompts.
 
-## Storage Child Namespace Contents
+## Storage Child Namespace Articles
 The following articles provide information on **storage** child namespaces:
 
 {{< children depth="2" description="true" >}}


### PR DESCRIPTION
This PR changes the child namespace section heading to Storage Child Namespace Articles.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
