### PR TITLE
Hardware links fixes

### DIFF
--- a/content/Hardware/ExpansionShelves.md
+++ b/content/Hardware/ExpansionShelves.md
@@ -32,7 +32,7 @@ descr="Deployment guide for TrueNAS ES24 Expansion Shelf." >}}
 {{< imagecard image="/images/Hardware/ExpansionShelves/ES24FBSG.png" title="ES24F Basic Setup Guide" link="https://www.truenas.com/docs/files/ES24FBSG1.2.pdf"
 descr="Deployment guide for TrueNAS ES24F Expansion Shelf." >}}
 
-{{< imagecard image="/images/Hardware/ExpansionShelves/ES60BSG.png" title="ES50 Basic Setup Guide" link="https://www.truenas.com/docs/files/ES60BSG1.94.pdf"
+{{< imagecard image="/images/Hardware/ExpansionShelves/ES60BSG.png" title="ES60 Basic Setup Guide" link="https://www.truenas.com/docs/files/ES60BSG1.94.pdf"
 descr="Deployment guide for TrueNAS ES60 Expansion Shelf." >}}
 
 {{< imagecard image="/images/Hardware/ExpansionShelves/ES102BSG.png" title="ES102 Basic Setup Guide" link="https://www.truenas.com/docs/files/ES102BSG1.1.pdf"

--- a/content/Hardware/MSeries.md
+++ b/content/Hardware/MSeries.md
@@ -26,8 +26,8 @@ descr="Deployment guide for 3rd Generation TrueNAS M-Series Systems." >}}
 {{< imagecard image="/images/Hardware/MSeries/MSeriesHANetworking1.png" title="HA Networking" link="https://www.truenas.com/docs/files/MSeriesHANetworking1.0.pdf"
 descr="Additional cabling examples for High Availability M-Series systems." >}}
 
-{{< imagecard image="/images/Hardware/NetworkPortID.png" title="Network Port IDs" link="https://www.truenas.com/docs/hardware/mseries/mseriesnetworkportids/"
-descr="TrueNAS SCALE identifications list of TrueNAS M-Series systems network ports." >}}
+<!-- {{< imagecard image="/images/Hardware/NetworkPortID.png" title="Network Port IDs" link="https://www.truenas.com/docs/hardware/mseries/mseriesnetworkportids/"
+descr="TrueNAS SCALE identifications list of TrueNAS M-Series systems network ports." >}}-->
 
 {{< imagecard image="/images/Hardware/MSeries/MSeriesOOBM.png" title="Out-of-Band Management" link="https://www.truenas.com/docs/files/MSeriesOOBM3.1.pdf"
 descr="BIOS configuration instructions for TrueNAS M-Series systems." >}}
@@ -35,8 +35,8 @@ descr="BIOS configuration instructions for TrueNAS M-Series systems." >}}
 {{< imagecard image="/images/Hardware/MSeries/MSeriesSOV.png" title="Statement of Volatility" link="https://www.truenas.com/docs/files/m-series-sov.pdf"
 descr="iXsystems official Statement of Volatility for M-Series systems." >}}
 
-{{< imagecard image="/images/Hardware/MSeries/NVDIMMUpdates.png" title="NVDIMM Updates" link="https://www.truenas.com/docs/hardware/mseries/nvdimmupdates/"
-descr="Procedure to update M-Series NVDIMMs firmware." >}}
+<!-- {{< imagecard image="/images/Hardware/MSeries/NVDIMMUpdates.png" title="NVDIMM Updates" link="https://www.truenas.com/docs/hardware/mseries/nvdimmupdates/"
+descr="Procedure to update M-Series NVDIMMs firmware." >}} -->
 
 {{< imagecard image="/images/Hardware/MSeries/MSeriesStencil.png" title="Hardware Stencils" link="https://www.truenas.com/docs/files/truenasmmodels.vssx"
 descr="Download M-Series stencils to diagram your TrueNAS hardware configuration." >}}

--- a/content/Hardware/Mini.md
+++ b/content/Hardware/Mini.md
@@ -19,8 +19,8 @@ descr="Deployment guide for 3rd Generation TrueNAS Mini Systems." >}}
 {{< imagecard image="/images/Hardware/Minis/MiniRBSG.png" title="Mini R Basic Setup Guide" link="https://www.truenas.com/docs/files/MiniRBSG1.0.pdf"
 descr="Deployment guide for TrueNAS Mini R Systems." >}}
 
-{{< imagecard image="/images/Hardware/NetworkPortID.png" title="Network Port IDs" link="https://www.truenas.com/docs/hardware/mini/mininetworkportids/"
-descr="TrueNAS identifications list of TrueNAS Mini systems network ports." >}}
+<!-- {{< imagecard image="/images/Hardware/NetworkPortID.png" title="Network Port IDs" link="https://www.truenas.com/docs/hardware/mini/mininetworkportids/"
+descr="TrueNAS identifications list of TrueNAS Mini systems network ports." >}} -->
 
 {{< imagecard image="/images/Hardware/Minis/MiniE+HUG.png" title="Mini E+ Hardware Upgrades" link="https://www.truenas.com/docs/files/MiniE+HardwareUpgradesGuide1.1.pdf"
 descr="Hardware Upgrade Guide for TrueNAS Mini E+." >}}

--- a/content/Hardware/RSeries.md
+++ b/content/Hardware/RSeries.md
@@ -28,8 +28,8 @@ descr="Deployment Guide for TrueNAS R30 systems." >}}
 {{< imagecard image="/images/Hardware/RSeries/R50BSG.png" title="R50 Basic Setup Guide" link="https://www.truenas.com/docs/files/R50BSG3.0.pdf"
 descr="Deployment Guide for 3rd Generation TrueNAS R50 systems." >}}
 
-{{< imagecard image="/images/Hardware/NetworkPortID.png" title="Network Port IDs" link="https://www.truenas.com/docs/hardware/rseries/rseriesnetworkportids/"
-descr="TrueNAS SCALE identifications list of TrueNAS R-Series systems network ports." >}}
+<!-- {{< imagecard image="/images/Hardware/NetworkPortID.png" title="Network Port IDs" link="https://www.truenas.com/docs/hardware/rseries/rseriesnetworkportids/"
+descr="TrueNAS SCALE identifications list of TrueNAS R-Series systems network ports." >}} -->
 
 {{< imagecard image="/images/Hardware/RSeries/RSeriesOOBM.png" title="Out-of-Band Management" link="https://www.truenas.com/docs/files/RSeriesOOBM1.1.pdf"
 descr="BIOS configuration instructions for TrueNAS R-Series systems." >}}

--- a/content/Hardware/XSeries.md
+++ b/content/Hardware/XSeries.md
@@ -19,10 +19,10 @@ icon4="IconGraph.png" cell4title="Proven Platform" cell4text="1000+ Successful d
 
 <div class="docs-sections">
 
-{{< imagecard image="/images/Hardware/XSeries/XSeriesBSG.png" title="Basic Setup Guide" link="https://www.truenas.com/docs/files/F-SeriesPRG.pdf"
+{{< imagecard image="/images/Hardware/XSeries/XSeriesBSG.png" title="Basic Setup Guide" link="https://www.truenas.com/docs/files/XSeriesBSG1.91.pdf"
 descr="Deployment guide for TrueNAS X-Series Systems." >}}
 
-{{< imagecard image="/images/Hardware/XSeries/XSeriesHANetworking.png" title="HA Networking" link="https://www.truenas.com/docs/files/MSeriesHANetworking1.0.pdf"
+{{< imagecard image="/images/Hardware/XSeries/XSeriesHANetworking.png" title="HA Networking" link="https://www.truenas.com/docs/files/XSeriesHANetworking1.0.pdf"
 descr="Additional cabling examples for High Availability X-Series systems." >}}
 
 {{< imagecard image="/images/Hardware/NetworkPortID.png" title="Network Port IDs" link="https://www.truenas.com/docs/hardware/xseries/xseriesnetworkportids/"

--- a/content/Hardware/XSeries.md
+++ b/content/Hardware/XSeries.md
@@ -25,8 +25,8 @@ descr="Deployment guide for TrueNAS X-Series Systems." >}}
 {{< imagecard image="/images/Hardware/XSeries/XSeriesHANetworking.png" title="HA Networking" link="https://www.truenas.com/docs/files/XSeriesHANetworking1.0.pdf"
 descr="Additional cabling examples for High Availability X-Series systems." >}}
 
-{{< imagecard image="/images/Hardware/NetworkPortID.png" title="Network Port IDs" link="https://www.truenas.com/docs/hardware/xseries/xseriesnetworkportids/"
-descr="TrueNAS identifications list of TrueNAS X-Series systems network ports." >}}
+<!--{{< imagecard image="/images/Hardware/NetworkPortID.png" title="Network Port IDs" link="https://www.truenas.com/docs/hardware/xseries/xseriesnetworkportids/"
+descr="TrueNAS identifications list of TrueNAS X-Series systems network ports." >}}-->
 
 {{< imagecard image="/images/Hardware/XSeries/XSeriesSOV.png" title="Statement of Volatility" link="https://www.truenas.com/docs/files/x-series-sov.pdf"
 descr="iXsystems official Statement of Volatility for X-Series systems." >}}


### PR DESCRIPTION
Internal report that some X-Series docs cards links were in error.
Reviewed links for each of the reworked sections and fixed a number of issues.
I've commented out the Network Port IDs for each family and the M-Series NVDIMM replace card until we can finish investigating and do a clean resolution.
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
