### PR TITLE
Add Update Path Clarifications

### DIFF
--- a/content/SCALE/SCALETutorials/SystemSettings/UpdateSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/UpdateSCALE.md
@@ -9,7 +9,7 @@ tags:
 
 TrueNAS has several software branches (linear update paths) known as trains. If SCALE is in a prerelease train it can have various preview/early build releases of the software.
 
-The **Update Screen** only displays the current train. For more information on other available trains and the upgrade path from one version to the next, see [Release Schedules](https://www.truenas.com/docs/truenasupgrades/).
+The **Update Screen** only displays the current train. For more information on other available trains and the upgrade path from one version to the next, see [Software Releases](https://www.truenas.com/docs/truenasupgrades/).
 
 {{< hint type=warning >}}
 See the [Software Status](https://www.truenas.com/software-status/) page for the latest recommendations for software usage.

--- a/content/SCALE/SCALETutorials/SystemSettings/UpdateSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/UpdateSCALE.md
@@ -9,7 +9,7 @@ tags:
 
 TrueNAS has several software branches (linear update paths) known as trains. If SCALE is in a prerelease train it can have various preview/early build releases of the software.
 
-The **Update Screen** only displays the current train. For more information on other available trains, see [Release Schedules](https://www.truenas.com/docs/truenasupgrades/).
+The **Update Screen** only displays the current train. For more information on other available trains and the upgrade path from one version to the next, see [Release Schedules](https://www.truenas.com/docs/truenasupgrades/).
 
 {{< hint type=warning >}}
 See the [Software Status](https://www.truenas.com/software-status/) page for the latest recommendations for software usage.
@@ -21,6 +21,8 @@ For information on how to file an issue ticket see [Filing an Issue Ticket in SC
 {{< /hint >}}
 
 The TrueNAS SCALE **Update** screen provides users with two different methods to update the system, automatic or manual.
+Upgrade your SCALE release to the next major version before installing the latest publicly available prerelease candidate (i.e., BETA.1 or RC.1) of an upcoming major release version. 
+
 We recommend updating SCALE when the system is idle (no clients connected, no disk activity, etc.).
 The system restarts after an upgrade.
 Update during scheduled maintenance times to avoid disrupting user activities.

--- a/content/SCALE/SCALETutorials/SystemSettings/UpdateSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/UpdateSCALE.md
@@ -9,7 +9,9 @@ tags:
 
 TrueNAS has several software branches (linear update paths) known as trains. If SCALE is in a prerelease train it can have various preview/early build releases of the software.
 
-The **Update Screen** only displays the current train. For more information on other available trains and the upgrade path from one version to the next, see [Software Releases](https://www.truenas.com/docs/truenasupgrades/).
+The **Update Screen** only displays the current train.
+When looking to upgrade SCALE to a new major version, make sure to upgrade SCALE along the path of major versions until the system is on the desired major version release.
+For more information on other available trains and the upgrade path from one version to the next, see [Software Releases](https://www.truenas.com/docs/truenasupgrades/).
 
 {{< hint type=warning >}}
 See the [Software Status](https://www.truenas.com/software-status/) page for the latest recommendations for software usage.
@@ -21,7 +23,6 @@ For information on how to file an issue ticket see [Filing an Issue Ticket in SC
 {{< /hint >}}
 
 The TrueNAS SCALE **Update** screen provides users with two different methods to update the system, automatic or manual.
-Upgrade your SCALE release to the next major version before installing the latest publicly available prerelease candidate (i.e., BETA.1 or RC.1) of an upcoming major release version. 
 
 We recommend updating SCALE when the system is idle (no clients connected, no disk activity, etc.).
 The system restarts after an upgrade.


### PR DESCRIPTION
This PR adds clarification and references to the release upgrade path information in the TruenasUpgrades.md article to reaffirm the process for users that try to skip a release.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
