### PR TITLE
PD-911: Add TC 3.0.0 clustering compatibility text and inject in 3 articles

### DIFF
--- a/content/Solutions/Integrations/SMBClustering.md
+++ b/content/Solutions/Integrations/SMBClustering.md
@@ -21,6 +21,8 @@ It is intended for early testing and research purposes only.
 
 ## Requirements
 
+{{< include file="/_includes/TC3.0ClusterCompatWarning.md" >}}
+
 {{< include file="/content/_includes/ClusterRequirements.md" >}}
 
 ## Warnings and Restrictions

--- a/content/TrueCommand/TCGettingStarted/TCReleaseNotes.md
+++ b/content/TrueCommand/TCGettingStarted/TCReleaseNotes.md
@@ -69,6 +69,8 @@ TrueCommand 3.0 is tested and compatible with these TrueNAS versions:
 * SCALE 22.12
 * SCALE 23.10 - High Availability systems are not yet fully supported.
 
+{{< include file="/_includes/TC3.0ClusterCompatWarning.md" >}}
+
 ### Paths
 
 Self-hosted Containers:
@@ -109,6 +111,7 @@ This is the first public release of TrueCommand 3.0 for early testing and review
 
 Notable changes:
 * Allow reusing IP address/hostname for TrueNAS connections ([TC-2672](https://ixsystems.atlassian.net/browse/TC-2672)).
+* Clusterin
 * Additional warnings on cluster feature ([TC-2630](https://ixsystems.atlassian.net/browse/TC-2630))
 * Default ports updated: 443 on TrueCommand Cloud deployments and 80 on self-hosted containers ([TC-2573](https://ixsystems.atlassian.net/browse/TC-2573))
 * Bug fixes for SAML user creation ([TC-2532](https://ixsystems.atlassian.net/browse/TC-2532))

--- a/content/TrueCommand/TCGettingStarted/TCReleaseNotes.md
+++ b/content/TrueCommand/TCGettingStarted/TCReleaseNotes.md
@@ -111,7 +111,6 @@ This is the first public release of TrueCommand 3.0 for early testing and review
 
 Notable changes:
 * Allow reusing IP address/hostname for TrueNAS connections ([TC-2672](https://ixsystems.atlassian.net/browse/TC-2672)).
-* Clusterin
 * Additional warnings on cluster feature ([TC-2630](https://ixsystems.atlassian.net/browse/TC-2630))
 * Default ports updated: 443 on TrueCommand Cloud deployments and 80 on self-hosted containers ([TC-2573](https://ixsystems.atlassian.net/browse/TC-2573))
 * Bug fixes for SAML user creation ([TC-2532](https://ixsystems.atlassian.net/browse/TC-2532))

--- a/content/TrueCommand/UserGuide/Clusters.md
+++ b/content/TrueCommand/UserGuide/Clusters.md
@@ -13,18 +13,16 @@ aliases:
 {{< hint type="warning" title="Experimental Feature" >}}
 TrueCommand-managed clusters is an experimental feature and must not be used for production or critical data management.
 It is intended for early testing and research purposes only.
+Before using such features, please back up all your data.
+Do not rely on this for critical data.
 {{< /hint >}}
 
 TrueCommand 2.3 (and later), in conjunction with TrueNAS SCALE 22.12.0 (and later), can create and manage clusters, cluster volumes, and cluster volume shares.
 
+{{< include file="/_includes/TC3.0ClusterCompatWarning.md" >}}
+
 This article describes the various screens used for clustering. 
 If you want to create and integrate clusters, see [Clustering and Sharing SCALE Volumes with TrueCommand]({{< relref "/Solutions/Integrations/SMBClustering.md" >}})
-
-{{< hint type=warning >}}
-Clusters are an experimental feature in TrueCommand.
-Before using such features, please back up all your data.
-Do not rely on this for critical data.
-{{< /hint >}}
 
 ## Clusters
 

--- a/content/_includes/TC3.0ClusterCompatWarning.md
+++ b/content/_includes/TC3.0ClusterCompatWarning.md
@@ -2,7 +2,7 @@
 
 {{< hint type="warning" title="Clustering Compatibility" >}}
 TrueCommand 3.0.0 introduced a significant rebuild of the TrueNAS SCALE clustering feature.
-This is to allow for greater stability, upgradability, and less disruptive changes in the future.
+This is to allow for greater stability, upgradeability, and less disruptive changes in the future.
 This changes which TrueNAS SCALE versions are compatible with TrueCommand-managed clustering:
 
 * SCALE 22.12 TrueNAS SCALE deployments can continue to use the clustering feature present in TrueCommand 2.3.3 or earlier.

--- a/content/_includes/TC3.0ClusterCompatWarning.md
+++ b/content/_includes/TC3.0ClusterCompatWarning.md
@@ -1,0 +1,12 @@
+&NewLine;
+
+{{< hint type="warning" title="Clustering Compatibility" >}}
+TrueCommand 3.0.0 introduced a significant rebuild of the TrueNAS SCALE clustering feature.
+This is to allow for greater stability, upgradability, and less disruptive changes in the future.
+This changes which TrueNAS SCALE versions are compatible with TrueCommand-managed clustering:
+
+* SCALE 22.12 TrueNAS SCALE deployments can continue to use the clustering feature present in TrueCommand 2.3.3 or earlier.
+* SCALE 23.10 and later TrueNAS SCALE deployments must use the clustering feature present in TrueCommand 3.0.0 and later.
+
+Upgrading a TrueCommand deployment with a SCALE cluster to 3.0.0 requires updating the SCALE systems to 23.10 and redeploying the cluster.
+{{< /hint >}}

--- a/words-to-ignore.txt
+++ b/words-to-ignore.txt
@@ -1647,6 +1647,6 @@ InstallMinioAddConfiguration
 InstallMinioEnableDistributedMode
 PlexMedia
 plex
-
+upgradeability
 
 


### PR DESCRIPTION
Provide explanation of impact and clarify which versions of SCALE are compatible with which versions of TrueCommand clustering feature.

PR is in draft while I ask TC leadership for review.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
