### PR TITLE
PD-554: extra padding for feedback button

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -78,7 +78,7 @@ p,h1,h2,h3,h4,th,td,a {
     padding: 1rem 1.5rem 1rem 1rem;
 }
 .gdoc-page {
-    padding: 1rem 1rem 0rem 0rem;
+    padding: 1rem 2rem 0rem 0rem;
 }
 .container{
     max-width: 100rem;


### PR DESCRIPTION
This keeps the feedback button from covering any content.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
