### PR TITLE
PD-704: 13.0 branch cross references fixes

### DIFF
--- a/content/API/_index.md
+++ b/content/API/_index.md
@@ -17,8 +17,4 @@ For convenience, static builds of the current 2.0 API documentation stored on th
 * [Websocket Protocol](/api/core_websocket_api.html)
 * [RESTful](/api/core_rest_api.html)
 
-## CORE Documentation Sections
-
-{{< include file="/_includes/COREDocsSections.md" >}}
-
 {{< taglist tag="coretopmenu" limit="10" >}}

--- a/content/CORETutorials/_index.md
+++ b/content/CORETutorials/_index.md
@@ -3,6 +3,7 @@ title: Configuration Tutorials
 description: "Standalone tutorials. Tutorials are organized parallel to the CORE interface layout."
 geekdocCollapseSection: true
 weight: 40
+aliases:
 ---
 
 Welcome to TrueNAS CORE tutorials!

--- a/content/CoreSecurityReports/_index.md
+++ b/content/CoreSecurityReports/_index.md
@@ -3,6 +3,7 @@ title: "CORE Security Reports"
 description: "CORE-specific security notices and links to the TrueNAS Security Hub."
 geekdocCollapseSection: true
 weight: 175
+aliases:
 ---
 
 See the [TrueNAS Security Hub](https://security.truenas.com/) to get the latest responses to TrueNAS CORE-related security advisories.

--- a/content/_index.md
+++ b/content/_index.md
@@ -26,7 +26,7 @@ Plugin applications like Plex, NextCloud, and Asigra allow the functionality of 
 <img src="/images/tn-enterprise-logo.png" alt="TNCORELogo"/>
 </p>
 <--->
-**TrueNAS CORE Enterprise** is provided as part of an [iXsystems hardware](/hardware) purchase or extended iXsystems Support Contract.
+**TrueNAS CORE Enterprise** is provided as part of an [iXsystems hardware](https://www.truenas.com/docs/hardware) purchase or extended iXsystems Support Contract.
 Systems can have either single or dual controllers to enable High Availability (HA).
 It can also be provided with Enterprise-grade support from iXsystems.
 {{< /columns >}}


### PR DESCRIPTION
Ahrefs report hit a couple cross-references in the API and home pages that were not pointed the right direction. The API article shortcode is removed (obsolete) and the home page reference to the hardware area updated to be a static link (cross-version compatibility)
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
