### PR TITLE
Nightly Dev home page polish and some early 13.1 development notes

### DIFF
--- a/content/CORE/GettingStarted/COREReleaseNotes.md
+++ b/content/CORE/GettingStarted/COREReleaseNotes.md
@@ -44,7 +44,6 @@ More details are available from [Updating Core]({{< relref "/core/coretutorials/
 {{< include file="/content/_includes/ReleaseScheduleWarning.md" >}}
 
 {{< releaselist name=core-releases >}}
-<br>
 {{< /expand >}}
 
 ## Major Component Versions

--- a/content/CORE/GettingStarted/COREReleaseNotes.md
+++ b/content/CORE/GettingStarted/COREReleaseNotes.md
@@ -47,10 +47,11 @@ More details are available from [Updating Core]({{< relref "/core/coretutorials/
 <br>
 {{< /expand >}}
 
-## Component Versions
+## Major Component Versions
 
 Click the component version number to see the latest release notes for that component.
-<table class="truetable" style="width:25%;">
+
+<table class="truetable" style="width:40%;margin-left:0;margin-right:auto">
   <tr>
     <th>Component</th>
 	<th>Version</th>
@@ -73,4 +74,4 @@ Notable changes:
   See the CORE 13.0 tutorial for [detailed migration instructions](http://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/plugins/minioplugin/).
   See also [Feature Deprecations]({{< relref "Deprecations.md" >}}).
 
-* The web UI **Shell** is removed in CORE 13.1. Users can continue to access the shell using [SSH]({{< relref "ConfiguringSSH.md" >}}) or a local connection. <!-- Add NAS ticket when available -->
+* The web UI **Shell** is removed in CORE 13.1. Users can continue to access the shell using [SSH]({{< relref "ConfiguringSSH.md" >}}) or a physical system connection with serial cable or other direct method. <!-- Add NAS ticket when available -->

--- a/content/CORE/GettingStarted/COREReleaseNotes.md
+++ b/content/CORE/GettingStarted/COREReleaseNotes.md
@@ -73,4 +73,4 @@ Notable changes:
   See the CORE 13.0 tutorial for [detailed migration instructions](http://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/plugins/minioplugin/).
   See also [Feature Deprecations]({{< relref "Deprecations.md" >}}).
 
-* The web UI **Shell** is removed in CORE 13.1. Users can continue to access the shell using [SSH]({{< relref "ConfiguringSSH.md" >}}) or a physical system connection with serial cable or other direct method. <!-- Add NAS ticket when available -->
+* The web UI **Shell** is removed in CORE 13.1. Users can continue to access the shell using [SSH]({{< relref "ConfiguringSSH.md" >}}) or a physical system connection with serial cable or other direct method ([NAS-124392](https://ixsystems.atlassian.net/browse/NAS-124392)).

--- a/content/CORE/GettingStarted/COREReleaseNotes.md
+++ b/content/CORE/GettingStarted/COREReleaseNotes.md
@@ -47,6 +47,22 @@ More details are available from [Updating Core]({{< relref "/core/coretutorials/
 <br>
 {{< /expand >}}
 
+## Component Versions
+
+Click the component version number to see the latest release notes for that component.
+<table class="truetable" style="width:25%;">
+  <tr>
+    <th>Component</th>
+	<th>Version</th>
+  </tr>
+  <tr>
+    <td>FreeBSD</td><td><a href="https://www.freebsd.org/releases/13.2R/relnotes/">13.2-RELEASE-p6</a></td>
+  </tr>
+  <tr>
+	<td>OpenZFS</td><td><a href="https://github.com/openzfs/zfs/releases/tag/zfs-2.2.2">2.2.2-1</a></td>
+  </tr>
+</table>
+
 ## Nightly Changelog
 
 Notable changes:
@@ -56,4 +72,5 @@ Notable changes:
   Users should migrate to a separately maintained [MinIO plugin]({{< relref "MinIOPlugin.md" >}}) or otherwise move any production data away from the S3 service storage location before upgrading to a 13.1 pre-release version.
   See the CORE 13.0 tutorial for [detailed migration instructions](http://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/plugins/minioplugin/).
   See also [Feature Deprecations]({{< relref "Deprecations.md" >}}).
+
 * The web UI **Shell** is removed in CORE 13.1. Users can continue to access the shell using [SSH]({{< relref "ConfiguringSSH.md" >}}) or a local connection. <!-- Add NAS ticket when available -->

--- a/content/CORE/_index.md
+++ b/content/CORE/_index.md
@@ -44,22 +44,22 @@ To view documentation for historical or the latest stable TrueNAS CORE major ver
 
 <div class="docs-sections">
   <p>
-	<a href="/core/gettingstarted/" style="font-size:18px;">Getting Started Guide</a>
+	Getting Started Guide
 	<br><a href="/core/gettingstarted/corereleasenotes/">Release Notes</a>
 	<br><a href="/core/gettingstarted/corehardwareguide/">Community Hardware Guide</a>
 	<br><a href="/core/gettingstarted/install/">Software Install</a>
   </p>
   <p>
-	<a href="/core/coretutorials/" style="font-size:18px;">Tutorials</a>
-	<br><a href="/core/coretutorials/network/">Networking Tutorials</a>
-	<br><a href="/core/coretutorials/storage/">Storage Tutorials</a>
-	<br><a href="/core/coretutorials/sharing/">Sharing Tutorials</a>
+	Tutorials
+	<br><a href="/core/coretutorials/network/">Networking</a>
+	<br><a href="/core/coretutorials/storage/">Storage</a>
+	<br><a href="/core/coretutorials/sharing/">Sharing</a>
   </p>
   <p>
-	<a href="/core/uireference/" style="font-size:18px;">UI Reference Guide</a>
-	<br><a href="/core/uireference/system/">System Screens</a>
-	<br><a href="/core/uireference/network/">Network Screens</a>
-	<br><a href="/core/uireference/storage/">Storage Screens</a>
+	UI Reference Guide
+	<br><a href="/core/uireference/system/">System</a>
+	<br><a href="/core/uireference/network/">Network</a>
+	<br><a href="/core/uireference/storage/">Storage</a>
   </p>
   <p>
 	Additional Content


### PR DESCRIPTION
Quick cleanup of the links on the CORE index page and add a Major Component Versions subsection to the development notes with FreeBSD and OpenZFS versions.
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
