### PR TITLE
Update FusionPoolsCommonContent.md - increased clarity around meta vdev behavior

### DIFF
--- a/content/_includes/FusionPoolsCommonContent.md
+++ b/content/_includes/FusionPoolsCommonContent.md
@@ -3,7 +3,7 @@
 Add SSDs to the new **Metadata VDev** and select the same layout as the **Data VDevs**.
 
 {{< hint type=important >}}
-Metadata VDEVs are critical for pool operation and data integrity, so you must protect them with redundancy measures such as mirroring, and optionally hot spare(s) for additional fault tolerance. It is suggested to use an equal or greater level of failure tolerance in each of your metadata VDEVs; for example, if your data VDEVs are configured as RAIDZ2, consider the use of 3-way mirrors for your metadata VDEVs.
+Metadata VDEVs are critical for pool operation and data integrity. Protect them with redundancy measures such as mirroring, and optionally hot spare(s) for additional fault tolerance. It is suggested to use an equal or greater level of failure tolerance in each of your metadata VDEVs; for example, if your data VDEVs are configured as RAIDZ2, consider the use of 3-way mirrors for your metadata VDEVs.
 {{< /hint >}}
 
 {{< expand "UPS Recommendation" "v" >}}
@@ -14,11 +14,11 @@ Using special VDEVs identical to the data VDEVs (so they can use the same hot sp
 In that case, you must provide hot spare(s) for that drive type as well. Otherwise, if the special VDEV fails and there is no redundancy, the pool becomes corrupted and prevents access to stored data.
 
 {{< hint type=important >}}
-While the metadata VDEV can be adjusted after its addition by attaching or detaching drives, the entire metadata VDEV itself can only be removed from the pool if your data VDEVs are mirrors. *If your pool uses RAIDZ data VDEVs, a metadata VDEV will be a permanent addition to your pool and cannot be removed.*
+While the metadata VDEV can be adjusted after its addition by attaching or detaching drives, the entire metadata VDEV itself can only be removed from the pool when the pool data VDEVs are mirrors. *If the pool uses RAIDZ data VDEVs, a metadata VDEV is a permanent addition to the pool and cannot be removed.*
 {{< /hint >}}
 
 When more than one metadata VDEV is created, then allocations are load-balanced between all these devices.
 If the special class becomes full, then allocations spill back into the normal class.
-Deduplication table data will be placed first onto a dedicated Dedup VDEV, then a Metadata VDEV, and finally the data VDEVs if neither exists.
+Deduplication table data is placed first onto a dedicated Dedup VDEV, then a Metadata VDEV, and finally the data VDEVs if neither exists.
 
-After you create the fusion pool, the **Status** shows a **Special** section with the metadata SSDs.
+Create a fusion pool and **Status** shows a **Special** section with the metadata SSDs.


### PR DESCRIPTION
+ details around protecting meta vdevs with mirroring/equal redundancy to data vdevs
+ warning around permanence of meta vdev when data vdev is RAIDZ
+ note on overflow behavior of ddt (dedup -> special -> data)
