### PR TITLE
Update the CLI shortcode

### DIFF
--- a/layouts/shortcodes/cli.html
+++ b/layouts/shortcodes/cli.html
@@ -1,6 +1,7 @@
 {{ $id := printf "cli-%x" (sha1 .Inner) }}
 <code class="cli-cmd" id="{{ $id }}">
-  {{ .Inner | markdownify }}
+  {{ $content := .Inner | replaceRE "\\*\\*(.*?)\\*\\*" "<b>$1</b>" | replaceRE "\\*(.*?)\\*" "<i>$1</i>" }}
+  {{ $content | safeHTML }}
   <button class="cli-cmd-copy" data-cmd="{{ .Inner }}" data-target="{{ $id }}">
     <span class="copy-icon"><span class="iconify" data-icon="mdi:content-copy"></span></span>
     <span class="checkmark-icon" style="display: none;"><span class="iconify checkmark" data-icon="mdi:check"></span></span>


### PR DESCRIPTION
- shortcode now renders content as preformatted to avoid automatic rendering issue.
EXCEPT:
- Using asterisks as markdown formatting calls for bold and italics will still render the contained content. Example: {{< cli >}}**command** --name=test ***variable** italic*{{< /cli >}} renders the string with the asterisks properly translating to bold, italic, or even stacked bold and italic.
- The copy button continues to pull only the raw rendered text without formatting.
- Note that asterisks won't be usable as raw code text (i.e. part of a command) without proper escaping.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
