### PR TITLE
Polish "where am I" notice at top of nightly version content pages

### DIFF
--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -55,13 +55,32 @@
       </span>
     </div>
   {{ end }}
-  {{ if or (in .Section "CORE") (in .Section "SCALE") (in .Section "TrueCommand") }}
-  <div class="version-doc">
-    <h3>Nightly Development</h3>
-    <p>
-      This content follows experimental early release software.
-      Use the <b>Product and Version</b> selectors above to view content specific to a stable software release.
-    </p>
-  </div>
-{{ end }}
 </div>
+{{ if in .Section "CORE" }}
+<blockquote class="gdoc-hint warning" style="margin-bottom:1rem;">
+  <div class="gdoc-hint__title flex align-center">
+    <img src="/favicon/TN-favicon-32x32.png" alt="TrueNAS CORE" title="CORE Nightly Development Documentation" style="padding-right:.75rem;"></img>TrueNAS CORE Nightly Development Documentation
+  </div>
+  <div class="gdoc-hint__text" style="font-size:smaller;">
+    This content follows experimental early release software. Use the <b>Product</b> and <b>Version</b> selectors above to view content specific to a stable software release.
+  </div>
+</blockquote>
+{{ else if in .Section "SCALE" }}
+<blockquote class="gdoc-hint warning">
+  <div class="gdoc-hint__title flex align-center">
+    <img src="/favicon/TNScale-favicon-32x32.png" alt="TrueNAS SCALE" title="SCALE Nightly Development Documentation" style="padding-right:.75rem;"></img>TrueNAS SCALE Nightly Development Documentation
+  </div>
+  <div class="gdoc-hint__text" style="font-size:smaller;">
+    This content follows experimental early release software. Use the <b>Product</b> and <b>Version</b> selectors above to view content specific to a stable software release.
+  </div>
+</blockquote>
+{{ else if in .Section "TrueCommand" }}
+<blockquote class="gdoc-hint warning">
+  <div class="gdoc-hint__title flex align-center">
+    <img src="/favicon/TC-favicon-32x32.png" alt="TrueNAS SCALE" title="TrueCommand Nightly Development Documentation" style="padding-right:.75rem;"></img>TrueCommand Nightly Development Documentation
+  </div>
+  <div class="gdoc-hint__text" style="font-size:smaller;">
+    This content follows experimental early release software. Use the <b>Product</b> and <b>Version</b> selectors above to view content specific to a stable software release.
+  </div>
+</blockquote>
+{{ end }}

--- a/static/custom.css
+++ b/static/custom.css
@@ -416,6 +416,7 @@ p,h1,h2,h3,h4,th,td,a,body {
 /* Adjust breadcrumb header sizing */
 .gdoc-page__header {
 	font-size: small;
+	margin-bottom: 1rem;
 }
 /* Add right sidebar for page TOCs */
 .sidebar-right {


### PR DESCRIPTION
Break out the notice to it's own warning hint box and apply conditionally to the different software docs sections (CORE, SCALE, TrueCommand). Do some local build testing and css adjustments for polish.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
