### PR TITLE
PD-1020: review and clarify SMB1 deprecation caution.

### DIFF
--- a/content/References/SMB.md
+++ b/content/References/SMB.md
@@ -25,7 +25,7 @@ Another helpful reference is [Methods For Fine-Tuning Samba Permissions](https:/
 
 {{< include file="/_includes/SMBShareMSDOSalert.md" >}}
 
-Note the [SMB1 protocol is disabled by default]({{< relref "/CORE/CORESecurityReports/SMB1Advisory.md" >}}).
+Note: the [SMB1 protocol is disabled by default]({{< relref "/CORE/CORESecurityReports/SMB1Advisory.md" >}}).
 
 By default, Samba disables NTLMv1 authentication for security.
 Standard configurations of Windows XP and some configurations of later clients like Windows 7 are not able to connect with NTLMv1 disabled.

--- a/content/References/SMB.md
+++ b/content/References/SMB.md
@@ -23,16 +23,15 @@ Windows 7 clients support server-side copying with [Robocopy](https://docs.micro
 
 Another helpful reference is [Methods For Fine-Tuning Samba Permissions](https://www.truenas.com/community/threads/methods-for-fine-tuning-samba-permissions.50739/).
 
-{{< hint type=important >}}
-[The SMB1 protocol is disabled by default for security]({{< relref "/CORE/CORESecurityReports/SMB1Advisory.md" >}}).
-{{< /hint >}}
+
+{{< include file="/_includes/SMBShareMSDOSalert.md" >}}
+
+Note the [SMB1 protocol is disabled by default]({{< relref "/CORE/CORESecurityReports/SMB1Advisory.md" >}}).
 
 By default, Samba disables NTLMv1 authentication for security.
 Standard configurations of Windows XP and some configurations of later clients like Windows 7 are not able to connect with NTLMv1 disabled.
 [Security guidance for NTLMv1 and LM network authentication](https://support.microsoft.com/en-us/help/2793313/security-guidance-for-ntlmv1-and-lm-network-authentication) has information about the security implications and ways to enable NTLMv2 on those clients.
 If changing the client configuration is not possible, enable NTLMv1 authentication by selecting the **NTLMv1 auth** option in the SMB service configuration screen.
-
-{{< include file="/_includes/SMBShareMSDOSalert.md" >}}
 
 To view all active SMB connections and users, enter `smbstatus` in the TrueNAS SCALE **Shell** or open an SSH or local console shell in CORE.
 

--- a/content/References/SMB.md
+++ b/content/References/SMB.md
@@ -23,7 +23,6 @@ Windows 7 clients support server-side copying with [Robocopy](https://docs.micro
 
 Another helpful reference is [Methods For Fine-Tuning Samba Permissions](https://www.truenas.com/community/threads/methods-for-fine-tuning-samba-permissions.50739/).
 
-
 {{< include file="/_includes/SMBShareMSDOSalert.md" >}}
 
 Note the [SMB1 protocol is disabled by default]({{< relref "/CORE/CORESecurityReports/SMB1Advisory.md" >}}).

--- a/content/SCALE/GettingStarted/Configure/SetUpSharing.md
+++ b/content/SCALE/GettingStarted/Configure/SetUpSharing.md
@@ -11,8 +11,6 @@ tags:
 After setting up storage on your TrueNAS, it is time to begin sharing data!
 There are several sharing solutions available on SCALE, but in this article we discuss the most common.
 
-{{< include file="/_includes/SMBShareMSDOSalert.md" >}}
-
 ## Sharing Data Methods
 
 TrueNAS SCALE provides four types of sharing methods, but this article only discusses three:
@@ -101,7 +99,9 @@ To set up a basic SMB share:
 
    c. Click **Save**.
 
-5. Connect to the share. On a Windows 10 or later system, open the **File Browsers** and then:
+   {{< include file="/_includes/SMBShareMSDOSalert.md" >}}
+
+5. Connect to the share. On a **Windows 10** or later system, open the **File Browsers** and then:
 
    a. Enter `\\` and the TrueNAS system name or IP address in the navigation bar. A login credentials dialog displays.
 

--- a/content/SCALE/SCALETutorials/Shares/SMB/AddSMBHomeShare.md
+++ b/content/SCALE/SCALETutorials/Shares/SMB/AddSMBHomeShare.md
@@ -7,8 +7,6 @@ tags:
 - smb
 ---
 
-{{< include file="/_includes/SMBShareMSDOSalert.md" >}}
-
 ## Setting Up SMB Home Shares
 TrueNAS offers the **Use as Home Share** option, found in the **Add SMB** and **Edit SMB** screen **Advanced Options** settings in the **Other Options** section, for organizations or SMEs that want to use a single SMB share to provide a personal directory to every user account.
 
@@ -82,3 +80,5 @@ Then, click **Continue**.
 ![StoragePoolsOptionsEditPermissionsACLPresetHomeSCALE](/images/SCALE/Datasets/StoragePoolsOptionsEditPermissionsACLPresetHome.png "Set the Home ACL Preset")
 
 After adding the user accounts and configuring permissions, users can log in to the share and see a folder matching their user name.
+
+{{< include file="/_includes/SMBShareMSDOSalert.md" >}}

--- a/content/SCALE/SCALETutorials/Shares/SMB/_index.md
+++ b/content/SCALE/SCALETutorials/Shares/SMB/_index.md
@@ -12,9 +12,6 @@ tags:
 - shares
 ---
 
-
-{{< include file="/_includes/SMBShareMSDOSalert.md" >}}
-
 ## About Windows (SMB) Shares
 SMB (also known as CIFS) is the native file-sharing system in Windows.
 SMB shares can connect to most operating systems, including Windows, MacOS, and Linux.
@@ -26,6 +23,9 @@ SMB is suitable for managing and administering large or small pools of data.
 TrueNAS uses [Samba](https://www.samba.org/) to provide SMB services.
 The SMB protocol has multiple versions. An SMB client typically negotiates the highest supported SMB protocol during SMB session negotiation.
 Industry-wide, SMB1 protocol (sometimes referred to as NT1) usage is deprecated for security reasons.
+
+{{< include file="/_includes/SMBShareMSDOSalert.md" >}}
+
 However, most SMB clients support SMB 2 or 3 protocols, even when not default.
 
 {{< hint type=note >}}

--- a/content/SCALE/SCALETutorials/SystemSettings/Services/SMBServiceSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Services/SMBServiceSCALE.md
@@ -31,7 +31,7 @@ Enter any notes about the service configuration in **Description**
 
 For more advanced settings, see [SMB Services Screen]({{< relref "SMBServicesScreen.md" >}}).
 
-Use **Auxiliary Parameters** to enter additional [smb.conf](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html) options, or to log more details when a client attempts to authenticate to the share, add `log level = 1, auth_audit:5`. Refer to the [Samba Guide]9http://www.oreilly.com/openbook/samba/book/appb_02.html) for more information on these settings. 
+Use **Auxiliary Parameters** to enter additional [smb.conf](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html) options, or to log more details when a client attempts to authenticate to the share, add `log level = 1, auth_audit:5`. Refer to the [Samba Guide](http://www.oreilly.com/openbook/samba/book/appb_02.html) for more information on these settings. 
 
 Click **Save**.
 

--- a/content/SCALE/SCALEUIReference/Shares/SMBSharesScreens.md
+++ b/content/SCALE/SCALEUIReference/Shares/SMBSharesScreens.md
@@ -11,8 +11,6 @@ tags:
 - acl
 ---
 
-{{< include file="/_includes/SMBShareMSDOSalert.md" >}}
-
 ## Windows (SMB) Shares Widget
 If you have not added SMB shares to the system, the SMB widget shows **No records have been added yet**.
 

--- a/content/SCALE/SCALEUIReference/SystemSettings/Services/SMBServicesScreen.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/Services/SMBServicesScreen.md
@@ -29,9 +29,11 @@ Click **Save** or **Cancel** to close the configuration screen and return to the
 | **NetBIOS Alias** | Enter any alias name up to 15 characters in length. If entering multiple aliases, separate alias names with a space between them. |
 | **Workgroup** | Enter a name that matches the Windows workgroup name. If you do not configure a workgroup, and Active Directory or LDAP is active, TrueNAS detects and sets the correct workgroup from these services. |
 | **Description** | (Optional) Enter any notes or descriptive details about the service configuration. |
-| **Enable SMB1 support** | Select to allow legacy SMB1 clients to connect to the server. Note: SMB1 is deprecated. We advise you to upgrade clients to operating system versions that support modern SMB protocol versions. Also, SMB audit logging does not work if using SMB1. |
+| **Enable SMB1 support** | Select to allow legacy SMB1 clients to connect to the server (see caution below). SMB audit logging does not work when using SMB1. |
 | **NTLMv1 Auth** | Off by default. Select to allow [smbd](https://www.samba.org/samba/docs/current/man-html/smbd.8.html) attempts to authenticate users with the insecure and vulnerable NTLMv1 encryption. This setting allows backward compatibility with older versions of Windows, but we do not recommend it. Do not use on untrusted networks. |
 {{< /truetable >}}
+
+{{< include file="/_includes/SMBShareMSDOSalert.md" >}}
 
 ### Advanced Settings
 

--- a/content/_includes/SMBShareMSDOSalert.md
+++ b/content/_includes/SMBShareMSDOSalert.md
@@ -1,21 +1,9 @@
 &NewLine;
 
-{{< hint type=important >}}
-As of SCALE 22.12 (Bluefin), MS-DOS SMB1 clients cannot connect to TrueNAS SCALE Bluefin. TrueNAS SCALE SMB does not support End-of-Life (EoL) Windows clients, including MS-DOS. 
+{{< hint type=important title="SMB1 Protocol Deprecation" >}}
+As of SCALE 22.12 (Bluefin) and later, TrueNAS does not support SMB client operating systems that are labeled by their vendor as End of Life or End of Support.
+This means MS-DOS (including Windows 98) clients, among others, cannot connect to TrueNAS SCALE SMB servers.
 
-The Samba project, which TrueNAS SCALE uses to provide SMB sharing features, has deprecated the SMB1 protocol for security concerns.
-The Samba 4.16 release notes announced that they deprecated and disabled the whole SMB1 protocol as of 4.11. 
-If needed, for security purposes or code maintenance, Samba continues to remove older protocol commands and unused dialects or those that are replaced in more modern SMB1 versions.
-
-TrueNAS now uses Samba 4.17. TrueNAS still has SMB1 protocol support but:
-
-* MS-DOS-based SMB clients cannot connect to TrueNAS SCALE Bluefin. 
-* MS-DOS-based SMB clients are no longer able to connect to any TrueNAS servers. 
-* SMB clients determined to be end-of-life (EOL) by their vendor are not supported. 
-
+The upstream Samba project that TrueNAS uses for SMB features [notes in the 4.11 release](https://www.samba.org/samba/history/samba-4.11.0.html) the SMB1 protocol is deprecated and warns portions of the protocol might be further removed in future releases.
 Administrators should work to phase out any clients using the SMB1 protocol from their environments.
-
-Client systems that can only use the SMB1 protocol for SMB shares are no longer capable of connecting to SMB shares created in TrueNAS SCALE 22.12 or later. 
-
-Refer to [Samba](https://www.samba.org/samba/latest_news.html) release notes for more information.
 {{< /hint >}}

--- a/content/_includes/SMBShareMSDOSalert.md
+++ b/content/_includes/SMBShareMSDOSalert.md
@@ -4,6 +4,6 @@
 As of SCALE 22.12 (Bluefin) and later, TrueNAS does not support SMB client operating systems that are labeled by their vendor as End of Life or End of Support.
 This means MS-DOS (including Windows 98) clients, among others, cannot connect to TrueNAS SCALE SMB servers.
 
-The upstream Samba project that TrueNAS uses for SMB features [notes in the 4.11 release](https://www.samba.org/samba/history/samba-4.11.0.html) the SMB1 protocol is deprecated and warns portions of the protocol might be further removed in future releases.
+The upstream Samba project that TrueNAS uses for SMB features [notes in the 4.11 release](https://www.samba.org/samba/history/samba-4.11.0.html) that the SMB1 protocol is deprecated and warns portions of the protocol might be further removed in future releases.
 Administrators should work to phase out any clients using the SMB1 protocol from their environments.
 {{< /hint >}}


### PR DESCRIPTION
- Condense the text
- Clarify TrueNAS (non) support for SMB client OS that are End of Life/End of Support
- Clarify that SMB1 protocol is not removed, but deprecated and subject to upstream Samba project changes. Link to original Samba release that makes this statement.
- Review locations where the single sourced text is called and refine placement.

Note that I'll backport these changes to Cobia & Bluefin branches once SME review is complete.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
