### PR TITLE
Update SCALE, CORE, and TC anticipated release dates

### DIFF
--- a/content/TrueNASUpgrades/_index.md
+++ b/content/TrueNASUpgrades/_index.md
@@ -92,23 +92,17 @@ Development timelines for [TrueNAS SCALE](#scale-schedule-timeline), [TrueNAS CO
 
 {{< /columns >}}
 
-Individual releases within a major version are labeled as:
-{{< columns >}}
-{{< expand "Early" "v" >}}
-Public release of a unstable version that is either not feature complete or has more testing cycles planned.
-Follows an ALPHA, BETA, and RC naming convention.
+{{< expand "Individual releases within a major version are labeled as Early, Stable, or Maintenance (expand for details)." "v" >}}
+
+{{< truetable >}}
+| Type | Status |
+|-----------|-------------|
+| Early | Public release of a unstable version that is either not feature complete or has more testing cycles planned. Follows an ALPHA, BETA, and RC naming convention. |
+| Stable | Public release of a feature complete and internal and community tested major version. Follows a .0 naming convention. |
+| Maintenance | Public release with software bugfixes and additional internal and community testing. Follows a .# naming convention, with small-scope maintenance releases ("hotpatches") following a .#.# convention. |
+{{< /truetable >}}
+
 {{< /expand >}}
-<--->
-{{< expand "Stable" "v" >}}
-Public release of a feature complete and internal and community tested major version.
-Follows a .0 naming convention.
-{{< /expand >}}
-<--->
-{{< expand "Maintenance" "v" >}}
-Public release with software bugfixes and additional internal and community testing.
-Follows a .# naming convention, with small-scope maintenance releases ("hotpatches") following a .#.# convention.
-{{< /expand >}}
-{{< /columns >}}
 
 ## Timelines
 

--- a/content/TrueNASUpgrades/_index.md
+++ b/content/TrueNASUpgrades/_index.md
@@ -74,16 +74,6 @@ A("Current 22.12 (Bluefin) release") --> B["22.12.4.2 (Bluefin)"] --> C["23.10.1
 
 ## Release Schedules
 
-Individual releases within a major version are labeled in this section as:
-* **Early** - public release of a unstable version that is either not feature complete or has more testing cycles planned.
-  Follows an ALPHA, BETA, and RC naming convention.
-
-* **Stable** - public release of a feature complete and internal and community tested major version.
-  Follows a .0 naming convention.
-
-* **Maintenance** - public release with software bugfixes and additional internal and community testing.
-  Follows a .# naming convention, with small-scope maintenance releases ("hotpatches") following a .#.# convention.
-
 **The release names and dates provided here are tentative and can change at any time.**
 
 Development timelines for [TrueNAS SCALE](#scale-schedule-timeline), [TrueNAS CORE](#core-schedule-timeline), and [TrueCommand](#truecommand-schedule-timeline) are available below.
@@ -100,6 +90,24 @@ Development timelines for [TrueNAS SCALE](#scale-schedule-timeline), [TrueNAS CO
 
 {{< releaselist name=tc-releases defaultTab=2 >}}
 
+{{< /columns >}}
+
+Individual releases within a major version are labeled as:
+{{< columns >}}
+{{< expand "Early" "v" >}}
+Public release of a unstable version that is either not feature complete or has more testing cycles planned.
+Follows an ALPHA, BETA, and RC naming convention.
+{{< /expand >}}
+<--->
+{{< expand "Stable" "v" >}}
+Public release of a feature complete and internal and community tested major version.
+Follows a .0 naming convention.
+{{< /expand >}}
+<--->
+{{< expand "Maintenance" "v" >}}
+Public release with software bugfixes and additional internal and community testing.
+Follows a .# naming convention, with small-scope maintenance releases ("hotpatches") following a .#.# convention.
+{{< /expand >}}
 {{< /columns >}}
 
 ## Timelines

--- a/data/properties/core-releases.yaml
+++ b/data/properties/core-releases.yaml
@@ -23,14 +23,14 @@ majorVersions:
         releaseDate: "2023-12-07"
         latest: true
   - lifecycle: "Next"
-    name: "TrueNAS CORE 13.1"
-    releaseName: "13.1"
+    name: "TrueNAS CORE 13.3"
+    releaseName: "13.3"
     releases:
-      - name: "13.1-RC.1"
+      - name: "13.3-RC.1"
         type: "Early"
-        releaseDate: "2024-02-20"
+        releaseDate: "2024-04-07"
         latest: false
-      - name: "13.1.0"
+      - name: "13.3.0"
         type: "Stable"
-        releaseDate: "2024-04-02"
+        releaseDate: "2024-06-18"
         latest: false

--- a/data/properties/scale-releases.yaml
+++ b/data/properties/scale-releases.yaml
@@ -25,7 +25,7 @@ majorVersions:
       - name: "23.10.2"
         type: "Maintenance"
         link:
-        releaseDate: ""
+        releaseDate: "2024-02-22"
         latest: false
   - lifecycle: "Next"
     name: "TrueNAS SCALE 24.04 - Dragonfish"
@@ -33,11 +33,16 @@ majorVersions:
     releases:
       - name: "24.04-BETA.1"
         type: "Early"
-        link:
+        link: "https://www.truenas.com/docs/scale/24.04/gettingstarted/scalereleasenotes/"
         releaseDate: "2024-02-06"
-        latest: false
+        latest: true
       - name: "24.04-RC.1"
         type: "Early"
         link:
         releaseDate: "2024-03-19"
+        latest: false
+      - name: "24.04.0"
+        type: "Stable"
+        link: 
+        releaseDate: "2024-04-23"
         latest: false

--- a/data/properties/tc-releases.yaml
+++ b/data/properties/tc-releases.yaml
@@ -20,10 +20,16 @@ majorVersions:
         link: "https://www.truenas.com/docs/truecommand/3.0/tcgettingstarted/tcreleasenotes/"
         releaseDate: "2023-12-19"
         latest: true
+      - name: "3.0.1"
+        type: "Maintenance"
+        link:
+        releaseDate: "2024-03-05"
+        latest: false
   - lifecycle: "Next"
-    name: "TBD"
+    name: "TrueCommand Next"
     releases:
-      - name: ""
-        type: ""
+      - name: "Next Major Version"
+        type: "TBD"
+        link:
         releaseDate: ""
-        latest: 
+        latest: false


### PR DESCRIPTION
Add the latest anticipated dates for each software project.
Rename CORE next from 13.1 to 13.3.
Add a more obvious tentative card for TC next.
Do some small reworks to the Software Releases content to condense a bit.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
