### PR TITLE
PD-1081 Backport Config File Backup Content to 23.10

### DIFF
--- a/content/SCALETutorials/SystemSettings/General/ManageSysConfigSCALE.md
+++ b/content/SCALETutorials/SystemSettings/General/ManageSysConfigSCALE.md
@@ -50,3 +50,13 @@ After the configuration resets, the system restarts and users must set a new log
 
 {{< taglist tag="scalesettings" limit="10" >}}
 {{< taglist tag="scalebackup" limit="10" title="Related Backup Articles" >}}
+
+### Backing Up the Config File
+SCALEdoes not automatically backup the system configuration file to the system dataset.
+
+Users that want to schedule an automatic backup of the system configuration file should:
+1. [Set up TrueCommand](https://www.truenas.com/docs/truecommand/tcgettingstarted/install/).
+2. [Add their SCALE system](https://www.truenas.com/docs/truecommand/tcgettingstarted/connectingtruenas/).
+3. Create and schedule the [configuration file backup](https://www.truenas.com/docs/truecommand/userguide/systemmanagement/truenasconfigmanage/#create-a-config-backup).
+
+Users can manually backup the SCALE config file by downloading and saving the file to a location that is automatically backed up.

--- a/content/SCALETutorials/SystemSettings/General/ManageSysConfigSCALE.md
+++ b/content/SCALETutorials/SystemSettings/General/ManageSysConfigSCALE.md
@@ -28,7 +28,7 @@ The **Download File** option downloads your TrueNAS SCALE current configuration 
 The **Upload File** option gives users the ability to replace the current system configuration with any previously saved TrueNAS SCALE configuration file.
 
 {{< hint type=warning >}}
-All passwords are reset if the uploaded configuration file was saved without the selecting **Save Password Secret Seed**.
+All passwords are reset if the uploaded configuration file was saved without selecting **Save Password Secret Seed**.
 {{< /hint >}}
 
 ### Resetting to Defaults
@@ -52,11 +52,11 @@ After the configuration resets, the system restarts and users must set a new log
 {{< taglist tag="scalebackup" limit="10" title="Related Backup Articles" >}}
 
 ### Backing Up the Config File
-SCALEdoes not automatically backup the system configuration file to the system dataset.
+SCALE does not automatically back up the system configuration file to the system dataset.
 
-Users that want to schedule an automatic backup of the system configuration file should:
+Users who want to schedule an automatic backup of the system configuration file should:
 1. [Set up TrueCommand](https://www.truenas.com/docs/truecommand/tcgettingstarted/install/).
 2. [Add their SCALE system](https://www.truenas.com/docs/truecommand/tcgettingstarted/connectingtruenas/).
 3. Create and schedule the [configuration file backup](https://www.truenas.com/docs/truecommand/userguide/systemmanagement/truenasconfigmanage/#create-a-config-backup).
 
-Users can manually backup the SCALE config file by downloading and saving the file to a location that is automatically backed up.
+Users can manually back up the SCALE config file by downloading and saving the file to a location that is automatically backed up.


### PR DESCRIPTION
This PR backports the new section on backing up the system config file using TrueCommand to the 23.10 branch

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
