### PR TITLE
Update outdated link

### DIFF
--- a/content/References/ConceptsAndTerms.md
+++ b/content/References/ConceptsAndTerms.md
@@ -64,7 +64,7 @@ While TrueNAS is designed for and ever-evolving towards increased user friendlin
 
 * [ZFS zvols]({{< relref "CORE/CORETutorials/Storage/Pools/Zvols.md" >}}): datasets that represent block devices.
 
-* [ZIL](https://www.freenas.org/blog/zfs-zil-and-slog-demystified/) (or ZFS Intent Log): special vdev class. This is also sometimes referred to as a SLOG or Separate Intent Log.
+* [ZIL](https://www.truenas.com/blog/zfs-zil-and-slog-demystified/) (or ZFS Intent Log): special vdev class. This is also sometimes referred to as a SLOG or Separate Intent Log.
 
 * [Fusion Pool]({{< relref "CORE/CORETutorials/Storage/Pools/FusionPool.md" >}}) (or metadata vdev): is a special class of vdev. This special vdev can store meta data such as file locations and allocation tables. Using a special vdev drastically speeds up random I/O and can cut the average number of spinning-disk I/Os needed to find and access a file by up to half.
 


### PR DESCRIPTION
Updates dead link found for "ZIL" on this page: https://www.truenas.com/docs/references/conceptsandterms/

I checked all other links to `freenas.org` link references and they all properly redirect to `truenas.com`

