### PR TITLE
PD-514 Document Disabling admin Password is Forbidden

### DIFF
--- a/content/GettingStarted/Configure/FirstTimeLogin.md
+++ b/content/GettingStarted/Configure/FirstTimeLogin.md
@@ -92,6 +92,8 @@ If you choose **Root user (not recommended)** as the TrueNAS authentication meth
 
 ### Troubleshooting Accessing the Web UI
 
+If you cannot remember the administrator password to log in to the web interface, connect a keyboard and mouse to the TrueNAS system and open the [Console Setup Menu]({{< relref "ConsoleSetupMenuScale.md#changing-the-root-password" >}}) to reset the admin account password.
+
 {{< expand "UI is not accessible by IP address" "V" >}}
 If the user interface is not accessible by IP address from a browser, check these things:
 
@@ -106,20 +108,6 @@ If the web interface displays but seems unresponsive or incomplete:
 
 If the UI becomes unresponsive after an upgrade or other system operation, clear the site data and refresh the browser (<kbd>Shift</kbd>+<kbd>F5</kbd>).
 {{< /expand >}}
-{{< expand "What happens if I disable both admin and root passwords at the same time?" "V">}}
-If you disable the root user password and do not create the admin user with a password enabled, or if you disable both admin and root user passwords and your session times out before you enable one of the passwords, SCALE displays the **Set up TrueNAS authentication method** sign-in screen.
-
-{{< trueimage src="/images/SCALE/22.12/FirstTimeLoginInstallOpt3SCALE.png" alt="TrueNAS SCALE Login Screen Set Temporary Password" id="Set Temporary Password" >}}
-
-This screen allows you to create a temporary password for one-time access.
-
-{{< hint type=important >}}
-This option does not configure the admin or root user account.
-The password entered is a one-time user access password.
-You must go to the **Credentials > Local Users** screen then [create and enable the admin account password]({{< relref "ManageLocalUsersSCALE.md" >}}) immediately after you enter the UI.
-{{< /hint >}}
-{{< /expand >}}
-If you cannot remember the administrator password to log in to the web interface, connect a keyboard and mouse to the TrueNAS system and open the [Console Setup Menu]({{< relref "ConsoleSetupMenuScale.md#changing-the-root-password" >}}) to reset the admin account password.
 
 ## Introducing the Main SCALE Dashboard
 

--- a/content/SCALEUIReference/Credentials/LocalUsersScreensSCALE.md
+++ b/content/SCALEUIReference/Credentials/LocalUsersScreensSCALE.md
@@ -52,7 +52,7 @@ Built-in users (except the **root** user) do not include the **Home Directory Pe
 |---------|-------------|
 | **Full Name** | Required. Enter a description for the user, such as a first and last name. |  
 | **Username** | Required. Enter a user name of up to 16 characters in length. When using NIS or other legacy software with limited user name lengths, keep names to eight characters or less for compatibility. Do not begin the user name with a hyphen (-), and do not include a space, tab, the comma (,), plus (+), ampersand (&), percent (%), carat (^), open or close parenthesis ( ), exclamation mark (!), at symbol (@), tilde (~), question mark (?), greater or less than symbols (<)(>), or equals (+) in the name. You can use the dollar sign ($) as the last character of the user name. |  
-| **Disable Password** | Use the toggle to disable the password for the selected user. If you disable the admin account the admin user cannot login. If you disable the root and admin user passwords you see a **Set new root account password** sign-in splash screen. |
+| **Disable Password** | Use the toggle to disable the password for the selected user. At least one user with administrative privileges must have a password enabled. |
 | **Password** | Required. Enter a user password unless you set **Enable Password login** to **No**. A password cannot contain a question mark (?). The **Edit User** screen displays **New Password**. |  
 | **Confirm Password** | Required. Re-enter the value entered in **Password**. The **Edit User** screen displays **Confirm New Password**. |  
 | **Email** | Enter the email address of the new user. This email address receives notifications, alerts, messages based on the settings configured. |


### PR DESCRIPTION
Removes deprecated troubleshooting section. Updates UI reference. 

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
