### PR TITLE
Some post-merges cleanups

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -64,9 +64,12 @@
             {{ partial "menu-nextprev" . }}
           </div>
         </div>
-		<aside class="sidebar-right">
-		  {{ partial "toc-panel" . }}
-		</aside>
+		{{ $isTrueNASUpgrades := eq .Section "TrueNASUpgrades" }}
+		{{ if not $isTrueNASUpgrades }}
+		  <aside class="sidebar-right">
+		    {{ partial "toc-panel" . }}
+		  </aside>
+		{{ end }}
       </main>
 
       {{ partial "site-footer" . }}

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -57,15 +57,18 @@
   {{ end }}
 </div>
 {{ if in .Section "CORE" }}
-<blockquote class="gdoc-hint warning" style="margin-bottom:1rem;">
-  <div class="gdoc-hint__title flex align-center">
+<article class="gdoc-markdown">
+<blockquote class="gdoc-hint warning version-note" style="margin-bottom:1rem;">
+  <div class="gdoc-hint__title flex align-center vnote-title">
     <img src="/favicon/TN-favicon-32x32.png" alt="TrueNAS CORE" title="CORE Nightly Development Documentation" style="padding-right:.75rem;"></img>TrueNAS CORE Nightly Development Documentation
   </div>
   <div class="gdoc-hint__text" style="font-size:smaller;">
     This content follows experimental early release software. Use the <b>Product</b> and <b>Version</b> selectors above to view content specific to a stable software release.
   </div>
 </blockquote>
+</article>
 {{ else if in .Section "SCALE" }}
+<article class="gdoc-markdown">
 <blockquote class="gdoc-hint warning">
   <div class="gdoc-hint__title flex align-center">
     <img src="/favicon/TNScale-favicon-32x32.png" alt="TrueNAS SCALE" title="SCALE Nightly Development Documentation" style="padding-right:.75rem;"></img>TrueNAS SCALE Nightly Development Documentation
@@ -74,13 +77,16 @@
     This content follows experimental early release software. Use the <b>Product</b> and <b>Version</b> selectors above to view content specific to a stable software release.
   </div>
 </blockquote>
+</article>
 {{ else if in .Section "TrueCommand" }}
-<blockquote class="gdoc-hint warning">
-  <div class="gdoc-hint__title flex align-center">
+<article class="gdoc-markdown">
+<blockquote class="gdoc-hint warning version-note">
+  <div class="gdoc-hint__title flex align-center vnote-title">
     <img src="/favicon/TC-favicon-32x32.png" alt="TrueNAS SCALE" title="TrueCommand Nightly Development Documentation" style="padding-right:.75rem;"></img>TrueCommand Nightly Development Documentation
   </div>
   <div class="gdoc-hint__text" style="font-size:smaller;">
     This content follows experimental early release software. Use the <b>Product</b> and <b>Version</b> selectors above to view content specific to a stable software release.
   </div>
 </blockquote>
+</article>
 {{ end }}

--- a/layouts/shortcodes/imagecard.html
+++ b/layouts/shortcodes/imagecard.html
@@ -3,8 +3,7 @@
       <img class="prod-card-img" src="{{ .Get "image" }}" aria-label="{{ .Get "title" }} Documentation Page">
   </div>
   <div class="section-tab-content ixprods">
-    <h2 style="justify-content:center";>{{ .Get "title" }}</h2>
+    <b style="justify-content:center;font-size:1.5rem;font-weight:600;">{{ .Get "title" }}</b>
     <p>{{ .Get "descr" }}</p>
   </div>
 </a>
-


### PR DESCRIPTION
1. Adjust toc-panel to ignore the TrueNASUpgrades section when generating.
2. Adjust imagecard shortcode (used in TrueNAS Systems) to not use h2 elements and cause extra toc panel entries.
3. Update the whereamI note to be consistent with gdoc hint warning styling and light/dark modes.
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
