### PR TITLE
Pd 346 update cli static route.md article content

### DIFF
--- a/content/SCALE/SCALECLIReference/Network/CLIStaticRoute.md
+++ b/content/SCALE/SCALECLIReference/Network/CLIStaticRoute.md
@@ -6,6 +6,8 @@ aliases:
 draft: false
 tags:
 - scaleclinetwork
+- scalenetwork
+- scalestaticroute
 ---
 
 {{< toc >}}
@@ -13,4 +15,150 @@ tags:
 
 {{< include file="/_includes/CLIGuideWIP.md" >}}
 
+## Static_Route Namespace
+The **static_route** namespace has four commands, and is based on network static route creation and management functions found in the SCALE API and web UI.
+It provides access to network methods through the **static_route** commands.
+
+## Static_Route Commands 
+The following **static_route** commands allow you to create new and manage existing static routes.
+
+You can enter commands from the main CLI prompt or from the **static_route** namespace prompt.
+
+### Interactive Argument Editor (TUI)
+
+{{< include file="/_includes/CLI/HintInteractiveArgsEditor.md" >}}
+
+### Create Command
+The `create` command adds a single static route IP address and gateway to the system.
+
+{{< expand "Using the Create Command" "v" >}}
+#### Description
+The `create` command has three required properties, `destination`, `gateway`, and `description`.
+See **Create Properties** below for details.
+Enter the property arguments using the `=` delimiter to separate property and value. Double-quote values with special characters.
+Enter the command string then press <kbd>Enter</kbd>.
+The command returns an empty line. Enter the `network static_route query` command to verify creation of the static route.
+
+{{< expand "Create Properties" "v" >}}
+{{< truetable >}}
+| Property | Required | Description | Syntax Example |
+|----------|----------|-------------|----------------|
+| `destination` | Yes | Enter the IP address in the format a.b.c.d/e for the static route you want to create. | <code>destination=<i>a.b.c.d/e</i>"</code> |
+| `gateway` | Yes | Enter the IP address for the gateway for the destination IP address in the format a.b.c.d. | <code>gateway="<i>a.b.c.d</i>"</code> |
+| `description` | No |  Enter optional text to describe the static route. The default value is just the double quotes. | <code>description="<i>test</i>"</code> | 
+{{< /truetable >}}
+{{< /expand >}}
+
+#### Usage
+From the CLI prompt, enter:
+
+<code>network static_route create destination="<i>10.123.0.123/20</i>" gateway="<i>10.123.0.1</i>" description="<i>test</i>"</code>
+
+Where:
+* *10.123.0.123/20* is IP address for the static route.
+* *10.123.0.1* is the gateway for the destination IP address.
+* *test* is a description for the static route.
+
+{{< expand "Command Example" "v" >}}
+```
+network static_route create destination="10.123.0.123/20" gateway="10.123.0.1" description="test"
+
+```
+{{< /expand >}}
+{{< /expand >}}
+
+### Delete Command
+The `delete` command deletes the static route matching the ID entered.
+
+{{< expand "Using the Delete Command" "v" >}}
+#### Description
+The `delete` command has one required property, `id`.
+`id` is the system-assigned number for the static route found in the output of the `network static_route query` command.
+Enter the property argument using the `=` delimiter to separate property and value. 
+Enter the command string then press <kbd>Enter</kbd>.
+The command returns an empty line. Enter the `network static_route query` command to verify deletion of the static route.
+
+#### Usage
+From the CLI prompt, enter:
+
+<code>network static_route delete id=<i></i>"</code>
+
+Where *1* is the system-assigned number for the static route.
+
+{{< expand "Command Example" "v" >}}
+```
+network static_route delete id=1
+
+```
+{{< /expand >}}
+{{< /expand >}}
+
+### Query Command
+The `query` command lists details on static routes added to the system.
+
+{{< expand "Using the Query Command" "v" >}}
+#### Description
+The `query` command does not require entering a property argument.
+To narrow the information returned include the one property of the static route you want to see for all static routes.
+Properties are `id`, `destination`, `gateway`, and `description`.
+Enter the command then press <kbd>Enter</kbd>.
+The command returns the values for all static routes configured on the system, or just the property included in the command. 
+
+#### Usage
+From the CLI prompt, enter:
+
+`network static_route query`
+
+{{< expand "Command Example" "v" >}}
+```
+network static_route query
++----+-----------------+------------+-------------+
+| id | destination     | gateway    | description |
++----+-----------------+------------+-------------+
+| 1  | 10.123.0.123/20 | 10.123.0.1 | TEST        |
++----+-----------------+------------+-------------+
+```
+{{< /expand >}}
+{{< /expand >}}
+
+### Update Command
+Use the `update` command to change the properties of the static route matching the ID entered.
+
+{{< expand "Using the Update Command" "v" >}}
+#### Description
+The `update` command has one required property, `id`.
+See **Update Properties** below for details on `update` properties.
+Enter the property arguments using the `=` delimiter to separate property and value. Double-quote values with special characters.
+Enter the command string then press <kbd>Enter</kbd>.
+The command returns an empty line. Enter the `network static_route query` command to verify updates to the static route.
+
+{{< expand "Update Properties" "v" >}}
+{{< truetable >}}
+| Property | Description | Syntax Example |
+|----------|-------------|----------------|
+| `destination` | Enter the IP address in the format a.b.c.d/e for the static route you want to create. | <code>destination=<i>a.b.c.d/e</i>"</code> |
+| `gateway` | Enter the IP address for the gateway for the destination IP address in the format a.b.c.d. | <code>gateway="<i>a.b.c.d</i>"</code> |
+| `description` | Enter optional text to describe the static route. | <code>description="<i>test</i>"</code> | 
+{{< /truetable >}}
+{{< /expand >}}
+
+#### Usage
+From the CLI prompt, enter:
+
+<code>network static_route update id=<i>1</i> description="<i>test route</i>"</code>
+
+Where:
+* *1* is system-assigned ID for the static route.
+* *test route* is the new optional descriptive text for the static route.
+
+{{< expand "Command Example" "v" >}}
+```
+network static_route update id=1 description="test route"
+
+```
+{{< /expand >}}
+{{< /expand >}}
+
+
 {{< taglist tag="scaleclinetwork" limit="10" title="Related CLI Network Articles" >}}
+{{< taglist tag="scalestaticroute" limit="10" title="Related Static Route Articles" >}}

--- a/content/SCALE/SCALECLIReference/Network/CLIStaticRoute.md
+++ b/content/SCALE/SCALECLIReference/Network/CLIStaticRoute.md
@@ -42,9 +42,9 @@ The command returns an empty line. Enter the `network static_route query` comman
 {{< truetable >}}
 | Property | Required | Description | Syntax Example |
 |----------|----------|-------------|----------------|
-| `destination` | Yes | Enter the IP address in the format a.b.c.d/e for the static route you want to create. | <code>destination=<i>a.b.c.d/e</i>"</code> |
+| `destination` | Yes | Enter the IP address in the format a.b.c.d/e for the static route you want to create. | <code>destination="<i>a.b.c.d/e</i>"</code> |
 | `gateway` | Yes | Enter the IP address for the gateway for the destination IP address in the format a.b.c.d. | <code>gateway="<i>a.b.c.d</i>"</code> |
-| `description` | No |  Enter optional text to describe the static route. The default value is just the double quotes. | <code>description="<i>test</i>"</code> |
+| `description` | No | Enter optional text to describe the static route. | <code>description="<i>test</i>"</code> |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -80,7 +80,7 @@ The command returns an empty line. Enter the `network static_route query` comman
 #### Usage
 From the CLI prompt, enter:
 
-<code>network static_route delete id=<i></i>"</code>
+<code>network static_route delete id="<i>1</i>"</code>
 
 Where *1* is the system-assigned number for the static route.
 
@@ -126,7 +126,7 @@ Use the `update` command to change the properties of the static route matching t
 {{< expand "Using the Update Command" "v" >}}
 #### Description
 The `update` command has one required property, `id`.
-See **Update Properties** below for details on `update` properties.
+See **Update Properties** below for details.
 Enter the property arguments using the `=` delimiter to separate property and value. Double-quote values with special characters.
 Enter the command string then press <kbd>Enter</kbd>.
 The command returns an empty line. Enter the `network static_route query` command to verify updates to the static route.
@@ -135,7 +135,7 @@ The command returns an empty line. Enter the `network static_route query` comman
 {{< truetable >}}
 | Property | Description | Syntax Example |
 |----------|-------------|----------------|
-| `destination` | Enter the IP address in the format a.b.c.d/e for the static route you want to create. | <code>destination=<i>a.b.c.d/e</i>"</code> |
+| `destination` | Enter the IP address in the format a.b.c.d/e for the static route you want to create. | <code>destination="<i>a.b.c.d/e</i>"</code> |
 | `gateway` | Enter the IP address for the gateway for the destination IP address in the format a.b.c.d. | <code>gateway="<i>a.b.c.d</i>"</code> |
 | `description` | Enter optional text to describe the static route. | <code>description="<i>test</i>"</code> |
 {{< /truetable >}}
@@ -148,7 +148,7 @@ From the CLI prompt, enter:
 
 Where:
 * *1* is system-assigned ID for the static route.
-* *test route* is the new optional descriptive text for the static route.
+* *test route* is the new descriptive text for the static route.
 
 {{< expand "Command Example" "v" >}}
 ```

--- a/content/SCALE/SCALECLIReference/Network/CLIStaticRoute.md
+++ b/content/SCALE/SCALECLIReference/Network/CLIStaticRoute.md
@@ -12,14 +12,13 @@ tags:
 
 {{< toc >}}
 
-
 {{< include file="/_includes/CLIGuideWIP.md" >}}
 
 ## Static_Route Namespace
 The **static_route** namespace has four commands, and is based on network static route creation and management functions found in the SCALE API and web UI.
 It provides access to network methods through the **static_route** commands.
 
-## Static_Route Commands 
+## Static_Route Commands
 The following **static_route** commands allow you to create new and manage existing static routes.
 
 You can enter commands from the main CLI prompt or from the **static_route** namespace prompt.
@@ -45,7 +44,7 @@ The command returns an empty line. Enter the `network static_route query` comman
 |----------|----------|-------------|----------------|
 | `destination` | Yes | Enter the IP address in the format a.b.c.d/e for the static route you want to create. | <code>destination=<i>a.b.c.d/e</i>"</code> |
 | `gateway` | Yes | Enter the IP address for the gateway for the destination IP address in the format a.b.c.d. | <code>gateway="<i>a.b.c.d</i>"</code> |
-| `description` | No |  Enter optional text to describe the static route. The default value is just the double quotes. | <code>description="<i>test</i>"</code> | 
+| `description` | No |  Enter optional text to describe the static route. The default value is just the double quotes. | <code>description="<i>test</i>"</code> |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -74,7 +73,7 @@ The `delete` command deletes the static route matching the ID entered.
 #### Description
 The `delete` command has one required property, `id`.
 `id` is the system-assigned number for the static route found in the output of the `network static_route query` command.
-Enter the property argument using the `=` delimiter to separate property and value. 
+Enter the property argument using the `=` delimiter to separate property and value.
 Enter the command string then press <kbd>Enter</kbd>.
 The command returns an empty line. Enter the `network static_route query` command to verify deletion of the static route.
 
@@ -102,7 +101,7 @@ The `query` command does not require entering a property argument.
 To narrow the information returned include the one property of the static route you want to see for all static routes.
 Properties are `id`, `destination`, `gateway`, and `description`.
 Enter the command then press <kbd>Enter</kbd>.
-The command returns the values for all static routes configured on the system, or just the property included in the command. 
+The command returns the values for all static routes configured on the system, or just the property included in the command.
 
 #### Usage
 From the CLI prompt, enter:
@@ -138,7 +137,7 @@ The command returns an empty line. Enter the `network static_route query` comman
 |----------|-------------|----------------|
 | `destination` | Enter the IP address in the format a.b.c.d/e for the static route you want to create. | <code>destination=<i>a.b.c.d/e</i>"</code> |
 | `gateway` | Enter the IP address for the gateway for the destination IP address in the format a.b.c.d. | <code>gateway="<i>a.b.c.d</i>"</code> |
-| `description` | Enter optional text to describe the static route. | <code>description="<i>test</i>"</code> | 
+| `description` | Enter optional text to describe the static route. | <code>description="<i>test</i>"</code> |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -158,7 +157,6 @@ network static_route update id=1 description="test route"
 ```
 {{< /expand >}}
 {{< /expand >}}
-
 
 {{< taglist tag="scaleclinetwork" limit="10" title="Related CLI Network Articles" >}}
 {{< taglist tag="scalestaticroute" limit="10" title="Related Static Route Articles" >}}

--- a/content/SCALE/SCALETutorials/Network/ConfigureStaticRoutes.md
+++ b/content/SCALE/SCALETutorials/Network/ConfigureStaticRoutes.md
@@ -28,4 +28,4 @@ If you need a static route to reach portions of the network, from the **Network*
 
 5. Click **Save**.
 
-{{< taglist tag="scalestaticroute" limit="10" "Related Static Route Articles" >}}
+{{< taglist tag="scalestaticroute" limit="10" title="Related Static Route Articles" >}}

--- a/content/SCALE/SCALETutorials/Network/ConfigureStaticRoutes.md
+++ b/content/SCALE/SCALETutorials/Network/ConfigureStaticRoutes.md
@@ -4,7 +4,7 @@ description: "Provides instructions on configuring a static route using the SCAL
 weight: 35
 tags:
 - scalenetwork
-- scaleinterface
+- scalestaticroute
 ---
 
 

--- a/content/SCALE/SCALETutorials/Network/ConfigureStaticRoutes.md
+++ b/content/SCALE/SCALETutorials/Network/ConfigureStaticRoutes.md
@@ -28,4 +28,4 @@ If you need a static route to reach portions of the network, from the **Network*
 
 5. Click **Save**.
 
-{{< taglist tag="scaleinterface" limit="10" >}}
+{{< taglist tag="scalestaticroute" limit="10" "Related Static Route Articles" >}}

--- a/content/SCALE/SCALEUIReference/Network/StaticRouteScreens.md
+++ b/content/SCALE/SCALEUIReference/Network/StaticRouteScreens.md
@@ -26,5 +26,5 @@ If you need a static route to reach portions of the network, add the route by go
 
 Use **Save** to add the static route.
 
-{{< taglist tag="scalestaticroute" limit="10" "Related Static Route Articles" >}}
+{{< taglist tag="scalestaticroute" limit="10" title="Related Static Route Articles" >}}
 {{< taglist tag="scalenetwork" limit="10" title="Related Network Articles" >}}

--- a/content/SCALE/SCALEUIReference/Network/StaticRouteScreens.md
+++ b/content/SCALE/SCALEUIReference/Network/StaticRouteScreens.md
@@ -4,7 +4,7 @@ description: "The Static Routes widget displays existing static routes or sets u
 weight: 30
 tags:
 - scalenetwork
-- scalesinterfaces
+- scalesstaticroute
 ---
 
 The **Static Routes** widget on the **Network** screen displays static IP addresses configured as static routes. Use this to manually enter routes to network destinations outside the TrueNAS network so the router can send packets to a destination network.
@@ -26,6 +26,5 @@ If you need a static route to reach portions of the network, add the route by go
 
 Use **Save** to add the static route.
 
-{{< taglist tag="scaleinterfaces" limit="10" >}}
-
+{{< taglist tag="scalestaticroute" limit="10" "Related Static Route Articles" >}}
 {{< taglist tag="scalenetwork" limit="10" title="Related Network Articles" >}}


### PR DESCRIPTION
This PR updates the CLIStaticRoute.md article with standard CLI text and the static_route command content.
It updates the UI ref and tutorial articles on static routes with a new tag "scalestaticroute" and taglist shortcode.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
