### PR TITLE
Refine site search (master branch)

### DIFF
--- a/jenkins/update-dev1
+++ b/jenkins/update-dev1
@@ -15,7 +15,7 @@ pipeline {
             sh 'npm install -D --save autoprefixer'
             sh 'npm install -D --save postcss-cli'
             sh 'hugo -d public --gc --minify --cleanDestinationDir'
-            sh 'npx pagefind --site "public"'
+            sh 'npx pagefind --site "public" --glob "{api,archive,contributing,core,hardware,references,scale,softwarestatus,solutions,truecommand,truenasupgrades}/**/*.html"'
         }
     }
     stage('Publish') {

--- a/jenkins/update-master
+++ b/jenkins/update-master
@@ -15,7 +15,7 @@ pipeline {
             sh 'npm install -D --save autoprefixer'
             sh 'npm install -D --save postcss-cli'
             sh 'hugo -d public --gc --minify --cleanDestinationDir'
-            sh 'npx pagefind --site "public"'
+            sh 'npx pagefind --site "public" --glob "{api,archive,contributing,core,hardware,references,scale,softwarestatus,solutions,truecommand,truenasupgrades}/**/*.html"'
         }
     }
     stage('Publish') {

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -30,7 +30,6 @@
     <!-- End Google Tag Manager (noscript) -->
 	{{ partial "svg-icon-symbols" . }}
 
-
     <div
       class="wrapper {{ if default false .Site.Params.GeekdocDarkModeDim }}dark-mode-dim{{ end }}"
     >
@@ -39,7 +38,6 @@
       <input type="checkbox" class="hidden" id="menu-header-control" />
       {{ $navEnabled := default true .Page.Params.GeekdocNav }}
       {{ partial "site-header" (dict "Root" . "MenuEnabled" $navEnabled) }}
-
 
       <main class="container flex">
 		<button class="scrollToTopBtn" title="Back to top">&#10148;</button>
@@ -56,7 +54,7 @@
           {{ end }}
 
           {{ if .Params.related | default true }}
-          <div class="gdoc-page__footer justify-center" style="margin-bottom: 0;">
+          <div class="gdoc-page__footer justify-center" style="margin-bottom: 0;" data-pagefind-ignore>
             {{ partial "related-content.html" . }}
           </div>
           {{ end }}

--- a/layouts/_default/baseof.print.html
+++ b/layouts/_default/baseof.print.html
@@ -15,7 +15,7 @@
               </div>
               <div class="d-none d-xl-block col-xl-2 td-toc d-print-none">
               </div>
-              <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+              <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main" data-pagefind-ignore>
                 {{ block "main" . }}{{ end }}
               </main>
             </div>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,0 +1,49 @@
+{{ define "main" }}
+  {{ range .Paginator.Pages }}
+    <article class="gdoc-post" data-pagefind-ignore>
+      <header class="gdoc-post__header">
+        <h1 class="gdoc-post__title">
+          <a href="{{ .RelPermalink }}">{{ partial "utils/title" . }}</a>
+        </h1>
+      </header>
+
+      <section class="gdoc-markdown">
+        {{ .Summary }}
+      </section>
+
+      <div class="gdoc-post__readmore">
+        {{ if .Truncated }}
+          <a
+            class="flex-inline align-center fake-link"
+            title="{{ i18n "posts_read_more" }}"
+            href="{{ .RelPermalink }}"
+          >
+            {{ i18n "posts_read_more" }}
+            <i class="gdoc-icon">gdoc_arrow_right_alt</i>
+          </a>
+        {{ end }}
+      </div>
+
+      <footer class="gdoc-post__footer">
+        <div class="flex flex-wrap align-center gdoc-post__meta">
+          {{ partial "posts/metadata.html" . }}
+        </div>
+      </footer>
+    </article>
+  {{ end }}
+  {{ partial "pagination.html" . }}
+{{ end }}
+
+{{ define "post-tag" }}
+  <span class="gdoc-post__tag">
+    <span class="gdoc-button">
+      <a
+        class="gdoc-button__link"
+        href="{{ .page.RelPermalink }}"
+        title="{{ i18n "posts_tagged_with" .name }}"
+      >
+        {{ .name }}
+      </a>
+    </span>
+  </span>
+{{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,32 @@
+{{ define "main" }}
+  {{ range .Paginator.Pages.ByTitle }}
+    <article class="gdoc-post" data-pagefind-ignore>
+      <header class="gdoc-post__header">
+        <h1 class="gdoc-post__title">
+          <a href="{{ .RelPermalink }}">{{ partial "utils/title" . }}</a>
+        </h1>
+      </header>
+
+      <footer class="gdoc-post__meta flex align-center">
+        <span class="flex align-center no-wrap">
+          {{ $pageCount := len .Pages }}
+          <svg class="gdoc-icon gdoc_tag"><use xlink:href="#gdoc_tag"></use></svg>
+          <span class="gdoc-post__tag">
+            {{ i18n "posts_count" $pageCount }}
+          </span>
+        </span>
+
+        <span class="flex align-center no-wrap">
+          <svg class="gdoc-icon gdoc_star"><use xlink:href="#gdoc_star"></use></svg>
+          <span>
+            {{ $latet := index .Pages.ByDate 0 }}
+            {{ with $latet }}
+              <a href="{{ .RelPermalink }}">{{ partial "utils/title" . }}</a>
+            {{ end }}
+          </span>
+        </span>
+      </footer>
+    </article>
+  {{ end }}
+  {{ partial "pagination.html" . }}
+{{ end }}

--- a/layouts/partials/print/content.html
+++ b/layouts/partials/print/content.html
@@ -4,7 +4,7 @@
   {{ partial $tpl . }}
 {{ else -}}
 {{ $break := cond .DoPageBreak "page-break-before: always" "" -}}
-<div class="td-content-print" style="{{ $break }}">
+<div class="td-content-print" style="{{ $break }}" data-pagefind-ignore>
     {{ $break := cond .DoPageBreak "page-break-before: always" "" }}
 	<h1 id="pg-{{ .Page.File.UniqueID }}">{{ .PageNum }} - {{ .Page.Title }}</h1>
     {{ with .Page.Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -58,6 +58,8 @@ async function displaySearchResults(query, page) {
                     : result.url.includes("/hardware/") ? `TrueNAS Systems:`
                     : result.url.includes("/contributing/") ? `Contributing:`
                     : result.url.includes("/references/") ? `References:`
+					: result.url.includes("core_websocket") ? `${coreIcon}\u00A0API:`
+					: result.url.includes("scale_websocket") ? `${scaleIcon}\u00A0API:`
                     : `${title}:`;
 
                 resultDiv.innerHTML = `

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -8,7 +8,7 @@ let loadMoreButton; // Cache reference to the load more button
 initPageFind();
 
 async function initPageFind() {
-    pagefind = await import("https://docs-dev.ixsystems.com/pagefind/pagefind.js");
+    pagefind = await import("https://www.truenas.com/docs/pagefind/pagefind.js");
     pagefind.init();
 
     if (query != null) {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -3,76 +3,86 @@ let searchResultsContainer = document.getElementById('results');
 let currentPage = 1;
 const resultsPerPage = 10;
 let pagefind;
+let loadMoreButton; // Cache reference to the load more button
 
 initPageFind();
 
 async function initPageFind() {
-    pagefind = await import("https://www.truenas.com/docs/pagefind/pagefind.js");
+    pagefind = await import("https://docs-dev.ixsystems.com/pagefind/pagefind.js");
     pagefind.init();
 
     if (query != null) {
         document.getElementById("search-input").value = query;
-        displaySearchResults(query, currentPage);
+        await displaySearchResults(query, currentPage);
     }
 }
 
 async function displaySearchResults(query, page) {
-    let button;
     try {
-        let startIndex = (page - 1) * resultsPerPage;
-        let endIndex = startIndex + resultsPerPage;
-
         let results = await pagefind.search(query);
-
-        let paginatedResults = results.results.slice(startIndex, endIndex);
+        let paginatedResults = results.results;
         let slicedResults = await Promise.all(paginatedResults.map(r => r.data()));
 
-        searchResultsContainer.innerHTML = '';
-        if (!document.getElementById("loadMoreButton") == null) {
-            document.getElementById("loadMoreButton").classList.remove("loading");
+        let startIndex = (page - 1) * resultsPerPage;
+        let endIndex = startIndex + resultsPerPage;
+        let paginatedSlicedResults = slicedResults.slice(startIndex, endIndex);
+
+        if (loadMoreButton) {
+            loadMoreButton.classList.remove("loading");
         }
-        if (slicedResults.length === 0) {
-            searchResultsContainer.innerHTML = 'No results found.';
+
+        if (paginatedSlicedResults.length === 0) {
+            if (currentPage === 1) {
+                searchResultsContainer.innerHTML = 'No results found.';
+            } else {
+                let noMoreResultsMessage = document.createElement('div');
+                noMoreResultsMessage.innerHTML = '<p>No more results.</p>';
+                searchResultsContainer.appendChild(noMoreResultsMessage);
+            }
         } else {
             let fragment = document.createDocumentFragment();
 
-            slicedResults.forEach((result, index) => {
+            paginatedSlicedResults.forEach((result, index) => {
                 let resultDiv = document.createElement('div');
-                let title = result.meta.title.charAt(0).toUpperCase() + result.meta.title.slice(1)
+                let title = result.meta.title.charAt(0).toUpperCase() + result.meta.title.slice(1);
+
+                // Add section marker in front of the <a>
+                let coreIcon = '<img src="/favicon/TN-favicon-32x32.png" alt="TrueNAS CORE" title="TrueNAS CORE" class="icon">';
+                let scaleIcon = '<img src="/favicon/TNScale-favicon-32x32.png" alt="TrueNAS SCALE" title="TrueNAS SCALE" class="icon">';
+                let tcIcon = '<img src="/favicon/TC-favicon-32x32.png" alt="TrueCommand" title="TrueCommand" class="icon">';
+
+                let linkText = result.url.includes("/core/") ? `${coreIcon}`
+                    : result.url.includes("/scale/") ? `${scaleIcon}`
+                    : result.url.includes("/truecommand/") ? `${tcIcon}`
+                    : result.url.includes("/solutions/") ? `Solutions:`
+                    : result.url.includes("/hardware/") ? `TrueNAS Systems:`
+                    : result.url.includes("/contributing/") ? `Contributing:`
+                    : result.url.includes("/references/") ? `References:`
+                    : `${title}:`;
+
                 resultDiv.innerHTML = `
-                  <h3>${startIndex + index + 1}. <a href="${result.url}">${title}</a></h3>
-                  <p>${result.excerpt}</p>
+                    <h3>${linkText}&ensp;<a href="${result.url}">${title}</a></h3>
+                    <p>${result.excerpt}</p>
+                    <hr>
                 `;
                 fragment.appendChild(resultDiv);
             });
 
+            // Append the new results fragment to existing content
             searchResultsContainer.appendChild(fragment);
 
-            let button;
-            if (document.getElementById("loadMoreButton") == null) {
-                button = document.createElement("a");
-                button.classList.add("absolute-center");
-                button.classList.add("button");
-                button.textContent = "Load more results";
-                button.id = "loadMoreButton";
-                button.addEventListener('click', loadMoreResults);
-            } else {
-                button = document.getElementById("loadMoreButton");
-            }
+            // Check if there are more results to display
+            const hasMoreResults = slicedResults.length > endIndex;
 
-            if (results.results.length > endIndex) {
-                document.getElementById("results").parentNode.appendChild(button);
-                button.classList.remove("loading");
-                button.style.display = 'block';
-
-                let v = document.documentElement;
-                v.scrollTo({
-                    top: 0,
-                    behavior: "smooth"
-                })
-            } else {
-                button.classList.remove("loading");
-                button.style.display = 'none';
+            // Show/hide the load more button
+            if (hasMoreResults) {
+                if (!loadMoreButton) {
+                    loadMoreButton = createLoadMoreButton();
+                }
+                loadMoreButton.classList.remove("loading");
+                loadMoreButton.style.display = 'block';
+            } else if (loadMoreButton) {
+                loadMoreButton.style.display = 'none';
             }
         }
 
@@ -85,7 +95,19 @@ async function displaySearchResults(query, page) {
 async function loadMoreResults() {
     currentPage++;
     let query = new URLSearchParams(window.location.search).get("query");
-    let loadMoreButton = document.getElementById('loadMoreButton');
-    loadMoreButton.classList.add("loading");
+    if (loadMoreButton) {
+        loadMoreButton.classList.add("loading");
+    }
     await displaySearchResults(query, currentPage);
+}
+
+function createLoadMoreButton() {
+    const button = document.createElement("a");
+    button.classList.add("absolute-center");
+    button.classList.add("button");
+    button.textContent = "Load more results";
+    button.id = "loadMoreButton";
+    button.addEventListener('click', loadMoreResults);
+    searchResultsContainer.parentNode.appendChild(button);
+    return button;
 }


### PR DESCRIPTION
Refine the basic pagefind implementation:
- Ingest only content directories.
- Add ignore elements to printview and posts outputs
- Add ignore element on related content generator, to avoid keyword hits on article title links.
- Restyle the search results page with icons for CORE or SCALE content, or section names for the other nonspecific website sections.
Thank you to @DjP-iX for assisting with this effort!

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
