### PR TITLE
PD-1070 Update Resilvering Articles CORE and SCALE

### DIFF
--- a/content/CORE/CORETutorials/Tasks/UsingResilverPriority.md
+++ b/content/CORE/CORETutorials/Tasks/UsingResilverPriority.md
@@ -7,18 +7,10 @@ tags:
 - resilver
 ---
 
-Resilvering is a process that copies data to a replacement disk. You should complete it as quickly as possible.
-Increasing the priority of resilvers helps them finish faster.
-The **Resilver Priority** menu allows you to schedule when a resilver can become a higher priority for the system.
-You should schedule resilvers when the additional I/O or CPU use does not affect normal usage.
+{{< include file="/static/includes/ResilverPriority.md" >}}
 
 Go to **Tasks > Resilver Priority** to configure the priority to the best time for your environment.
 
 ![TasksResilverPriority](/images/CORE/Tasks/TasksResilverPriority.png "Scheduling Resilver Priority Times")
 
-Set **Enabled**, then use the drop-down menus to select a **Begin** and **End** time and what days of the week you want the priority to run.
-
-{{< hint type=note >}} 
-A resilver process running during the time frame defined between "Begin Time" and "End Time" will likely work faster.
-We advise you avoid putting the system under any intensive activity or heavy loads (replications, SMB transfers, NFS transfers, Rsync transfers, S.M.A.R.T. tests, pool scrubs, etc) during a resilver process. 
-{{< /hint >}}
+{{< include file="/static/includes/ResliverPrioritySetWhen.md" >}}

--- a/content/SCALE/SCALETutorials/DataProtection/ScrubTasksSCALE.md
+++ b/content/SCALE/SCALETutorials/DataProtection/ScrubTasksSCALE.md
@@ -12,21 +12,19 @@ When TrueNAS performs a scrub, ZFS scans the data on a pool.
 Scrubs identify data integrity problems, detect silent data corruptions caused by transient hardware issues, and provide early disk failure alerts.
 
 ## Default Scrub Tasks
-
 TrueNAS generates a default scrub task when you create a new pool and sets it to run every Sunday at 12:00 AM.
 
 ![ScrubTaskDefaultSCALE](/images/SCALE/DataProtection/scrubtaskpriority.png "Default Scrub Task")
 
-## Adjust Scrub/Resilver Priority
+## Adjusting Scrub/Resilver Priority
+
+{{< include file="/static/includes/ResilverPriority.md" >}}
 
 ![ScrubTaskPrioritySCALE](/images/SCALE/DataProtection/resilverscrubedit.png "Default Scrub Task")
 
-To schedule a new resilver task to run at a higher priority, select the hour and minutes from the **Begin** dropdown list.
-
-To schedule a new resilver task to run at a lower priority to other processes, select the hour and minutes from the **End** dropdown list. Running at a lower priority is a slower process and takes longer to complete. Schedule this for times when your server is at its lowest demand level.
+{{< include file="/static/includes/ResliverPrioritySetWhen.md" >}}
 
 ## Creating New Scrub Tasks
-
 TrueNAS needs at least one data [pool]({{< relref "/SCALE/SCALEUIReference/Storage/_index.md" >}}) to create scrub task.
 
 To create a scrub task for a pool, go to **Data Protection** and click **ADD** in the **Scrub Tasks** window.
@@ -42,7 +40,6 @@ Select a preset schedule from the dropdown list or click **Custom** to create a 
 To view the progress of a scrub task, check the status under the **Next Run** column.
 
 ## Editing Scrub Tasks
-
-To edit a scrub, go to **Data Protection** and click the scrub task you want to edit.
+To edit a scrub, go to **Data Protection** and click the scrub task to edit.
 
 ![ScrubTaskEditSCALE](/images/SCALE/DataProtection/ScrubTaskEditSCALE.png "Edit Scrub Task")

--- a/content/SCALE/SCALEUIReference/DataProtection/ScrubTasksScreensSCALE.md
+++ b/content/SCALE/SCALEUIReference/DataProtection/ScrubTasksScreensSCALE.md
@@ -28,11 +28,14 @@ The **Add Scrub Task** and **Edit Scrub Task** screens display the same settings
 | Setting | Description |
 |---------|-------------|
 | **Pool** | Select the pool to scrub from the dropdown list. |
-| **Threshold days** | Enter the number of days before a completed scrub is allowed to run again. This controls the task schedule. For example, scheduling a scrub to run daily and setting **Threshold days** to 7 means the scrub attempts to run daily. When the scrub succeeds, it continues to check daily but does not run again until the seven days have elapsed. Using a multiple of seven ensures the scrub always occurs on the same weekday. |
+| **Threshold days** | Enter the number of days before a completed scrub is allowed to run again. This controls the task schedule. For example, scheduling a scrub to run daily with setting **Threshold days** to 7 means the scrub attempts to run daily. When the scrub succeeds, it continues to check daily but does not run again until seven days elapse. Using a multiple of seven ensures the scrub always occurs on the same weekday. |
 | **Description** | Enter a description for this scrub tasks. |
 | **Schedule** | Select a preset from the dropdown list that runs the scrub task according to that schedule time. Select **Custom** to use the advanced scheduler. |
 | **Enabled** | Select to enable the scrub task to run. Leave checkbox clear to disable the task without deleting it. |
 {{< /truetable >}}
+{{< expand "Advanced Scheduler" "v" >}}
+{{< include file="/static/includes/SCALEAdvancedScheduler.md" >}}
+{{< /expand >}}
 
 ## Scrub/Resilver Priority Screen
 The settings specify times when new resilver tasks can start, and run, at a higher priority or when a resilver task cannot run at a lower priority. 
@@ -44,6 +47,6 @@ The settings specify times when new resilver tasks can start, and run, at a high
 |---------|-------------|
 | **Enabled** | Select to run resilver tasks between the configured times. |
 | **Begin** | Select the hour and minute when a resilver task can start from the dropdown list. The resilver process can run at a higher priority. |
-| **End** | Select the hour and minute when new resilver tasks are not allowed to start. This does not affect active resilver tasks. The resilver process must return to running at a lower priority. A resilver process running after this time likely takes much longer to complete due to running at a lower priority compared to other disk and CPU activities, such as replications, SMB transfers, NFS transfers, Rsync transfers, S.M.A.R.T. tests, pool scrubs, user activity, etc. |
-| **Days of the Week** | Select the days to run resilver tasks from the dropdown list. |
+| **End** | Select the hour and minute when new resilver tasks are not allowed to start. This does not affect active resilver tasks. The resilver process returns to running at a lower priority. A resilver process running after this time can take much longer to complete due to running at a lower priority compared to other disk and CPU activities, such as replications, SMB transfers, NFS transfers, Rsync transfers, S.M.A.R.T. tests, pool scrubs, user activity, etc. |
+| **Days of the Week** | Select the days to run resilver tasks from the dropdown list. Select day(s) when demands on system I/O processing and activity is at a lower levels. |
 {{< /truetable >}}

--- a/static/includes/ResilverPriority.md
+++ b/static/includes/ResilverPriority.md
@@ -1,0 +1,7 @@
+&NewLine;
+
+Resilvering is a process that copies data to a replacement disk. You should complete it as quickly as possible.
+Resilvering is a high priority task but can run in the background while performing other system functions, however, this can put a higher demand on system resources.
+Increasing the priority of resilvers helps them finish faster as the system runs tasks with higher prioirty ranking.
+
+Use the **Resilver Priority** screen to schedule a time where a resilver task can become a higher priority for the system and when the additional I/O or CPU use does not affect normal usage.

--- a/static/includes/ResliverPrioritySetWhen.md
+++ b/static/includes/ResliverPrioritySetWhen.md
@@ -1,0 +1,9 @@
+&NewLine;
+
+Select **Enabled**, then use the dropdown lists to select a start time in **Begin** and time to finish in **End** to define a priority period for the resilver.
+To select the day(s) to run the resliver, use the **Days of the Week** dropdown to select when the task can run with the priority given.
+
+{{< hint type=note >}} 
+A resilver process running during the time frame defined between the beginning and end times likely runs faster than during times when demand on system resources is higher.
+We advise you to avoid putting the system under any intensive activity or heavy loads (replications, SMB transfers, NFS transfers, Rsync transfers, S.M.A.R.T. tests, pool scrubs, etc) during a resilver process.
+{{< /hint >}}

--- a/static/includes/TasksResilverPriorityFields.md
+++ b/static/includes/TasksResilverPriorityFields.md
@@ -7,6 +7,6 @@
 |------|-------------|
 | **Enabled** | Select to run resilver tasks between the configured times. |
 | **Begin** | Choose the hour and minute when a resilver process can run at a higher priority. |
-| **End** | Choose the hour and minute after which a resilver process must return to running at a lower priority. A resilver process running after this time will likely take much longer to complete due to running at a lower priority compared to other disk and CPU activities, such as replications, SMB transfers, NFS transfers, Rsync transfers, S.M.A.R.T. tests, pool scrubs, user activity, etc. |
+| **End** | Choose the hour and minute after which a resilver process must return to running at a lower priority. A resilver process running after this time can likely take much longer to complete due to running at a lower priority compared to other disk and CPU activities, such as replications, SMB transfers, NFS transfers, Rsync transfers, S.M.A.R.T. tests, pool scrubs, user activity, etc. |
 | **Days of the Week** | Select the days to run resilver tasks. |
 {{< /truetable >}}


### PR DESCRIPTION
This PR updates both the CORE and SCALE articles on resilvering priorities in Master. 
It creates two new snippets for content shared in both CORE and SCALE. 
It updates the SCALE Scrub Task UI ref with the Advanced Scheduler snippet/expand. 
It makes minor changes to setting descriptions and instructions to clarify the information on setting begin and end priorities. 

These changes can be backported into separate PRs, one for CORE 13.0 and the other for SCALE 24.04 and/or 23.10 as the content applies to those release versions.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
