### PR TITLE
PD-684 Updates and Corrections

### DIFF
--- a/content/SCALE/SCALEUIReference/Shares/iSCSISharesScreens.md
+++ b/content/SCALE/SCALEUIReference/Shares/iSCSISharesScreens.md
@@ -18,24 +18,24 @@ The **Sharing** screen opens after you click **Shares** on the main navigation p
 
 ## Block (iSCSI) Shares Targets Widget
 
-The **Block (iSCSI) Shares Targets** widget displays the widget toolbar with the status of the iSCSI service and two buttons, **Configure** and **Add**. After adding a block share, the widget displays shares below the toolbar.
+The **Block (iSCSI) Shares Targets** widget displays the widget toolbar with the status of the iSCSI service. 
+Click **Configure** to open the **iSCSI** screen on the **[Target Global Configuration](#target-global-configuration-screen)** tab. 
+Click **Wizard** to open the **Wizard iSCSI** screen.
 
 ![iSCSIBlockSharesWidget](/images/SCALE/Shares/iSCSIBlockSharesWidget.png "Block (iSCSI) Share Target Widget Toolbar")
 
 After adding an iSCSI target or share, the widget toolbar displays the **STOPPED** service status in red and includes the share below.
 
 Before you add your first iSCSI block share, click anywhere on **Block (iSCSI) Shares Targets <span class="material-icons">launch</span>** to open the **Sharing > iSCSI** screen with the **Targets** iSCSI configuration tab displayed.
-
+Click **Add** in the top right or **Add Target** in the middle of the screen to open the **[Add ISCSI Target](#add-and-edit-iscsi-target-screens)** screen. 
+Click **Wizard** to open the **Wizard iSCSI** screen. After adding a block share, the widget displays shares below the toolbar.
 The **No Targets** screen opens only when the system does not have an iSCSI target configured on the system.  
 
 ![iSCSINoTargetsScreen](/images/SCALE/Shares/iSCSINoTargetsScreen.png "iSCSI No Targets screen")
 
-**Add Targets** and the **Add** button on the toolbar opens the **[Add ISCSI Target](#add-and-edit-iscsi-target-screens)** screen.
-
-**Configure** on the widget toolbar opens the **Sharing > iSCSI** screen with the configuration tabs displayed.
-**[Target Global Configuration](#target-global-configuration-screen)** displays the first time you click **Configure**.
-
-The <span class="material-icons">more_vert</span> on the toolbar displays options to turn the iSCSI service on or off. **Turn Off Service** displays if the service is running. Otherwise, **Turn On Service** displays. The **Config Service** option opens the configuration tabs **[Target Global Configuration](#target-global-configuration-screen)** screen.
+The <span class="material-icons">more_vert</span> on the toolbar displays options to turn the iSCSI service on or off. 
+**Turn Off Service** displays if the service is running. Otherwise, **Turn On Service** displays. 
+The **Config Service** option opens the configuration tabs **[Target Global Configuration](#target-global-configuration-screen)** screen.
 
 If you have other share types added to your TrueNAS system, the widget displays as a card on the **Sharing** screen.
 
@@ -48,7 +48,7 @@ If you have other share types added to your TrueNAS system, the widget displays 
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Target Name** | Required. Enter a name using lowercase alphanumeric characters. Allowed characters are plus dot (.), dash (-), and colon (:). A name longer than 63 characters can prevent access to the block. See the "Constructing iSCSI names using the iqn.format" section of [RFC3721](https://tools.ietf.org/html/rfc3721.html). The base name is automatically prepended if the target name does not start with **iqn**. |
+| **Target Name** | Required. Enter a name using up to 64 lowercase alphanumeric and special characters. Allowed characters are dot (.), dash (-), and colon (:). A name longer than 64 characters is not allowed. See the "Constructing iSCSI names using the iqn.format" section of [RFC3721](https://tools.ietf.org/html/rfc3721.html). The base name (**from Target Global Configuration**) is automatically prepended if the target name does not start with **iqn**. |
 | **Target Alias** | Enter an optional user-friendly name. |
 {{< /truetable >}}
 
@@ -58,8 +58,8 @@ To display the **iSCSI Group** settings, click **Add**.
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Portal Group ID** | Required. Select the number of the existing portal to use or leave it empty. |
-| **Initiator Group ID** | Select the existing initiator group ID that has access to the target from the dropdown list of options. **None**, **1(init1)**, or **3(ALL initiators Allowed)**. |
+| **Portal Group ID** | Required if specifying an iSCSI Group. Select the number of the existing portal to use. This is the portal group ID created in **Portals**. |
+| **Initiator Group ID** | Select the existing initiator group ID that has access to the target from the dropdown list of options. Options are **None**, **1(init1)**, or **3(ALL initiators Allowed)**. This is the initiator group ID created in **Initiator Groups**. |
 | **Authentication Method** | Select the method from the dropdown list of options. **None**, **CHAP** or **Mutual Chap**. iSCSI supports multiple authentication methods that targets can use to discover valid devices. **None** allows anonymous discovery. If set to **None** you can leave **Discovery Authentication Group** set to **None** or empty. If set to **CHAP** or **Mutual CHAP** you must enter or create a new group in **Discovery Authentication Group**. |
 | **Authentication Group Number** | Select the option from the dropdown list. This is the group ID created in **Authorized Access**. Required when the **Discovery Authentication Method** is set to **CHAP** or **Mutual CHAP**. Select **None** or the value representing the number of the existing authorized accesses. |
 {{< /truetable >}}

--- a/content/SCALE/SCALEUIReference/Shares/iSCSISharesScreens.md
+++ b/content/SCALE/SCALEUIReference/Shares/iSCSISharesScreens.md
@@ -59,7 +59,7 @@ To display the **iSCSI Group** settings, click **Add**.
 | Setting | Description |
 |---------|-------------|
 | **Portal Group ID** | Required if specifying an iSCSI Group. Select the number of the existing portal to use. This is the portal group ID created in **Portals**. |
-| **Initiator Group ID** | Select the existing initiator group ID that has access to the target from the dropdown list of options. Options are **None**, **1(init1)**, or **3(ALL initiators Allowed)**. This is the initiator group ID created in **Initiator Groups**. |
+| **Initiator Group ID** | Select the existing initiator group ID that has access to the target from the dropdown list of options. When initiator groups exist, the dropdown populates with options to select a created group by ID, allow all groups, or allow no groups. |
 | **Authentication Method** | Select the method from the dropdown list of options. **None**, **CHAP** or **Mutual Chap**. iSCSI supports multiple authentication methods that targets can use to discover valid devices. **None** allows anonymous discovery. If set to **None** you can leave **Discovery Authentication Group** set to **None** or empty. If set to **CHAP** or **Mutual CHAP** you must enter or create a new group in **Discovery Authentication Group**. |
 | **Authentication Group Number** | Select the option from the dropdown list. This is the group ID created in **Authorized Access**. Required when the **Discovery Authentication Method** is set to **CHAP** or **Mutual CHAP**. Select **None** or the value representing the number of the existing authorized accesses. |
 {{< /truetable >}}


### PR DESCRIPTION
This PR fixes missing references to the Wizard and Configure buttons on the iSCSI widget. It makes a few other related changes adding the name of screens opened. Makes the suggested changes in the settings tables.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
