### PR TITLE
23.10 (Cobia): Clarify upgrade options

### DIFF
--- a/content/GettingStarted/23.10Upgrades.md
+++ b/content/GettingStarted/23.10Upgrades.md
@@ -8,6 +8,8 @@ weight: 35
 
 There are a variety of options for upgrading to SCALE 23.10.
 
+{{< include file="/_includes/23.10UpgradeMethods.md" >}}
+
 See the [Software Status page](https://www.truenas.com/software-status/) for iXsystems' software version recommendations based on user type.
 
 ## Upgrading from the Web Interface
@@ -33,10 +35,6 @@ Alternately, uploading a <file>.update</file> file and manually updating switche
 
 Changing trains is a one-way operation!
 Do not change to a prerelease or nightly release unless the system is intended to permanently remain on early versions and is not storing any critical data.
-
-## Upgrading Using an ISO File
-
-{{< include file="/content/_includes/ISOUpgrades.md" >}}
 
 ## Migrating from CORE to SCALE
 

--- a/content/GettingStarted/Migrate/MigratingFromCORE.md
+++ b/content/GettingStarted/Migrate/MigratingFromCORE.md
@@ -24,16 +24,12 @@ This article provides information and instructions for migrating from TrueNAS CO
 {{< include file="/_includes/COREMigratesList.md" >}}
 
 ### Migration Methods
-You can migrate from CORE to SCALE through an upgrade or clean install using an <file>iso</file> file.
+You can migrate from CORE to SCALE through a clean install using an <file>iso</file> file.
 Alternately, some CORE 13.0 releases can migrate using the CORE UI Upgrade function with the SCALE update file downloaded from the website.
-The easiest method is to upgrade from the CORE system UI, but your system must have the CORE 13.0 major release installed to use this method.
+The easiest method is to upgrade from the CORE system UI, but your system must have the CORE 13.0 major release installed and updated to the latest maintenance release to use this method.
 Note the CORE 13.0-U3 release might not work when updating from the CORE UI using the Update function.
 
 If you do a clean-install with a SCALE <file>iso</file> file, you need to reconfigure your CORE settings in SCALE and import your data.
-
-## Migrating Using an ISO File to Upgrade
-
-{{< include file="/_includes/ISOUpgrades.md" >}}
 
 When TrueNAS SCALE boots, you might need to [use the Shell to configure networking interfaces]({{< relref "/SCALEUIReference/Network/_index.md" >}}) to enable GUI accessibility.
 

--- a/content/GettingStarted/SCALEReleaseNotes.md
+++ b/content/GettingStarted/SCALEReleaseNotes.md
@@ -14,6 +14,8 @@ weight: 10
 Log in to the web interface and go to **System Settings > Update** to see an option to switch to the **TrueNAS-SCALE-Cobia-BETA** update train and begin downloading the latest BETA release.
 
 Alternately, to download an <file>.iso</file> file or <file>.update</file> for installing or upgrading to SCALE 23.10-BETA.1 (Cobia), go to https://www.truenas.com/truenas-scale/ and click **Download**.
+
+{{< include file="/_includes/23.10UpgradeMethods.md" >}}
 More details are available from [23.10 Upgrades]({{< relref "23.10Upgrades.md" >}}).
 
 {{< expand "Release Schedule (Click to expand)" "v" >}}
@@ -35,6 +37,12 @@ More details are available from [23.10 Upgrades]({{< relref "23.10Upgrades.md" >
 {{< include file="/content/_includes/23.10FeatureList.md" >}}
 
 ## Upgrade Notes
+
+* {{< hint type="warning" title="ISO Upgrades Unsupported" >}}
+  The only install option supported by the 23.10 (Cobia) <file>ISO</file> installer is **Fresh Install**.
+  The <file>ISO</file> installer upgrade option does not function and is being removed in a later 23.10 (Cobia) maintenance update.
+  Continue to use the TrueNAS SCALE [update process]({{< relref "UpdateSCALE.md" >}}) to seamlessly upgrade from one SCALE major version to another.
+  {{< /hint >}}
 
 * Several built-in services from SCALE 22.12 (Bluefin) or TrueNAS CORE 13.0 in **System Settings > Services** are replaced by community applications.
   You must disable these built-in services and begin using the equivalent application **before** upgrading to SCALE 23.10 (Cobia).

--- a/content/_includes/23.10UpgradeMethods.md
+++ b/content/_includes/23.10UpgradeMethods.md
@@ -1,4 +1,4 @@
 &NewLine;
 
 Upgrading to SCALE 23.10 (Cobia) is primarily done through the web interface [update process]({{< relref "UpdateSCALE.md" >}}).
-Another upgrade option is to restore a [system configuration file]({{< relref "ManageSysConfigSCALE.md" >}}) after performing a [**fresh** install]({{< relref "/GettingStarted/Install/_index.md" >}}) on the system.
+Another upgrade option is to perform a [fresh install]({{< relref "/GettingStarted/Install/_index.md" >}}) on the system and then restore a [system configuration file]({{< relref "ManageSysConfigSCALE.md" >}}).

--- a/content/_includes/23.10UpgradeMethods.md
+++ b/content/_includes/23.10UpgradeMethods.md
@@ -1,0 +1,4 @@
+&NewLine;
+
+Upgrading to SCALE 23.10 (Cobia) is primarily done through the web interface [update process]({{< relref "UpdateSCALE.md" >}}).
+Another upgrade option is to restore a [system configuration file]({{< relref "ManageSysConfigSCALE.md" >}}) after performing a [**fresh** install]({{< relref "/GettingStarted/Install/_index.md" >}}) on the system.

--- a/words-to-ignore.txt
+++ b/words-to-ignore.txt
@@ -1591,3 +1591,4 @@ GooglePhotosAPIClickEnable
 Multiprotocol
 multiprotocol
 MixedModeShares
+UpgradeMethods


### PR DESCRIPTION
- Write a single source text snippet that clarifies the only recommended upgrade methods for Cobia releases and include in the 23.10 release notes and upgrade methods articles.
- Add an additional admonition against using the installer upgrade option to the 23.10 relnotes article.
- Review the other installation docs and purge any inclusion of the .iso upgrade option (not currently supported in Cobia).



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
