### PR TITLE
Fix bug with SCALE download or print links (master branch only)

### DIFF
--- a/content/SCALE/GettingStarted/PrintPreview.md
+++ b/content/SCALE/GettingStarted/PrintPreview.md
@@ -5,4 +5,4 @@ weight: 1
 no_print: "true"
 ---
 
-<meta http-equiv="Refresh" content="0; url='/gettingstarted/printview'" />
+<meta http-equiv="Refresh" content="0; url='/scale/gettingstarted/printview/'" />

--- a/content/SCALE/SCALECLIReference/SCALECLIPrint.md
+++ b/content/SCALE/SCALECLIReference/SCALECLIPrint.md
@@ -5,4 +5,4 @@ weight: 1
 no_print: "true"
 ---
 
-<meta http-equiv="Refresh" content="0; url='/scaleclireference/printview'" />
+<meta http-equiv="Refresh" content="0; url='/scale/scaleclireference/printview'" />

--- a/content/SCALE/SCALETutorials/SCALETutorialsPrint.md
+++ b/content/SCALE/SCALETutorials/SCALETutorialsPrint.md
@@ -5,4 +5,4 @@ weight: 1
 no_print: "true"
 ---
 
-<meta http-equiv="Refresh" content="0; url='/scaletutorials/printview'" />
+<meta http-equiv="Refresh" content="0; url='/scale/scaletutorials/printview'" />

--- a/content/SCALE/SCALEUIReference/PrintPreview.md
+++ b/content/SCALE/SCALEUIReference/PrintPreview.md
@@ -5,4 +5,4 @@ weight: 1
 no_print: "true"
 ---
 
-<meta http-equiv="Refresh" content="0; url='/scaleuireference/printview'" />
+<meta http-equiv="Refresh" content="0; url='/scale/scaleuireference/printview'" />


### PR DESCRIPTION
Likely cruft from versioning change - needed to fix up the url pathways for the SCALE section print views on master branch.
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
