### PR TITLE
Pd 729 backport to 22.12

### DIFF
--- a/content/GettingStarted/Migrate/MigratePrep.md
+++ b/content/GettingStarted/Migrate/MigratePrep.md
@@ -12,6 +12,8 @@ tags:
 
 {{< include file="/content/_includes/MigrateCOREtoSCALEWarning.md" >}}
 
+{{< include file="/_includes/MigrateCoreServicesToCobia.md" >}}
+
 ## What can or cannot migrate?
 
 {{< include file="/content/_includes/COREMigratesList.md" >}}

--- a/content/GettingStarted/Migrate/MigratePrepEnterprise.md
+++ b/content/GettingStarted/Migrate/MigratePrepEnterprise.md
@@ -12,6 +12,8 @@ tags:
 
 {{< include file="/content/_includes/MigrateCOREtoSCALEWarning.md" >}}
 
+{{< include file="/_includes/MigrateCoreServicesToCobiaEnterprise.md" >}}
+
 ## What can or cannot migrate?
 
 {{< include file="/content/_includes/COREMigratesList.md" >}}

--- a/content/_includes/COREMigratesList.md
+++ b/content/_includes/COREMigratesList.md
@@ -1,0 +1,27 @@
+&NewLine;
+
+Although TrueNAS attempts to keep most of your CORE configuration data when upgrading to SCALE, some CORE-specific items do not transfer.
+These are the items that don't migrate from CORE:
+
+* FreeBSD GELI encryption.
+  If you have GELI-encrypted pools on your system that you plan to import into SCALE, you must migrate your data from the GELI pool to a non-GELI encrypted pool *before* migrating to SCALE.
+* Malformed certificates.
+  TrueNAS SCALE validates the system certificates when a CORE system migrates to SCALE.
+  When a malformed certificate is found, SCALE generates a new self-signed certificate to ensure system accessibility.
+* CORE plugins and jails. Save the configuration information for your plugin and back up any stored data.
+  After completing the SCALE install, add the equivalent SCALE application using the **Apps** option.
+  If your CORE plugin is not listed as an available application in SCALE, use the **Launch Docker Image** option to add it as an application and import data from the backup into a new SCALE dataset for the application.
+* NIS data.
+* System tunables.
+* ZFS boot environments.
+* AFP shares also do not transfer, but migrate into an SMB share with AFP compatibility enabled.
+* CORE `netcli` utility. A new CLI utility is used for the [Console Setup Menu]({{< relref "ConsoleSetupMenuSCALE.md" >}}) and other commands issued in a CLI.
+  By default, any TrueNAS user account with **netcli** as the chosen **Shell** updates to use the **nologin** option instead. See the [Users Screens]({{< relref "LocalUsersScreensSCALE.md#authentication-settings" >}}) reference article for descriptions of all **Shell** options.
+* SAS multipath is not supported in TrueNAS SCALE.
+* TrueNAS CORE account names beginning with a number are not supported in TrueNAS SCALE.
+  Usernames in SCALE must begin with a letter or an underscore.
+  Before attempting a CORE to SCALE migration, review the local user accounts and rename or replace any accounts that begin with a numeric character (`0`-`9`).
+
+VM storage and its basic configuration transfer over during a migration, but you need to double-check the VM configuration and the network interface settings specifically before starting the VM.
+
+Init/shutdown scripts transfer, but can break. Review them before use.

--- a/content/_includes/MigrateCOREtoSCALEWarning.md
+++ b/content/_includes/MigrateCOREtoSCALEWarning.md
@@ -1,12 +1,5 @@
 &NewLine;
 
-{{< hint type=warning >}}
-Migrating TrueNAS from CORE to SCALE is a one-way operation.
-Attempting to activate or roll back to a CORE boot environment can break the system.
-
-Upgrade your CORE system to the latest publicly-available 13.0-U*x* release before attempting to migrate from CORE to SCALE.
-{{< /hint >}}
-
 {{< enterprise >}}
 High Availability (HA) systems cannot migrate directly from CORE to SCALE.
 
@@ -16,3 +9,10 @@ Enterprise customers with HA systems should contact iXsystems Support before att
 {{< include file="content/_includes/iXsystemsSupportContact.md" >}}
 {{< /expand >}}
 {{< /enterprise >}}
+
+{{< hint type=warning >}}
+Migrating TrueNAS from CORE to SCALE is a one-way operation.
+Attempting to activate or roll back to a CORE boot environment can break the system.
+
+Upgrade your CORE system to the latest publicly-available 13.0-U*x* release before attempting to migrate from CORE to SCALE.
+{{< /hint >}}

--- a/content/_includes/MigrateCoreServicesToCobia.md
+++ b/content/_includes/MigrateCoreServicesToCobia.md
@@ -1,0 +1,11 @@
+&NewLine;
+
+{{< hint type=important >}}
+SCALE Bluefin deprecates and Cobia removes the built-in DDNS, OpenVPN server and client, rsync, S3, and TFTP service. 
+The WebDAV service and share feature are also deprecated in Bluefin and removed in Cobia. 
+New applications are available in Bluefin to serve as replacements for the functions these services provided.
+
+To migrate from CORE to SCALE Cobia, first upgrade to and migrate from the latest CORE release to the latest release of SCALE 22.12 (Bluefin).
+While running SCALE Bluefin, take the necessary steps to transition from these deprecated services to the applications that replace them, then upgrade to SCALE 23.10 (Cobia).
+The replacement applications are available in SCALE 22.12 and 23.10.
+{{< /hint >}}

--- a/content/_includes/MigrateCoreServicesToCobiaEnterprise.md
+++ b/content/_includes/MigrateCoreServicesToCobiaEnterprise.md
@@ -1,0 +1,10 @@
+&NewLine;
+
+{{< enterprise >}}
+SCALE Bluefin deprecates and SCALE Cobia removes the built-in DDNS, OpenVPN server and client, rsync, S3, and TFTP services.
+The WebDAV service and share feature are also deprecated in Bluefin and removed in Cobia.
+New applications are available in SCALE Bluefin to serve as replacements for the functions provided by these services.
+
+To avoid any potential service outages, Enterprise customers with licensed TrueNAS systems are prevented from upgrading from SCALE 22.12.3 (or later) to SCALE 23.10 unless the deprecated services have been replaced and/or disabled.
+Enterprise customers can contact iXsystems Support for assistance migrating from deprecated services.
+{{< /enterprise >}}

--- a/words-to-ignore.txt
+++ b/words-to-ignore.txt
@@ -1434,3 +1434,5 @@ qemu-xhci
 UIReferenceIntro
 AddDatasetNameAndOptions
 AddDatasetEncrytionAndOtherOptionsBasic
+LocalUsersScreensSCALE
+nologin


### PR DESCRIPTION
This PR ports change to `COREMigratesList.md` to 22.12. Also backports two other snippets on deprecated services. 
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
