### PR TITLE
PD-1086 Backport UDP Protocl and NFS Snippet to 23.10

### DIFF
--- a/content/SCALETutorials/Shares/AddingNFSShares.md
+++ b/content/SCALETutorials/Shares/AddingNFSShares.md
@@ -23,6 +23,10 @@ NFS treats each dataset as its own file system. When creating the NFS share on t
 If you need to create shares that include child datasets, SMB sharing is an option. Note that Windows NFS Client versions currently support only NFSv2 and NFSv3.
 {{< /hint >}}
 
+{{< hint type=info title="UDP Protocol and NFS" >}}
+{{< include file="/static/includes/NFSServiceUDPWarning.md" >}}
+{{< /hint >}}
+
 ## Adding an NFS Share Dataset
 
 Before creating an NFS share, create the dataset you want the share to use for data storage.

--- a/content/SCALETutorials/SystemSettings/Services/NFSServiceSCALE.md
+++ b/content/SCALETutorials/SystemSettings/Services/NFSServiceSCALE.md
@@ -37,7 +37,9 @@ Next enter a port to bind to in the field that applies:
 * Enter a port to bind [rpc.statd(8)](https://man7.org/linux/man-pages/man8/statd.8.html)in **rpc.statd(8) bind port**.
 * Enter a port to bind [rpc.lockd(8)](https://linux.die.net/man/8/rpc.lockd) in **rpc.lockd(8) bind port**.
 
-Select **Serve UDP NFS clients** if NFS clients need to use UDP.
+{{< hint type=info title="UDP Protocol and NFS" >}}
+{{< include file="/static/includes/NFSServiceUDPWarning.md" >}}
+{{< /hint >}}
 
 Select **Allow non-root mount** only if required by the NFS client to allow serving non-root mount requests. 
 

--- a/content/SCALEUIReference/Shares/NFSSharesScreens.md
+++ b/content/SCALEUIReference/Shares/NFSSharesScreens.md
@@ -62,6 +62,10 @@ Select **Confirm** and then **UNSHARE** to remove the share without affecting th
 ## Add and Edit NFS Screens
 The **Add NFS** and **Edit NFS** display the same **Basic Options** and **Advanced Options** settings.
 
+{{< hint type=info title="UDP Protocol and NFS" >}}
+{{< include file="/static/includes/NFSServiceUDPWarning.md" >}}
+{{< /hint >}}
+
 ### Basic Options Settings
 
 {{< trueimage src="/images/SCALE/22.12/SharingNFSAddSCALE.png" alt="Add NFS Basic Options" id="Add NFS Basic Options" >}}

--- a/content/SCALEUIReference/SystemSettings/Services/NFSServiceScreen.md
+++ b/content/SCALEUIReference/SystemSettings/Services/NFSServiceScreen.md
@@ -10,6 +10,11 @@ tags:
 
 {{< toc >}}
 
+
+{{< hint type=info title="UDP Protocol and NFS" >}}
+{{< include file="/static/includes/NFSServiceUDPWarning.md" >}}
+{{< /hint >}}
+
 ## NFS Service Screen
 The **Services > NFS** configuration screen displays settings to customize the TrueNAS NFS service.
 

--- a/static/includes/NFSServiceUDPWarning.md
+++ b/static/includes/NFSServiceUDPWarning.md
@@ -1,0 +1,5 @@
+&NewLine;
+
+
+The UDP protocol is deprecated and not supported with NFS. It is disabled by default in the Linux kernel.
+Using UDP over NFS on modern networks (1Gb+) can lead to data corruption caused by fragmentation during high loads.


### PR DESCRIPTION
This PR backports the hint admonition and UDP protocol and NFS service snippet to 23.10



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
