### PR TITLE
PD-974: Update sessions token lifetime max value (23.10)

### DIFF
--- a/content/_includes/SessionsSettingsWidget.md
+++ b/content/_includes/SessionsSettingsWidget.md
@@ -36,7 +36,7 @@ The default lifetime setting is 300 seconds, or five minutes.
 
 The minimum value allowed is 30 seconds.
 
-The maximum is 2147482 seconds, or 20 hours, 31 minutes, and 22 seconds.
+The maximum is 2147482 seconds, or 24 days, 20 hours, 31 minutes, and 22 seconds.
 {{< /hint >}}
 
 Click **Save**.


### PR DESCRIPTION
Investigated and identified that the UI does not appear to show the number of days the raw seconds value translates to, only the remainder hours/minutes/seconds. Updated the text guidance to show the correct max value and will follow up as needed with Engineering regarding the days value not being displayed.

Note that this widget is renamed to Access in the latest nightly dev, so will need to review the master branch docs separately.
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
