### PR TITLE
Add Enterprise-specific issue box

### DIFF
--- a/layouts/shortcodes/enterprise-error.html
+++ b/layouts/shortcodes/enterprise-error.html
@@ -1,0 +1,7 @@
+<blockquote class="gdoc-hint danger">
+  <div class="gdoc-hint__title" style="font-weight:bold;color:var(--enterprise-title);">
+	<img class="enterprise-icon" src="/favicon/TNEnt-favicon-32x32.png" style="padding-right:.25rem;padding-bottom:.5rem;">
+    <span>TrueNAS Enterprise Issue</span>
+  </div>
+  <div class="truenas-enterprise__text">{{ .Inner | $.Page.RenderString }}</div>
+</blockquote>


### PR DESCRIPTION
This is a standardized admonition box to be used when a Known Issue is TrueNAS Enterprise specific and not generic content that uses the light blue styling
![image](https://github.com/truenas/documentation/assets/17933320/d22d6965-e7e6-474f-a5a1-8838aa601405)

Example:
{{< enterprise-error >}}
This is an example of an Enterprise specific issue where we need danger coloration and the TrueNAS Enterprise logo.
{{< /enterprise-error >}}
I'll backport this to 24.04 and 13.3 branch so we can use this moving forward.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
