### PR TITLE
CORE 13.1 - Release notes adds and virtualization support notice updates

### DIFF
--- a/content/CORE/CORETutorials/JailsPluginsVMs/Jails/AccessingJailsUsingSSH.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Jails/AccessingJailsUsingSSH.md
@@ -6,6 +6,10 @@ tags:
 - jails
 ---
 
+{{< hint type=important title="Unsupported Feature" >}}
+{{< include file="content/_includes/COREFeatureSupport.md" >}}
+{{< /hint >}}
+
 ## Accessing a Jail Using SSH
 
 You must enable the ssh daemon [sshd(8)](https://www.freebsd.org/cgi/man.cgi?query=sshd) in a jail to allow SSH access to that jail from another system.

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Jails/InstallingJailSoftware.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Jails/InstallingJailSoftware.md
@@ -8,6 +8,10 @@ tags:
 - plugins
 ---
 
+{{< hint type=important title="Unsupported Feature" >}}
+{{< include file="content/_includes/COREFeatureSupport.md" >}}
+{{< /hint >}}
+
 A jail is created with no software aside from the core packages installed as part of the selected version of FreeBSD.
 To install software into a jail, go to the **Jails** screen and expand the jail entry.
 Start the jail, then after the jail boots, click **> SHELL**.

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Jails/ManagingJails.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Jails/ManagingJails.md
@@ -8,6 +8,10 @@ tags:
 - plugins
 ---
 
+{{< hint type=important title="Unsupported Feature" >}}
+{{< include file="content/_includes/COREFeatureSupport.md" >}}
+{{< /hint >}}
+
 The **Jails** screen displays a list of jails installed on your system.
 
 ![Jails](/images/CORE/Jails/Jails.png "Jails List")

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Jails/SettingUpJailStorage.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Jails/SettingUpJailStorage.md
@@ -8,6 +8,10 @@ tags:
 - plugins
 ---
 
+{{< hint type=important title="Unsupported Feature" >}}
+{{< include file="content/_includes/COREFeatureSupport.md" >}}
+{{< /hint >}}
+
 Jails can be given access to an area of storage outside of the jail that is configured on the TrueNAS system.
 It is possible to give a FreeBSD jail access to an area of storage on the TrueNAS system.
 This is useful for applications or plugins that store large amounts of data or if an application in a jail needs access to data stored on the TrueNAS system.

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Jails/_index.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Jails/_index.md
@@ -12,8 +12,7 @@ tags:
 - plugins
 ---
 
-
-{{< hint type=note >}}
+{{< hint type=important title="Unsupported Feature" >}}
 {{< include file="content/_includes/COREFeatureSupport.md" >}}
 {{< /hint >}}
 

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/CreatingCustomPlugin.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/CreatingCustomPlugin.md
@@ -7,13 +7,13 @@ tags:
 - plugins
 ---
 
+{{< hint type=important title="Unsupported Feature" >}}
+{{< include file="content/_includes/COREFeatureSupport.md" >}}
+{{< /hint >}}
+
 Plugins are a technology for easily and securely deploying 3rd party applications directly on TrueNAS storage systems.
 The web interface allows users to deploy, start, stop, and update applications, along with configuration tasks such as assigning storage to them.
 Plugins are popular for content, security, development, collaboration, and backup applications for home and business use.
-
-{{< hint type=note >}}
-{{< include file="content/_includes/COREFeatureSupport.md" >}}
-{{< /hint >}}
 
 {{< expand "Plugin Technology" "v" >}}
 [Jails](https://docs.freebsd.org/en/books/handbook/jails/) form the core of TrueNAS plugins.

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/PlexPlugin.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/PlexPlugin.md
@@ -7,6 +7,10 @@ tags:
 - plugins
 ---
 
+{{< hint type=important title="Unsupported Feature" >}}
+{{< include file="content/_includes/COREFeatureSupport.md" >}}
+{{< /hint >}}
+
 This tutorial provides instructions on adding the community-favorite [Plex](https://www.plex.tv/) application as a plugin.
 You need an account with Plex to complete these instructions.
 

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/_index.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/_index.md
@@ -10,7 +10,7 @@ tags:
 - plugins
 ---
 
-{{< hint type=note >}}
+{{< hint type=important title="Unsupported Feature" >}}
 {{< include file="content/_includes/COREFeatureSupport.md" >}}
 {{< /hint >}}
 

--- a/content/CORE/CORETutorials/JailsPluginsVMs/UpdateJailsPlugins.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/UpdateJailsPlugins.md
@@ -7,6 +7,10 @@ tags:
 - plugins
 ---
 
+{{< hint type=important title="Unsupported Feature" >}}
+{{< include file="content/_includes/COREFeatureSupport.md" >}}
+{{< /hint >}}
+
 The **Jails** screen displays a list of jails installed on your system.
 
 ![Jails](/images/CORE/Jails/Jails.png "Jails List")

--- a/content/CORE/GettingStarted/COREReleaseNotes.md
+++ b/content/CORE/GettingStarted/COREReleaseNotes.md
@@ -7,6 +7,7 @@ aliases:
   - /releasenotes/core/13.0rc1/
   - /releasenotes/core/
   - /core/corereleasenotes/
+  - /core/13.1/gettingstarted/corereleasenotes/
 related: false
 ---
 
@@ -45,8 +46,12 @@ More details are available from [Updating Core]({{< relref "/core/coretutorials/
 
 {{< releaselist name=core-releases >}}
 {{< /expand >}}
+<!-- Update for RC.1 release
+## Upgrade Notes
 
-## Major Component Versions
+### Upgrade Paths
+-->
+## Component Versions
 
 Click the component version number to see the latest release notes for that component.
 
@@ -63,6 +68,22 @@ Click the component version number to see the latest release notes for that comp
   </tr>
 </table>
 
+### New OpenZFS Feature Flags
+The items listed here represent new feature flags implemented since the previous update to the built-in OpenZFS version.
+
+{{< truetable >}}
+| Feature Flag | GUID | Notes |
+|--------------|------|-------|
+| blake3 | [org.openzfs:blake3](https://openzfs.github.io/openzfs-docs/man/master/7/zpool-features.7.html#org.openzfs:blake3) | |
+| block_cloning | [com.fudosecurity:block_cloning](https://openzfs.github.io/openzfs-docs/man/master/7/zpool-features.7.html#com.fudosecurity:block_cloning) | |
+| draid | [org.openzfs:draid](https://openzfs.github.io/openzfs-docs/man/master/7/zpool-features.7.html#org.openzfs:draid) | draid is not supported in the TrueNAS CORE web interface. See [TrueNAS SCALE](https://www.truenas.com/truenas-scale/) for this feature. |
+| head_errlog | [com.delphix:head_errlog](https://openzfs.github.io/openzfs-docs/man/master/7/zpool-features.7.html#com.delphix:head_errlog) | |
+| vdev_zaps_v2 | [com.klarasystems:vdev_zaps_v2](https://openzfs.github.io/openzfs-docs/man/master/7/zpool-features.7.html#com.klarasystems:vdev_zaps_v2) | |
+| zilsaxattr | [org.openzfs:zilsaxattr](https://openzfs.github.io/openzfs-docs/man/master/7/zpool-features.7.html#org.openzfs:zilsaxattr) |  |
+{{< /truetable >}}
+
+For more details on feature flags see [OpenZFS Feature Flags](https://openzfs.github.io/openzfs-docs/Basic%20Concepts/Feature%20Flags.html) and [OpenZFS zpool-feature.7](https://openzfs.github.io/openzfs-docs/man/7/zpool-features.7.html).
+
 ## Nightly Changelog
 
 Notable changes:
@@ -74,3 +95,6 @@ Notable changes:
   See also [Feature Deprecations]({{< relref "Deprecations.md" >}}).
 
 * The web UI **Shell** is removed in CORE 13.1. Users can continue to access the shell using [SSH]({{< relref "ConfiguringSSH.md" >}}) or a physical system connection with serial cable or other direct method ([NAS-124392](https://ixsystems.atlassian.net/browse/NAS-124392)).
+
+* The Plugins, Jails, and Virtual Machines features are in maintenance mode and are offered to the TrueNAS community "as-is".
+  [TrueNAS Enterprise](https://www.truenas.com/truenas-enterprise/) customers with a critical need for virtualization features should consider TrueNAS SCALE for officially tested and supported virtualization features.

--- a/content/CORE/UIReference/JailsPluginsVMs/JailsScreens.md
+++ b/content/CORE/UIReference/JailsPluginsVMs/JailsScreens.md
@@ -6,6 +6,10 @@ tags:
 - jails
 ---
 
+{{< hint type=important title="Unsupported Feature" >}}
+{{< include file="content/_includes/COREFeatureSupport.md" >}}
+{{< /hint >}}
+
 The Jails screen displays a list of jails installed on your system. Use to add, edit or delete jails.
 
 ![JailsScreen](/images/CORE/Jails/JailsScreen.png "Jails Screen")

--- a/content/CORE/UIReference/JailsPluginsVMs/PluginsScreens.md
+++ b/content/CORE/UIReference/JailsPluginsVMs/PluginsScreens.md
@@ -7,6 +7,10 @@ tags:
 - plugins
 ---
 
+{{< hint type=important title="Unsupported Feature" >}}
+{{< include file="content/_includes/COREFeatureSupport.md" >}}
+{{< /hint >}}
+
 Use the **Plugins** screen to install and maintain 3rd party applications on your TrueNAS storage systems.
 
 ![PluginsScreen](/images/CORE/Plugins/PluginsScreen.png "Plugins Screen")

--- a/content/CORE/UIReference/JailsPluginsVMs/VirtualMachines.md
+++ b/content/CORE/UIReference/JailsPluginsVMs/VirtualMachines.md
@@ -7,6 +7,10 @@ tags:
 - plugins
 ---
 
+{{< hint type=important title="Unsupported Feature" >}}
+{{< include file="content/_includes/COREFeatureSupport.md" >}}
+{{< /hint >}}
+
 The Virtual Machines screen displays a list of virtual machines (VM) configured on your system.
 
 ![VirtualMachinesScreen](/images/CORE/VirtualMachines/VirtualMachinesScreen.png "Virtual Machines")

--- a/content/CORE/UIReference/JailsPluginsVMs/_index.md
+++ b/content/CORE/UIReference/JailsPluginsVMs/_index.md
@@ -6,6 +6,12 @@ weight: 130
 related: false
 ---
 
+{{< hint type=important title="Unsupported Feature" >}}
+{{< include file="content/_includes/COREFeatureSupport.md" >}}
+{{< /hint >}}
+
+This section describes the various screens and options available for deploying resource-minimal FreeBSD jails or fully virtualized operating systems.
+
 ## Jails, Plugins, and Virtual Machine Contents
 
 {{< children depth="2" description="true" >}}


### PR DESCRIPTION
Add a few more items to the latest dev notes, in preparation for cutting over to 13.1-RC.1 release. Update the unsupported feature caution used in the beginning of the CORE plugins, jails, and vms content and apply to the parallel UI reference content.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
