### PR TITLE
Fix issue with _includes paths

### DIFF
--- a/content/GettingStarted/Configure/FirstTimeLogin.md
+++ b/content/GettingStarted/Configure/FirstTimeLogin.md
@@ -217,7 +217,7 @@ The Power icon <span class="material-icons">power_settings_new</span> on the rig
 **Shut Down** turns the system off.
 
 To monitor and manage all active sessions, go to **System Settings > Advanced**.
-{{< include file="SessionsSettingsWidget.md" >}}
+{{< include file="/_includes/SessionsSettingsWidget.md" >}}
 
 ## Next Steps
 

--- a/content/GettingStarted/Configure/SetUpSharing.md
+++ b/content/GettingStarted/Configure/SetUpSharing.md
@@ -30,7 +30,7 @@ Regardless of what type of share you create, the first step is to create a datas
 The share creation process starts with creating a dataset to use for the share. 
 {{< expand "Creating a Basic Dataset for Shares" "v" >}}
 
-{{< include file="CreateDatasetSCALE.md" >}}
+{{< include file="/_includes/CreateDatasetSCALE.md" >}}
 
 {{< /expand >}}
 ## Setting up SMB Shares for Windows

--- a/content/GettingStarted/Configure/UIConfigurationSCALE.md
+++ b/content/GettingStarted/Configure/UIConfigurationSCALE.md
@@ -64,7 +64,7 @@ You must disable failover in the UI on SCALE Enterprise HA systems to [add or ch
 
 ### Adding Network Interfaces
 
-{{< include file="MultipleInterfacesOnNetwork.md" >}}
+{{< include file="/_includes/MultipleInterfacesOnNetwork.md" >}}
 
 If your system includes more than one network interface card (NIC) connected to your internal network (wired to your router or Internet access point), you can add an interface in SCALE. 
 DHCP is available for only a single interface; any other physical interfaces must be configured with static IP addresses.
@@ -166,7 +166,7 @@ Contact iXsystems Support after you restore access to controller 1 to request fu
 
 {{< expand "Contact iXsystems Support" "v" >}}
 
-{{< include file="iXsystemsSupportContact.md" >}}
+{{< include file="/_includes/iXsystemsSupportContact.md" >}}
 
 {{< /expand >}}
 {{< /enterprise >}}

--- a/content/GettingStarted/SCALEReleaseNotes.md
+++ b/content/GettingStarted/SCALEReleaseNotes.md
@@ -80,7 +80,7 @@ More details are available from [23.10 Upgrades]({{< relref "23.10Upgrades.md" >
   Storage pools created in previous TrueNAS SCALE versions can upgrade to enable the new feature flags.
 
   {{< expand "About Storage Pool Upgrades (Click to expand)" "v" >}}
-  {{< include file="UpgradePools.md" >}}
+  {{< include file="/_includes/UpgradePools.md" >}}
   {{< /expand >}}
 
 * TrueCommand support for TrueNAS SCALE 23.10 (Cobia) system connections is anticipated in the TrueCommand 3.0 release.

--- a/content/SCALECLIReference/Account/CLIgroup.md
+++ b/content/SCALECLIReference/Account/CLIgroup.md
@@ -23,7 +23,7 @@ You can enter commands from the main CLI prompt or from the **account** namespac
 
 ### Interactive Argument Editor (TUI)
 
-{{< include file="HintInteractiveArgsEditor.md" >}}
+{{< include file="/_includes/HintInteractiveArgsEditor.md" >}}
 
 ### Create Command
 The `create` command creates a new group.
@@ -38,7 +38,7 @@ For more details, see **Create Configuration Properties** below.
 
 {{< expand "Create Configuration Properties" "v" >}}
 
-{{< include file="AccountGroupProperties.md" >}}
+{{< include file="/_includes/AccountGroupProperties.md" >}}
 
 {{< /expand >}}
 
@@ -363,7 +363,7 @@ The `update` command uses the same properties as the [`create`](#create-command)
 
 {{< expand "Update Configuration Properties" "v" >}}
 
-{{< include file="AccountGroupProperties.md" >}}
+{{< include file="/_includes/AccountGroupProperties.md" >}}
 
 {{< /expand >}}
 

--- a/content/SCALECLIReference/Account/CLIuser.md
+++ b/content/SCALECLIReference/Account/CLIuser.md
@@ -27,7 +27,7 @@ You can enter commands from the main CLI prompt or from the **account** namespac
 
 ### Interactive Argument Editor (TUI)
 
-{{< include file="HintInteractiveArgsEditor.md" >}}
+{{< include file="/_includes/HintInteractiveArgsEditor.md" >}}
 
 ### Create Command
 
@@ -290,7 +290,7 @@ true
 The `has_root_password` command is a deprecated method. Use the [`has_local_administrator_set_up`](#has_local_administrator_set_up-command) command instead.
 
 {{< expand "Deprecation Notice" "v" >}}
-{{< include file="RootLoginWarnSCALE.md" >}}
+{{< include file="/_includes/RootLoginWarnSCALE.md" >}}
 {{< /expand >}}
 
 ### Provisioning_URI Command	
@@ -571,7 +571,7 @@ true
 The `set_root_password` command is a deprecated method. Use the [`setup_local_administrator`](#setup_local_administrator-command) command instead.
 
 {{< expand "Deprecation Notice" "v" >}}
-{{< include file="RootLoginWarnSCALE.md" >}}
+{{< include file="/_includes/RootLoginWarnSCALE.md" >}}
 {{< /expand >}}
 
 ### Setup_Local_Administrator Command

--- a/content/SCALECLIReference/_index.md
+++ b/content/SCALECLIReference/_index.md
@@ -149,7 +149,7 @@ Each namespace article includes command syntax examples for each namespace.
 
 Enter the `--` flag following any CLI command to open the **interactive arguments editor** text-based user interface (TUI).
 
-{{< include file="InteractiveArgsEditor.md" >}}
+{{< include file="/_includes/InteractiveArgsEditor.md" >}}
 
 {{< expand "Click for a detailed example" "v" >}}
 Enter `account user create --` to open the **user_create** TUI.

--- a/content/SCALETutorials/Apps/CommunityApps/AddStorjNode.md
+++ b/content/SCALETutorials/Apps/CommunityApps/AddStorjNode.md
@@ -10,8 +10,8 @@ tags:
 
 {{< toc >}}
 
-{{< include file="CommunityAppsLegacy.md" >}}
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsLegacy.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 Storj is an open-source decentralized cloud storage (DCS) platform.
 Storj permits a computer running this software to configure the system as a node and to rent unused system storage capacity and bandwidth to other users.

--- a/content/SCALETutorials/Apps/CommunityApps/Chia.md
+++ b/content/SCALETutorials/Apps/CommunityApps/Chia.md
@@ -12,8 +12,8 @@ tags:
 
 {{< toc >}}
 
-{{< include file="CommunityAppsLegacy.md" >}}
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsLegacy.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 SCALE includes Chia in its Official Apps catalog. Chia Blockchain is a new cryptocurrency that uses Proof of Space and Time. Instead of using expensive hardware that consumes exorbitant amounts of electricity to mine cryptos, it leverages existing empty hard disk space on your computer(s) to farm cryptos with minimal resources, such as electricity.
 

--- a/content/SCALETutorials/Apps/CommunityApps/Collabora.md
+++ b/content/SCALETutorials/Apps/CommunityApps/Collabora.md
@@ -12,8 +12,8 @@ tags:
 
 {{< toc >}}
 
-{{< include file="CommunityAppsLegacy.md" >}}
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsLegacy.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 The SCALE **Apps** catalogue now includes [Collabora](https://nextcloud.com/collaboraonline/) from the developers of [Nextcloud](https://nextcloud.com/).
 

--- a/content/SCALETutorials/Apps/CommunityApps/InstallNetdataApp.md
+++ b/content/SCALETutorials/Apps/CommunityApps/InstallNetdataApp.md
@@ -12,8 +12,8 @@ tags:
 
 {{< toc >}}
 
-{{< include file="CommunityAppsLegacy.md" >}}
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsLegacy.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 ## Before You Begin
 

--- a/content/SCALETutorials/Apps/CommunityApps/InstallNextCloudMedia.md
+++ b/content/SCALETutorials/Apps/CommunityApps/InstallNextCloudMedia.md
@@ -13,8 +13,8 @@ tags:
 
 {{< toc >}}
 
-{{< include file="CommunityAppsLegacy.md" >}}
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsLegacy.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 Nextcloud is a drop-in replacement for many popular cloud services, including file sharing, calendar, groupware and more.
 One of its more common uses for the home environment is serving as a media backup, and organizing and sharing service.

--- a/content/SCALETutorials/Apps/CommunityApps/InstallPiHoleApp.md
+++ b/content/SCALETutorials/Apps/CommunityApps/InstallPiHoleApp.md
@@ -9,8 +9,8 @@ tags:
 - scalepihole
 ---
 
-{{< include file="CommunityAppsLegacy.md" >}}
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsLegacy.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 SCALE includes the ability to run Docker containers using Kubernetes.
 

--- a/content/SCALETutorials/Apps/CommunityApps/InstallWGEasyApp.md
+++ b/content/SCALETutorials/Apps/CommunityApps/InstallWGEasyApp.md
@@ -11,7 +11,7 @@ tags:
 - scaleapps
 ---
 
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 WG Easy is the easiest way to install and manage WireGuard on any Linux host.
 The application is included in the Community catalog of applications.

--- a/content/SCALETutorials/Apps/CommunityApps/MinIOApp/MinIOClustering.md
+++ b/content/SCALETutorials/Apps/CommunityApps/MinIOApp/MinIOClustering.md
@@ -17,7 +17,7 @@ tags:
 This article applies to the public release of the S3 **MinIO** charts application in the TRUENAS catalog.
 {{< /hint >}}
 
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 On TrueNAS SCALE 23.102-ALPHA.2 and later, users can create a MinIO S3 distributed instance to scale out and handle individual node failures.
 A node is a single TrueNAS storage system in a cluster.

--- a/content/SCALETutorials/Apps/CommunityApps/MinIOApp/MinioManualUpdate.md
+++ b/content/SCALETutorials/Apps/CommunityApps/MinIOApp/MinioManualUpdate.md
@@ -16,7 +16,7 @@ tags:
 This article applies to the public release of the S3 **MinIO** community application in the **charts** train of the TRUENAS catalog.
 {{< /hint >}}
 
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 ## Manual Update Overview
 

--- a/content/SCALETutorials/Apps/CommunityApps/MinIOApp/_index.md
+++ b/content/SCALETutorials/Apps/CommunityApps/MinIOApp/_index.md
@@ -14,7 +14,7 @@ tags:
 
 {{< toc >}}
 
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 This section has tutorials for using the MinIO apps available for TrueNAS SCALE.
 

--- a/content/SCALETutorials/Apps/CommunityApps/Rsyncd.md
+++ b/content/SCALETutorials/Apps/CommunityApps/Rsyncd.md
@@ -16,7 +16,7 @@ It is always recommended to use rsync with SSH as a security best practice.
 You do not need this application to schedule or run rsync tasks from the **Data Protections** screen using the **Rsync Task** widget.
 {{< /hint >}}
 
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 This application is an open source server that provides fast incremental file transfers.
 When installed, the Rsync Daemon application provides the server function to rsync clients given the server information and ability to connect.

--- a/content/SCALETutorials/Apps/CommunityApps/TFTP-HPAApp.md
+++ b/content/SCALETutorials/Apps/CommunityApps/TFTP-HPAApp.md
@@ -10,7 +10,7 @@ tags:
 - scaletftp
 ---
 
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 The new **TFTP Server** application provides Trivial File Transfer Protocol (TFTP) server functions.
 The TFTP Server application is a lightweight TFTP-server container in TrueNAS SCALE. It is not intended for use as a standalone container.

--- a/content/SCALETutorials/Apps/CommunityApps/WebDAV.md
+++ b/content/SCALETutorials/Apps/CommunityApps/WebDAV.md
@@ -16,7 +16,7 @@ tags:
 
 {{< toc >}}
 
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 The WebDAV application is a set of extensions to the HTTP protocol that allows users to collaboratively edit and manage files on remote web servers. It serves as the replacement for the built-in TrueNAS SCALE WebDAV feature.
 

--- a/content/SCALETutorials/Apps/CommunityApps/_index.md
+++ b/content/SCALETutorials/Apps/CommunityApps/_index.md
@@ -6,7 +6,7 @@ tags:
 - scaleapps
 ---
 
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 The TrueNAS community creates and maintains numerous applications intended to expand system functionality far beyond what is typically expected from a NAS.
 

--- a/content/SCALETutorials/Apps/CommunityApps/ddns-updater.md
+++ b/content/SCALETutorials/Apps/CommunityApps/ddns-updater.md
@@ -8,7 +8,7 @@ aliases:
  - /scale/scaletutorials/systemsettings/services/ddnsservicemigrate/
 ---
 
-{{< include file="CommunityAppsContribute.md" >}}
+{{< include file="/_includes/CommunityAppsContribute.md" >}}
 
 The DDNS-Updater application is a lightweight universal dynamic DNS (DDNS) updater with web UI.
 When installed, a container launches with root privileges in order to apply the correct permissions to the DDNS-Updater directories.

--- a/content/SCALETutorials/SystemSettings/Advanced/_index.md
+++ b/content/SCALETutorials/SystemSettings/Advanced/_index.md
@@ -76,7 +76,7 @@ Enter a number for the maximum number of simultaneous replication tasks you want
 
 ## Managing Sessions
 
-{{< include file="SessionsSettingsWidget.md" >}}
+{{< include file="/_includes/SessionsSettingsWidget.md" >}}
 
 ## Section Contents
 

--- a/content/SCALEUIReference/Shares/iSCSISharesScreens.md
+++ b/content/SCALEUIReference/Shares/iSCSISharesScreens.md
@@ -66,34 +66,34 @@ To display the **iSCSI Group** settings, click **Add**.
 
 ## iSCSI Configuration Screens
 
-{{< include file="iSCSIConfigurationScreens.md" >}}
+{{< include file="/_includes/iSCSIConfigurationScreens.md" >}}
 
 ### Target Global Configuration Screen
 
-{{< include file="iscsiTargetGlobalConfig.md" >}}
+{{< include file="/_includes/iscsiTargetGlobalConfig.md" >}}
 
 ### Portals Screens
 
-{{< include file="iscsiPortals.md" >}}
+{{< include file="/_includes/iscsiPortals.md" >}}
 
 ### Initiators Groups Screen
 
-{{< include file="iscsiInitiatorsGroups.md" >}}
+{{< include file="/_includes/iscsiInitiatorsGroups.md" >}}
 
 ### Authorized Access Screen
 
-{{< include file="iscsiAuthorizedAccess.md" >}}
+{{< include file="/_includes/iscsiAuthorizedAccess.md" >}}
 
 ### Targets Screen
 
-{{< include file="iscsiTargets.md" >}}
+{{< include file="/_includes/iscsiTargets.md" >}}
 
 ### Extents Screen
 
-{{< include file="iscsiExtents.md" >}}
+{{< include file="/_includes/iscsiExtents.md" >}}
 
 ### Associated Targets Screen
 
-{{< include file="iscsiAssociatedTargets.md" >}}
+{{< include file="/_includes/iscsiAssociatedTargets.md" >}}
 
 {{< taglist tag="scaleiscsi" limit="10" >}}

--- a/content/SCALEUIReference/Storage/_index.md
+++ b/content/SCALEUIReference/Storage/_index.md
@@ -241,7 +241,7 @@ Users with pools using virtual disks use this option to resize these virtual dis
 The **Upgrade** button displays on the **Storage Dashboard** for existing pools after an upgrade to a new TrueNAS release includes new [OpenZFS feature flags]({{< relref "SCALEReleaseNotes.md#component-versions" >}}).
 Newly created pools are always up to date with the OpenZFS feature flags available in the installed TrueNAS release.
 
-{{< include file="UpgradePools.md" >}}
+{{< include file="/_includes/UpgradePools.md" >}}
 
 {{< trueimage src="/images/SCALE/23.10/StorageDashboardUpgradPoolConfirmation.png" alt="Updgrade Pool Dialog" id="Upgrade Pool Dialog" >}}
 

--- a/content/SCALEUIReference/SystemSettings/AlertsSettingsServiceScreen.md
+++ b/content/SCALEUIReference/SystemSettings/AlertsSettingsServiceScreen.md
@@ -8,26 +8,26 @@ tags:
 
 {{< toc >}}
 
-{{< include file="AlertsSettings.md" >}}
+{{< include file="/_includes/AlertsSettings.md" >}}
 
 ## Add/Edit Alert Service Screen
 
-{{< include file="AlertsAddEdit.md" >}}
+{{< include file="/_includes/AlertsAddEdit.md" >}}
 
 ## Alert Service Types
 
-{{< include file="AlertsTypes.md" >}}
+{{< include file="/_includes/AlertsTypes.md" >}}
 
 ## Alert Categories
 
-{{< include file="AlertsCategories.md" >}}
+{{< include file="/_includes/AlertsCategories.md" >}}
 ## Alert Warning Levels
 
-{{< include file="AlertsWarningLevels.md" >}}
+{{< include file="/_includes/AlertsWarningLevels.md" >}}
 
 ## Alert Frequency
 
-{{< include file="AlertsFrequency.md" >}}
+{{< include file="/_includes/AlertsFrequency.md" >}}
 
 {{< taglist tag="scalesettings" limit="10" >}}
 {{< taglist tag="scalealerts" limit="10" title="Related Alerts Articles" >}}

--- a/content/SCALEUIReference/SystemSettings/Services/iSCSIServicesScreen.md
+++ b/content/SCALEUIReference/SystemSettings/Services/iSCSIServicesScreen.md
@@ -18,34 +18,34 @@ The **iSCSI** screen displays settings to configure iSCSI block shares.
 
 ## iSCSI Configuration Screens
 
-{{< include file="iSCSIConfigurationScreens.md" >}}
+{{< include file="/_includes/iSCSIConfigurationScreens.md" >}}
 
 ### Target Global Configuration Screen
 
-{{< include file="iscsiTargetGlobalConfig.md" >}}
+{{< include file="/_includes/iscsiTargetGlobalConfig.md" >}}
 
 ### Portals Screens
 
-{{< include file="iscsiPortals.md" >}}
+{{< include file="/_includes/iscsiPortals.md" >}}
 
 ### Initiators Groups Screen
 
-{{< include file="iscsiInitiatorsGroups.md" >}}
+{{< include file="/_includes/iscsiInitiatorsGroups.md" >}}
 
 ### Authorized Access Screen
 
-{{< include file="iscsiAuthorizedAccess.md" >}}
+{{< include file="/_includes/iscsiAuthorizedAccess.md" >}}
 
 ### Targets Screen
 
-{{< include file="iscsiTargets.md" >}}
+{{< include file="/_includes/iscsiTargets.md" >}}
 
 ### Extents Screen
 
-{{< include file="iscsiExtents.md" >}}
+{{< include file="/_includes/iscsiExtents.md" >}}
 
 ### Associated Targets Screen
 
-{{< include file="iscsiAssociatedTargets.md" >}}
+{{< include file="/_includes/iscsiAssociatedTargets.md" >}}
 
 {{< taglist tag="scaleiscsi" limit="10" >}}

--- a/content/SCALEUIReference/TopToolbar/Alerts/AlertSettingsScreen.md
+++ b/content/SCALEUIReference/TopToolbar/Alerts/AlertSettingsScreen.md
@@ -10,26 +10,26 @@ tags:
 
 {{< toc >}}
 
-{{< include file="AlertsSettings.md" >}}
+{{< include file="/_includes/AlertsSettings.md" >}}
 
 ## Add/Edit Alert Service Screen
 
-{{< include file="AlertsAddEdit.md" >}}
+{{< include file="/_includes/AlertsAddEdit.md" >}}
 
 ## Alert Service Types
 
-{{< include file="AlertsTypes.md" >}}
+{{< include file="/_includes/AlertsTypes.md" >}}
 
 ## Alert Categories
 
-{{< include file="AlertsCategories.md" >}}
+{{< include file="/_includes/AlertsCategories.md" >}}
 ## Alert Warning Levels
 
-{{< include file="AlertsWarningLevels.md" >}}
+{{< include file="/_includes/AlertsWarningLevels.md" >}}
 
 ## Alert Frequency
 
-{{< include file="AlertsFrequency.md" >}}
+{{< include file="/_includes/AlertsFrequency.md" >}}
 
 {{< taglist tag="scalealerts" limit="10" >}}
 {{< taglist tag="scaleclustering" limit="10" title="Related Clustering Articles" >}}


### PR DESCRIPTION
adds `/_includes/` to all `include file` shortcodes that did not have the path defined

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
