### PR TITLE
Pd 1097 add note about creating smb user in 24.04

### DIFF
--- a/content/GettingStarted/Configure/SetUpSharing.md
+++ b/content/GettingStarted/Configure/SetUpSharing.md
@@ -53,10 +53,7 @@ You can create an SMB or NFS share while creating the dataset or create the data
 
 For more information on adding SMB shares, see [Adding SMB Shares]({{< relref "/SCALETutorials/Shares/_index.md" >}}).
 
-{{< hint type=important >}}
-TrueNAS must be joined to Active Directory or have at least one local SMB user before creating an SMB share. When creating an SMB user, ensure that **Samba Authentication** is enabled.
-You cannot access SMB shares using the root user, TrueNAS built-in user accounts, or those without **Samba Authentication** selected.
-{{< /hint >}}
+{{< include file="/static/includes/LocalSMBUser.md" >}}
 
 To set up a basic SMB share:
 1. Create the share and dataset.

--- a/content/GettingStarted/Configure/SetUpSharing.md
+++ b/content/GettingStarted/Configure/SetUpSharing.md
@@ -53,6 +53,11 @@ You can create an SMB or NFS share while creating the dataset or create the data
 
 For more information on adding SMB shares, see [Adding SMB Shares]({{< relref "/SCALETutorials/Shares/_index.md" >}}).
 
+{{< hint type=important >}}
+TrueNAS must be joined to Active Directory or have at least one local SMB user before creating an SMB share. When creating an SMB user, ensure that **Samba Authentication** is enabled.
+You cannot access SMB shares using the root user, TrueNAS built-in user accounts, or those without **Samba Authentication** selected.
+{{< /hint >}}
+
 To set up a basic SMB share:
 1. Create the share and dataset.
 

--- a/content/SCALETutorials/Shares/SMB/AddSMBHomeShare.md
+++ b/content/SCALETutorials/Shares/SMB/AddSMBHomeShare.md
@@ -10,6 +10,11 @@ tags:
 ## Setting Up SMB Home Shares
 TrueNAS offers the **Use as Home Share** option, found in the **Add SMB** and **Edit SMB** screen **Advanced Options** settings in the **Other Options** section, for organizations or SMEs that want to use a single SMB share to provide a personal directory to every user account.
 
+{{< hint type=important >}}
+TrueNAS must be joined to Active Directory or have at least one local SMB user before creating an SMB share.
+When creating an SMB user, ensure that Samba Authentication is enabled.
+{{< /hint >}}
+
 With home shares, each user is given a personal home directory when connecting to the share.
 These home directories are not accessible by other users.
 You can use only one share as the home share, but you can create as many non-home shares as you need or want.

--- a/content/SCALETutorials/Shares/SMB/AddSMBHomeShare.md
+++ b/content/SCALETutorials/Shares/SMB/AddSMBHomeShare.md
@@ -40,10 +40,7 @@ Next, [set up the Active Directory]({{< relref "/SCALETutorials/credentials/dire
 
 ### Creating the Share and Dataset
 
-{{< hint type=important >}}
-TrueNAS must be joined to Active Directory or have at least one local SMB user before creating an SMB share. When creating an SMB user, ensure that **Samba Authentication** is enabled.
-You cannot access SMB shares using the root user, TrueNAS built-in user accounts, or those without **Samba Authentication** selected.
-{{< /hint >}}
+{{< include file="/static/includes/LocalSMBUser.md" >}}
 
 You can either add the share when you [create the dataset]({{< relref "DatasetsSCALE.md" >}}) for the share on the **Add Dataset** screen, or create the dataset when you add the share on the **Add SMB** screen.
 If you want to customize the dataset, use the **Add Dataset** screen.

--- a/content/SCALETutorials/Shares/SMB/AddSMBHomeShare.md
+++ b/content/SCALETutorials/Shares/SMB/AddSMBHomeShare.md
@@ -10,11 +10,6 @@ tags:
 ## Setting Up SMB Home Shares
 TrueNAS offers the **Use as Home Share** option, found in the **Add SMB** and **Edit SMB** screen **Advanced Options** settings in the **Other Options** section, for organizations or SMEs that want to use a single SMB share to provide a personal directory to every user account.
 
-{{< hint type=important >}}
-TrueNAS must be joined to Active Directory or have at least one local SMB user before creating an SMB share.
-When creating an SMB user, ensure that Samba Authentication is enabled.
-{{< /hint >}}
-
 With home shares, each user is given a personal home directory when connecting to the share.
 These home directories are not accessible by other users.
 You can use only one share as the home share, but you can create as many non-home shares as you need or want.
@@ -44,6 +39,12 @@ Go to **Storage** and [create a pool]({{< relref "CreatePoolWizard.md" >}}).
 Next, [set up the Active Directory]({{< relref "/SCALETutorials/credentials/directoryservices/configadscale.md" >}}) that you want to share resources with over your network.
 
 ### Creating the Share and Dataset
+
+{{< hint type=important >}}
+TrueNAS must be joined to Active Directory or have at least one local SMB user before creating an SMB share. When creating an SMB user, ensure that **Samba Authentication** is enabled.
+You cannot access SMB shares using the root user, TrueNAS built-in user accounts, or those without **Samba Authentication** selected.
+{{< /hint >}}
+
 You can either add the share when you [create the dataset]({{< relref "DatasetsSCALE.md" >}}) for the share on the **Add Dataset** screen, or create the dataset when you add the share on the **Add SMB** screen.
 If you want to customize the dataset, use the **Add Dataset** screen.
 

--- a/content/SCALETutorials/Shares/SMB/_index.md
+++ b/content/SCALETutorials/Shares/SMB/_index.md
@@ -60,10 +60,7 @@ After adding the share, [start the service](#starting-the-smb-service) and [moun
 
 ### Creating SMB Share User Accounts
 
-{{< hint type=important >}}
-TrueNAS must be joined to Active Directory or have at least one local SMB user before creating an SMB share. When creating an SMB user, ensure that **Samba Authentication** is enabled.
-You cannot access SMB shares using the root user, TrueNAS built-in user accounts, or those without **Samba Authentication** selected.
-{{< /hint >}}
+{{< include file="/static/includes/LocalSMBUser.md" >}}
 
 To add users or edit users, go to **Credentials > Local Users** to add or edit the SMB share user(s).
 Click **Add** to create a new or as many new user accounts as you need.

--- a/content/SCALETutorials/Shares/SMB/_index.md
+++ b/content/SCALETutorials/Shares/SMB/_index.md
@@ -59,8 +59,10 @@ Creating an SMB share to your system involves several steps to add the share and
 After adding the share, [start the service](#starting-the-smb-service) and [mount it](#mounting-the-smb-share) to your other system.
 
 ### Creating SMB Share User Accounts
-{{< hint type=note >}}
-You cannot access SMB shares using the root user, TrueNAS built-in user accounts, or those without the **Samba Authentication** selected.
+
+{{< hint type=important >}}
+TrueNAS must be joined to Active Directory or have at least one local SMB user before creating an SMB share. When creating an SMB user, ensure that **Samba Authentication** is enabled.
+You cannot access SMB shares using the root user, TrueNAS built-in user accounts, or those without **Samba Authentication** selected.
 {{< /hint >}}
 
 To add users or edit users, go to **Credentials > Local Users** to add or edit the SMB share user(s).

--- a/static/includes/LocalSMBUser.md
+++ b/static/includes/LocalSMBUser.md
@@ -1,0 +1,6 @@
+&NewLine;
+
+{{< hint type=important >}}
+TrueNAS must be joined to Active Directory or have at least one local SMB user before creating an SMB share. When creating an SMB user, ensure that **Samba Authentication** is enabled.
+You cannot access SMB shares using the root user, TrueNAS built-in user accounts, or those without **Samba Authentication** selected.
+{{< /hint >}}


### PR DESCRIPTION
Dragonfish now requires users to set up a user with Samba authentication or join AD before creating an SMB share.

Add an admonition box to the 24.04 Add SMB Home Share and SMB Share _index tutorials reminding users that they must have an SMB authentication user to access their shares.