### PR TITLE
PD-890: 13.0-U6.1 release note

### DIFF
--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -23,11 +23,13 @@ weight: 3
 {{< /truetable >}}
 
 ## 13.0-U6.1
-**TBD, 2023**
+**December 5, 2023**
 
-iXsystems is pleased to release TrueNAS CORE 13.0-U6.1.
+iXsystems is pleased to release TrueNAS CORE 13.0-U6.1!
 
-This is a small update to 13.0-U6 to address an issue with 
+This is a small update to 13.0-U6 to add an OpenZFS fix for a rare but potentially severe data corruption bug.
+To date, this bug has not been reported or observed on any deployed TrueNAS system.
+To read additional details about the issue, history, and developer discussion, see [OpenZFS issue #15526](https://github.com/openzfs/zfs/issues/15526), [OpenZFS pull request #15571](https://github.com/openzfs/zfs/pull/15571), and this [OpenZFS developer summary](https://gist.github.com/rincebrain/e23b4a39aba3fadc04db18574d30dc73).
 
 ## 13.0-U6
 **November 21, 2023**

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -23,14 +23,13 @@ weight: 3
 {{< /truetable >}}
 
 ## 13.0-U6.1
-**December 5, 2023**
+**December 7, 2023**
 
 iXsystems is pleased to release TrueNAS CORE 13.0-U6.1!
 
-This is a small update to 13.0-U6 to add an OpenZFS fix for a rare but potentially severe data corruption bug.
-To date, this bug has not been reported to have occurred on any deployed TrueNAS system in production.
-
-To read additional details about the issue, history, and developer discussion, see this [OpenZFS developer summary](https://gist.github.com/rincebrain/e23b4a39aba3fadc04db18574d30dc73), [OpenZFS issue #15526](https://github.com/openzfs/zfs/issues/15526), and [OpenZFS pull request #15571](https://github.com/openzfs/zfs/pull/15571).
+This is a small update to 13.0-U6 to [update OpenZFS to version 2.1.14](https://github.com/openzfs/zfs/releases/tag/zfs-2.1.14) and fix a data integrity issue discovered in that project.
+While this bug has been present in OpenZFS for many years, this issue has not been found to impact any TrueNAS systems to date.
+This [TrueNAS Community annoucement](https://www.truenas.com/community/threads/old-openzfs-issue-found-and-being-resolved.114556/) has further details.
 
 ## 13.0-U6
 **November 21, 2023**

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -29,7 +29,7 @@ iXsystems is pleased to release TrueNAS CORE 13.0-U6.1!
 
 This is a small update to 13.0-U6 to [update OpenZFS to version 2.1.14](https://github.com/openzfs/zfs/releases/tag/zfs-2.1.14) and fix a data integrity issue discovered in that project.
 While this bug has been present in OpenZFS for many years, this issue has not been found to impact any TrueNAS systems to date.
-This [TrueNAS Community annoucement](https://www.truenas.com/community/threads/old-openzfs-issue-found-and-being-resolved.114556/) has further details.
+This [TrueNAS Community announcement](https://www.truenas.com/community/threads/old-openzfs-issue-found-and-being-resolved.114556/) has further details.
 
 ## 13.0-U6
 **November 21, 2023**

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -28,9 +28,9 @@ weight: 3
 iXsystems is pleased to release TrueNAS CORE 13.0-U6.1!
 
 This is a small update to 13.0-U6 to add an OpenZFS fix for a rare but potentially severe data corruption bug.
-
 To date, this bug has not been reported to have occurred on any deployed TrueNAS system in production.
-To read additional details about the issue, history, and developer discussion, see [OpenZFS issue #15526](https://github.com/openzfs/zfs/issues/15526), [OpenZFS pull request #15571](https://github.com/openzfs/zfs/pull/15571), and this [OpenZFS developer summary](https://gist.github.com/rincebrain/e23b4a39aba3fadc04db18574d30dc73).
+
+To read additional details about the issue, history, and developer discussion, see this [OpenZFS developer summary](https://gist.github.com/rincebrain/e23b4a39aba3fadc04db18574d30dc73), [OpenZFS issue #15526](https://github.com/openzfs/zfs/issues/15526), and [OpenZFS pull request #15571](https://github.com/openzfs/zfs/pull/15571).
 
 ## 13.0-U6
 **November 21, 2023**

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -28,7 +28,8 @@ weight: 3
 iXsystems is pleased to release TrueNAS CORE 13.0-U6.1!
 
 This is a small update to 13.0-U6 to add an OpenZFS fix for a rare but potentially severe data corruption bug.
-To date, this bug has not been reported or observed on any deployed TrueNAS system.
+
+To date, this bug has not been reported to have occurred on any deployed TrueNAS system in production.
 To read additional details about the issue, history, and developer discussion, see [OpenZFS issue #15526](https://github.com/openzfs/zfs/issues/15526), [OpenZFS pull request #15571](https://github.com/openzfs/zfs/pull/15571), and this [OpenZFS developer summary](https://gist.github.com/rincebrain/e23b4a39aba3fadc04db18574d30dc73).
 
 ## 13.0-U6

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -19,9 +19,15 @@ weight: 3
 {{< truetable >}}
 | Version | Checkpoint       | Scheduled Date       |
 |---------|------------------|----------------------|
-| 13.0-U6 | Tag              | 20 November 2023     |
-| 13.0-U6 | **Release**      | **21 November 2023** |
+| TBD     |                  |                      |
 {{< /truetable >}}
+
+## 13.0-U6.1
+**TBD, 2023**
+
+iXsystems is pleased to release TrueNAS CORE 13.0-U6.1.
+
+This is a small update to 13.0-U6 to address an issue with 
 
 ## 13.0-U6
 **November 21, 2023**


### PR DESCRIPTION
This is a small PR for the 13.0-U6.1 hotpatch. It has a single draft note regarding the OpenZFS version update. Additional notes to be added as needed before the U6.1 release.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
