### PR TITLE
PD-1013: Reset 3.0 branch to lunr.js search

### DIFF
--- a/jenkins/update-3.0
+++ b/jenkins/update-3.0
@@ -15,7 +15,6 @@ pipeline {
             sh 'npm install -D --save autoprefixer'
             sh 'npm install -D --save postcss-cli'
             sh 'hugo -d public --gc --minify --cleanDestinationDir'
-			sh 'npx pagefind --site "public"'
         }
     }
     stage('Publish') {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,115 +1,36 @@
-let query = new URLSearchParams(window.location.search).get("query");
-let searchResultsContainer = document.getElementById('results');
-let currentPage = 1;
-const resultsPerPage = 10;
-let pagefind;
-let loadMoreButton; // Cache reference to the load more button
+const queryString = new URLSearchParams(window.location.search).get("query");
+if (queryString) {
+    document.getElementById("search-input").setAttribute("value", queryString);
+    
+    // Define the excluded URL paths
+    const excludedPaths = ["/tags/", "/book/", "/volume/", "/_includes/"];
 
-initPageFind();
-
-async function initPageFind() {
-    pagefind = await import("https://www.truenas.com/docs/truecommand/3.0/pagefind/pagefind.js");
-    pagefind.init();
-
-    if (query != null) {
-        document.getElementById("search-input").value = query;
-        await displaySearchResults(query, currentPage);
-    }
-}
-
-async function displaySearchResults(query, page) {
-    try {
-        let results = await pagefind.search(query);
-        let paginatedResults = results.results;
-        let slicedResults = await Promise.all(paginatedResults.map(r => r.data()));
-
-        let startIndex = (page - 1) * resultsPerPage;
-        let endIndex = startIndex + resultsPerPage;
-        let paginatedSlicedResults = slicedResults.slice(startIndex, endIndex);
-
-        if (loadMoreButton) {
-            loadMoreButton.classList.remove("loading");
-        }
-
-        if (paginatedSlicedResults.length === 0) {
-            if (currentPage === 1) {
-                searchResultsContainer.innerHTML = 'No results found.';
-            } else {
-                let noMoreResultsMessage = document.createElement('div');
-                noMoreResultsMessage.innerHTML = '<p>No more results.</p>';
-                searchResultsContainer.appendChild(noMoreResultsMessage);
-            }
-        } else {
-            let fragment = document.createDocumentFragment();
-
-            paginatedSlicedResults.forEach((result, index) => {
-                let resultDiv = document.createElement('div');
-                let title = result.meta.title.charAt(0).toUpperCase() + result.meta.title.slice(1);
-
-                // Add section marker in front of the <a>
-                let coreIcon = '<img src="https://www.truenas.com/docs/truecommand/3.0/favicon/TN-favicon-32x32.png" alt="TrueNAS CORE" title="TrueNAS CORE" class="icon">';
-                let scaleIcon = '<img src="https://www.truenas.com/docs/truecommand/3.0/favicon/TNScale-favicon-32x32.png" alt="TrueNAS SCALE" title="TrueNAS SCALE" class="icon">';
-                let tcIcon = '<img src="https://www.truenas.com/docs/truecommand/3.0/favicon/TC-favicon-32x32.png" alt="TrueCommand" title="TrueCommand" class="icon">';
-
-                let linkText = result.url.includes("/core/") ? `${coreIcon}`
-                    : result.url.includes("/scale/") ? `${scaleIcon}`
-                    : result.url.includes("/truecommand/") ? `${tcIcon}`
-                    : result.url.includes("/solutions/") ? `Solutions:`
-                    : result.url.includes("/hardware/") ? `TrueNAS Systems:`
-                    : result.url.includes("/contributing/") ? `Contributing:`
-                    : result.url.includes("/references/") ? `References:`
-					: result.url.includes("core_websocket") ? `${coreIcon}\u00A0API:`
-					: result.url.includes("scale_websocket") ? `${scaleIcon}\u00A0API:`
-                    : `${title}:`;
-
-                resultDiv.innerHTML = `
-                    <h3>${linkText}&ensp;<a href="${result.url}">${title}</a></h3>
-                    <p>${result.excerpt}</p>
-                    <hr>
-                `;
-                fragment.appendChild(resultDiv);
-            });
-
-            // Append the new results fragment to existing content
-            searchResultsContainer.appendChild(fragment);
-
-            // Check if there are more results to display
-            const hasMoreResults = slicedResults.length > endIndex;
-
-            // Show/hide the load more button
-            if (hasMoreResults) {
-                if (!loadMoreButton) {
-                    loadMoreButton = createLoadMoreButton();
+    // Perform the search
+    !function (queryString, excludedPaths) {
+        const resultsContainer = document.getElementById("results");
+        if (queryString.length) {
+            let resultsHTML = "";
+            for (const result of lunr(function () {
+                this.ref("id");
+                this.field("title", { boost: 15 });
+                this.field("tags");
+                this.field("content", { boost: 10 });
+                for (const key in window.store) {
+                    this.add({ id: key, title: window.store[key].title, tags: window.store[key].category, content: window.store[key].content });
                 }
-                loadMoreButton.classList.remove("loading");
-                loadMoreButton.style.display = 'block';
-            } else if (loadMoreButton) {
-                loadMoreButton.style.display = 'none';
+            }).search(queryString)) {
+                const item = window.store[result.ref];
+                // Check if the URL is excluded
+                if (!excludedPaths.some(path => item.url.includes(path))) {
+                    // Remove the "/docs/" prefix from the URL
+                    const url = `https://www.truenas.com/docs/truecommand/3.0${item.url.replace('/docs/', '/')}`;
+                    resultsHTML += `<li><p><a href="${url}">${item.title}</a></p>`;
+                    resultsHTML += `<p>${item.content.substring(0, 150)}...</p></li>`;
+                }
             }
+            resultsContainer.innerHTML = resultsHTML || "No results found.";
+        } else {
+            resultsContainer.innerHTML = "No results found.";
         }
-
-    } catch (error) {
-        console.error('Error:', error);
-        throw error;
-    }
-}
-
-async function loadMoreResults() {
-    currentPage++;
-    let query = new URLSearchParams(window.location.search).get("query");
-    if (loadMoreButton) {
-        loadMoreButton.classList.add("loading");
-    }
-    await displaySearchResults(query, currentPage);
-}
-
-function createLoadMoreButton() {
-    const button = document.createElement("a");
-    button.classList.add("absolute-center");
-    button.classList.add("button");
-    button.textContent = "Load more results";
-    button.id = "loadMoreButton";
-    button.addEventListener('click', loadMoreResults);
-    searchResultsContainer.parentNode.appendChild(button);
-    return button;
+    }(queryString, excludedPaths);
 }


### PR DESCRIPTION
With pagefind nonfunctional (so far), I'm resetting this to the basic lunr.js implementation used on the other branches. Local testing showed there was some unintended URLs pulled in, so adjusted to exclude those and keep the results url pointed to the branch docs on the Docs Hub.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
