### PR TITLE
Update SessionsSettingsWidget.md

### DIFF
--- a/content/_includes/SessionsSettingsWidget.md
+++ b/content/_includes/SessionsSettingsWidget.md
@@ -1,6 +1,6 @@
 &NewLine;
 
-The **Sessions** widget displays a list of all active sessions, including the user who initiated the session and what time it started.
+The **Sessions** widget, found in the Advanced section of the system settings, displays a list of all active sessions, including the user who initiated the session and what time it started.
 It also displays the **Token Lifetime** setting for your current session.
 It allows administrators to manage other active sessions and to configure the token lifetime for their account.
 


### PR DESCRIPTION
Make it clear where the widget is located, as there is no reference to where it is found, nor in the text nor in the breadcrumbs. Users who arrive on the page through e.g. a web search will not know where the widget is.

I acknowledge that my changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.