### PR TITLE
Add temporary alias for dragonfish nightly release notes

### DIFF
--- a/content/SCALE/GettingStarted/SCALEReleaseNotes.md
+++ b/content/SCALE/GettingStarted/SCALEReleaseNotes.md
@@ -5,6 +5,7 @@ aliases:
  - /scalenext-releasenotes/
  - /scale/scalenextversion/
  - /scale/scale22.12/
+ - /scale/24.04/gettingstarted/scalereleasenotes/
 weight: 10
 related: false
 ---


### PR DESCRIPTION
This alias needs to be removed when scale 24.04 docs are branched.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
