### PR TITLE
Pd 917 roles and privileges updates

### DIFF
--- a/content/SCALE/SCALETutorials/Credentials/ManageLocalGroups.md
+++ b/content/SCALE/SCALETutorials/Credentials/ManageLocalGroups.md
@@ -7,6 +7,12 @@ tags:
  - groups
 ---
 
+
+{{< hint type=warning title="Privileges">}}
+The **Groups** screen shows a **Privileges** button for use with role-based access and permissions.
+This feature is still in development not recommended for use at this time.
+{{< /hint >}} 
+
 TrueNAS offers groups as an efficient way to manage permissions for many similar user accounts.
 See [Users]({{< relref "ManageLocalUsersSCALE.md" >}}) for managing users.
 The interface lets you manage UNIX-style groups.

--- a/content/SCALE/SCALETutorials/Credentials/ManageLocalGroups.md
+++ b/content/SCALE/SCALETutorials/Credentials/ManageLocalGroups.md
@@ -8,7 +8,7 @@ tags:
 ---
 
 
-{{< hint type=warning title="Privileges">}}
+{{< hint type=info title="Privileges">}}
 The **Groups** screen shows a **Privileges** button for use with role-based access and permissions.
 This feature is still in development not recommended for use at this time.
 {{< /hint >}} 

--- a/content/SCALE/SCALEUIReference/Credentials/LocalGroupsScreens.md
+++ b/content/SCALE/SCALEUIReference/Credentials/LocalGroupsScreens.md
@@ -7,7 +7,7 @@ tags:
  - groups
 ---
 
-{{< hint type=warning title="Privileges">}}
+{{< hint type=info title="Privileges">}}
 The **Groups** screen shows a **Privileges** button for use with role-based access and permissions.
 This feature is still in development not recommended for use at this time.
 {{< /hint >}} 

--- a/content/SCALE/SCALEUIReference/Credentials/LocalGroupsScreens.md
+++ b/content/SCALE/SCALEUIReference/Credentials/LocalGroupsScreens.md
@@ -7,6 +7,11 @@ tags:
  - groups
 ---
 
+{{< hint type=warning title="Privileges">}}
+The **Groups** screen shows a **Privileges** button for use with role-based access and permissions.
+This feature is still in development not recommended for use at this time.
+{{< /hint >}} 
+
 ## Groups Screen
 
 The **Credentials > Local Groups** screen displays a list of groups configured on the screen. By default, built-in groups are hidden until you make them visible. 


### PR DESCRIPTION
This PR adds an "info" admonition box to the Groups Screen and Managing Groups article to make users aware of the Privileges button but this is not a function ready to use.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
