### PR TITLE
Update noindex entries for specific sections of master branch

### DIFF
--- a/layouts/partials/head/custom.html
+++ b/layouts/partials/head/custom.html
@@ -50,4 +50,8 @@ const token = await grecaptcha.enterprise.execute('6LeA_SkkAAAAADD6tuU8aNvNYRxCo
  {{ if .Site.Params.googlefonts }}
  <link rel="stylesheet" href="{{ .Site.Params.googlefonts }}" type="text/css" media="all" /> 
  {{ end }}
- 
+<!-- De-index various sections that we use internally but don't need to be included in search results -->
+{{ if or (eq .Section "_includes") (eq .Section "tags") (eq .Section "book") (eq .Section "volume") }}
+    <meta name="robots" content="noindex">
+{{ end }}
+


### PR DESCRIPTION
This is to fix the issue where our robots.txt file isn't properly applying as we're not a separate domain, but a subdirectory of truenas.com. Instead, we'll inject the noindex meta tag in <head> for the _includes, tags, volume, and book sections that we use for automatic relationships and single sourcing, but otherwise don't need Google crawling for content.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
