### PR TITLE
Documentation updated truecommand install for 3.0.0 to work.

### DIFF
--- a/content/TrueCommand/TCGettingStarted/Install/InstallTCDocker.md
+++ b/content/TrueCommand/TCGettingStarted/Install/InstallTCDocker.md
@@ -36,7 +36,7 @@ Enter <code>mkdir <i>directory</i></code>, where *directory* is the new name.
 
 After creating the new directory, fetch and run the TrueCommand image.
 
-Open a terminal and enter {{< cli >}}docker run \--detach -v "/<i>hostdir</i>:/data" -p port:<i>80</i> -p ssl:<i>443</i> ghcr.io/ixsystems/truecommand:<i>3.0.0</i>{{< /cli >}}.
+Open a terminal and enter {{< cli >}}docker run \--detach -v "/<i>hostdir</i>:/data" -p port:<i>80</i> -p ssl:<i>443</i> ghcr.io/ixsystems/truecommand:<i>v3.0.0</i>{{< /cli >}}.
 
 Where *hostdir* is a directory on the host machine for Docker container data, *80* is the TrueCommand web interface port number, and *443* is the port number for secure web interface access.
 

--- a/content/TrueCommand/TCGettingStarted/Install/InstallTCDocker.md
+++ b/content/TrueCommand/TCGettingStarted/Install/InstallTCDocker.md
@@ -40,9 +40,9 @@ Open a terminal and enter {{< cli >}}docker run \--detach -v "/<i>hostdir</i>:/d
 
 Where *hostdir* is a directory on the host machine for Docker container data, *80* is the TrueCommand web interface port number, and *443* is the port number for secure web interface access.
 
-To install the container with an earlier TrueCommand release, replace *3.0.0* with the desired TrueCommand version tag.
+To install the container with an earlier TrueCommand release, replace *v3.0.0* with the desired TrueCommand version tag.
 For example:
-`docker run \--detach -v "/DockerDir:/data" -p 9004:80 -p 9005:443 ghcr.io/ixsystems/truecommand:2.3.3`
+`docker run \--detach -v "/DockerDir:/data" -p 9004:80 -p 9005:443 ghcr.io/ixsystems/truecommand:v2.3.3`
 
 To preview the latest features in a non-production experimental environment, install the container with the latest TrueCommand development build:
 `docker run \--detach -v "/DockerDir:/data" -p 9004:80 -p 9005:443 ghcr.io/ixsystems/truecommand:latest`


### PR DESCRIPTION
no tag exists in repository for 3.0.0, so command fails. tag is v3.0.0

https://github.com/orgs/iXsystems/packages/container/truecommand/versions?filters%5Bversion_type%5D=tagged

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
