### PR TITLE
ToC Panel polish

### DIFF
--- a/layouts/partials/menu-nextprev.html
+++ b/layouts/partials/menu-nextprev.html
@@ -88,7 +88,7 @@
 
 <div class="content-cta">
 	{{ with .IsPage }}
-  <h3 style="margin-top: 0;">Have more Questions?</h3>
+  <p style="margin-top: 0;"><b>Have more questions?</b></p>
 	<p>For further discussion or assistance, see these resources:</p>
 	<ul>
 	  <li><a href="https://www.truenas.com/community/">TrueNAS Community Forum</a></li>

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -57,7 +57,7 @@
   {{ end }}
   {{ if or (in .Section "CORE") (in .Section "SCALE") (in .Section "TrueCommand") }}
   <div class="version-doc">
-    <h3>Nightly Development</h3>
+    <p><b>Nightly Development</b></p>
     <p>
       This content follows experimental early release software.
       Use the <b>Product and Version</b> selectors above to view content specific to a stable software release.

--- a/layouts/partials/related-content.html
+++ b/layouts/partials/related-content.html
@@ -50,11 +50,11 @@
 {{ $currentBookContent := where $relatedContent "Params.book" $currentBook }}
 
 {{ if gt (len $currentBookContent) 1 }}
-  <h3 style="">Related Content</h3>
+  <h2>Related Content</h2>
   <div class="columns">
     <div class="column">
       {{ $currentBookInfo := index (where $books "name" $currentBook) 0 }}
-      <h4>{{ with $currentBookInfo }}{{ .title }}{{ end }}</h4>
+      <b>{{ with $currentBookInfo }}{{ .title }}{{ end }}</b>
       <ul>
         {{ $count := 0 }}
         {{ range $currentBookContent }}
@@ -84,11 +84,11 @@
       {{ end }}
       {{ if $hasRelatedTagsInCurrentBook }}
         {{ if eq $columnCount 0 }}
-          <h3>Related Content</h3>
+          <h2>Related Content</h2>
           <div class="columns">
         {{ end }}
         <div class="column">
-          <h4>{{ $title }}</h4>
+          <b>{{ $title }}</b>
           <ul>
             {{ range $content }}
               {{ if and (ne .RelPermalink $currentPermalink) (lt $count 5) }}

--- a/layouts/partials/related-content.html
+++ b/layouts/partials/related-content.html
@@ -28,8 +28,8 @@
 
   .column {
     width: 25%;
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-left: 1rem;
+    padding-right: 1rem;
   }
 
   h3 {

--- a/layouts/partials/toc-panel.html
+++ b/layouts/partials/toc-panel.html
@@ -1,38 +1,34 @@
-<nav class="toc-panel">
-  {{- $tocLevels := default (default 1 .Site.Params.GeekdocToC) .Page.Params.GeekdocToC }}
+<nav class="toc-panel" style="display: none;">
   <b>Page Sections:</b>
-  {{- if and $tocLevels .Page.TableOfContents -}}
-    <div class="gdoc-toc gdoc-toc__level--{{ $tocLevels }}">
-      {{ .Page.TableOfContents | replaceRE "<ul>" "<ul class=\"toc-list\">" | safeHTML }}
-    </div>
-  {{- end -}}
+  <ul class="toc-list" style="list-style: none; padding-left: 0;">
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        var tocList = document.querySelector('.toc-list');
+        var headers = document.querySelectorAll('.gdoc-page h2, .gdoc-page h3, .gdoc-page h4');
+        
+        headers.forEach(function(header) {
+          var level = header.tagName.toLowerCase().replace('h', '');
+          var text = header.innerText;
+          var anchor = text.toLowerCase().replace(/\s/g, '-');
 
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      var tocLinks = document.querySelectorAll('.toc-list a');
-      var sidebarRight = document.querySelector('.sidebar-right');
-      var gdocPage = document.querySelector('.gdoc-page');
+          var tocItem = document.createElement('li');
+          var tocLink = document.createElement('a');
+          tocLink.textContent = text;
+          tocLink.href = '#' + anchor;
 
-      if (tocLinks.length <= 1) {
-        sidebarRight.style.display = 'none';
-        gdocPage.style.marginRight = '0';
-      }
+          tocItem.appendChild(tocLink);
+          tocList.appendChild(tocItem);
+          header.id = anchor;
 
-      tocLinks.forEach(function(link) {
-        link.addEventListener('click', function(event) {
-          event.preventDefault();
-
-          var targetId = link.getAttribute('href').substring(1);
-          var targetElement = document.getElementById(targetId);
-
-          if (targetElement) {
-            window.scrollTo({
-              top: targetElement.offsetTop - 16,
-              behavior: 'smooth'
-            });
-          }
+          tocItem.id = 'toc-' + level + '-' + anchor; // Unique ID based on header level
+          tocItem.style.marginLeft = (level === '3') ? '1em' : (level === '4') ? '2em' : '0';
+          tocItem.style.fontSize = (level === '3') ? '13px' : (level === '4') ? '12ox' : 'inherit';
         });
+		var tocPanel = document.querySelector('.toc-panel');
+        if (document.querySelectorAll('.toc-list li').length > 1) {
+          tocPanel.style.display = 'block';
+        }
       });
-    });
-  </script>
+    </script>
+  </ul>
 </nav>

--- a/layouts/partials/toc-panel.html
+++ b/layouts/partials/toc-panel.html
@@ -1,4 +1,4 @@
-<nav class="toc-panel" style="display: none;">
+<nav class="toc-panel">
   <b>Page Sections:</b>
   <ul class="toc-list" style="list-style: none; padding-left: 0;">
     <script>
@@ -7,26 +7,30 @@
         var headers = document.querySelectorAll('.gdoc-page h2, .gdoc-page h3, .gdoc-page h4');
         
         headers.forEach(function(header) {
-          var level = header.tagName.toLowerCase().replace('h', '');
-          var text = header.innerText;
-          var anchor = text.toLowerCase().replace(/\s/g, '-');
+          // Ignore headers within <details> elements
+          if (!header.closest('details')) {
+            var level = header.tagName.toLowerCase().replace('h', '');
+            var text = header.innerText;
+            var anchor = text.toLowerCase().replace(/\s/g, '-');
 
-          var tocItem = document.createElement('li');
-          var tocLink = document.createElement('a');
-          tocLink.textContent = text;
-          tocLink.href = '#' + anchor;
+            var tocItem = document.createElement('li');
+            var tocLink = document.createElement('a');
+            tocLink.textContent = text;
+            tocLink.href = '#' + anchor;
 
-          tocItem.appendChild(tocLink);
-          tocList.appendChild(tocItem);
-          header.id = anchor;
+            tocItem.appendChild(tocLink);
+            tocList.appendChild(tocItem);
+            header.id = anchor;
 
-          tocItem.id = 'toc-' + level + '-' + anchor; // Unique ID based on header level
-          tocItem.style.marginLeft = (level === '3') ? '1em' : (level === '4') ? '2em' : '0';
-          tocItem.style.fontSize = (level === '3') ? '13px' : (level === '4') ? '12ox' : 'inherit';
+            tocItem.id = 'toc-' + level + '-' + anchor; // Unique ID based on header level
+            tocItem.style.marginLeft = (level === '3') ? '1em' : (level === '4') ? '2em' : '0';
+            tocItem.style.fontSize = (level === '3') ? '13px' : (level === '4') ? '12px' : 'inherit';
+          }
         });
-		var tocPanel = document.querySelector('.toc-panel');
-        if (document.querySelectorAll('.toc-list li').length > 1) {
-          tocPanel.style.display = 'block';
+
+        var sidebarRight = document.querySelector('.sidebar-right');
+        if (document.querySelectorAll('.toc-list li').length < 2) {
+          sidebarRight.style.display = 'none';
         }
       });
     </script>


### PR DESCRIPTION
Update this layout to better find the html header elements, including those injected by hugo shortcodes. Headers within HTML details elements are currently being ignored.
Apply some styling rules to the toc-panel entries to better denote h2, h3, or h4 headers.
Remove some h# elements applied to automatically generated elements to avoid overpopulating the toc-panel with less relevant entries.
Local build testing - no issues discovered so far and logic to remove the panel when the list has fewer than 2 entries is preserved.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
