### PR TITLE
Update InstallTCDocker.md

### DIFF
--- a/content/TrueCommand/TCGettingStarted/Install/InstallTCDocker.md
+++ b/content/TrueCommand/TCGettingStarted/Install/InstallTCDocker.md
@@ -4,6 +4,8 @@ description: "Describes the steps to install the TrueCommand container in Docker
 weight: 40
 tags:
 - docker
+- container
+- truecommand
 - install
 ---
 
@@ -11,7 +13,7 @@ tags:
 ## Installing the TrueCommand Container
 
 {{< hint type=note >}}
-If you have not installed Docker on your machine, install the [Docker Engine](https://docs.docker.com/engine/install/debian/), then install [Docker Desktop](https://docs.docker.com/desktop/linux/).
+If you have not installed Docker on your machine, install the [Docker Engine](https://docs.docker.com/engine/install/debian/) and [Docker Desktop](https://docs.docker.com/desktop/linux/), or use [Podman](https://podman.io/).
 {{< /hint >}}
 
 To run TrueCommand in Docker on Linux, you must have:
@@ -26,7 +28,7 @@ Enter <code>mkdir <i>directory</i></code>, where *directory* is the new name.
 
 After creating the new directory, fetch and run the TrueCommand Docker image.
 
-Open a terminal and enter <code>docker run \--detach -v "/<i>hostdir</i>:/data" -p port:<i>80</i> -p ssl:<i>443</i> ixsystems/truecommand:<i>latest</i></code>.
+Open a terminal and enter <code>docker run \--detach -v "/<i>hostdir</i>:/data" -p port:<i>80</i> -p ssl:<i>443</i> ghcr.io/ixsystems/truecommand:<i>v2.3.3</i></code>.
 
 Where *hostdir* is a directory on the host machine for Docker container data, *80* is the TrueCommand web interface port number, and *443* is the port number for secure web interface access.
 
@@ -34,25 +36,24 @@ Where *hostdir* is a directory on the host machine for Docker container data, *8
 SSL provides extra security in network communications.
 {{< /hint >}}
 
-To install the container with an earlier TrueCommand release, replace *latest* with the desired TrueCommand version tag. 
+To install the container with an earlier TrueCommand release, replace *v2.3.3* with the desired TrueCommand version tag. 
 For example:  
-`docker run \--detach -v "/DockerDir:/data" -p 9004:80 -p 9005:443 ixsystems/truecommand:1.3.2`
+`docker run \--detach -v "/DockerDir:/data" -p 9004:80 -p 9005:443 ghcr.io/ixsystems/truecommand:release-3.0.0-RC.1`
 
-To install the container with the nightly TrueCommand release, replace *latest* with *nightly*:  
-`docker run \--detach -v "/DockerDir:/data" -p 9004:80 -p 9005:443 ixsystems/truecommand:nightly`
+To install the container with the nightly TrueCommand release, replace *v2.3.3* with *latest*:  
+`docker run \--detach -v "/DockerDir:/data" -p 9004:80 -p 9005:443 ghcr.io/ixsystems/truecommand:latest`
 
 {{< hint type=important >}}
 Only use the nightly version on test systems.
 {{< /hint >}}
 
-Although Docker containers have several run methods, TrueCommand requires`-v /hostdirectory:/data` to function.
+Although Docker containers have several run methods, TrueCommand requires a bind mount or docker volume manage to keep the database consistent between runs.
+Recreating the database will create a new system ID and invalidate a previously created license.
 
 {{< hint type=important >}}
 Do not try to use the same host directory for two different containers!
 Doing so results in file conflicts and database corruption.
 {{< /hint >}}
-
-For a list of TrueCommand versions and tags, see [Truecommand Docker](https://hub.docker.com/r/ixsystems/truecommand/tags).
 
 ## Accessing the TrueCommand Web Interface
 After fetching the TrueCommand Docker container, enter `docker ps` to see details about running containers.
@@ -61,11 +62,13 @@ After fetching the TrueCommand Docker container, enter `docker ps` to see detail
 
 Use the port assigned to the container to access the web interface.
 The list from `docker ps` contains a PORTS column.
-Find the port associated with the `ixsystems/truecommand:latest IMAGE`.
+Find the port associated with the `ghcr.io/ixsystems/truecommand` image.
 The PORTS entry is listed as `0.0.0.0:port->80/tcp`, `0.0.0.0:sslport->443/tcp` where *port* and *sslport* are the ports specified earlier.
 
 To access the web interface with no encryption, enter `hostsystemIPaddress:port` in a browser address bar, where *hostsystemIPaddress* is the IP address of the host system that is running the TrueCommand Docker container.
 To access the web interface with standard SSL encryption, enter `https://hostsystemIPaddress:sslport` in a browser address bar.
+
+Access the container directly via shell with `docker exec -it CONTAINER_ID /bin/bash` to make advanced configuration changes.
 
 {{< expand "The connection cannot be established?" "v" >}}
 If you cannot establish a connection to the web interface, add the container ports as an exception to the host system firewall.


### PR DESCRIPTION
Change image versions.
Added exec command description.
Expanded on the need for a bind mount (-v) or other volume management and the consequences therein. Included podman desktop link as an alternative to docker.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
