### PR TITLE
Minor bugfix for historical core release on home page

### DIFF
--- a/layouts/shortcodes/section-cards.html
+++ b/layouts/shortcodes/section-cards.html
@@ -15,9 +15,9 @@
       <div class="section-tab" id="core-next-tab">Next</div>
     </div>
     <div class="section-tab-content" id="core-previous">
-      <a href="https://www.truenas.com/docs/files/CORE12.0Docs.pdf">12.0 Documentation (Archived)</a>
-	  <br><a href="https://www.truenas.com/docs/archive/corereleasenotes/12.0/12.0u2/">12.0-U2 Release Notes (Enterprise Availability)</a>
-	  <br><a href="https://www.truenas.com/docs/archive/corereleasenotes/12.0/12.0release/">12.0 Release Notes</a>
+      <a href="https://www.truenas.com/docs/files/TrueNAS-11.3-U5-User-Guide.pdf">11.3 Documentation (Archived)</a>
+	  <br><a href="https://www.truenas.com/docs/_archive/corereleasenotes/freenas/11.3/11.3u5/">11.3-U5 Release Notes (Final Patch)</a>
+	  <br><a href="https://www.truenas.com/docs/_archive/corereleasenotes/freenas/11.3/11.3/">11.3 Release Notes</a>
     </div>
     <div class="section-tab-content" id="core-stable" style="display:none;">
 	  <a href="https://www.truenas.com/docs/core/13.0/">13.0 Home</a>


### PR DESCRIPTION
The legacy TrueNAS CORE box was accidentally pointed to the release that won't be named, so I've adjusted to reflect the accurate upgrade path, which is 11.3 > 13.0 > 13.3 (eventual).

This is the Docs Hub landing page, so no version backports necessary.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
