### PR TITLE
Add enterprise-error shortcode (13.3 backport)

### DIFF
--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -124,10 +124,10 @@ Notable changes:
 
 ### 13.3-BETA1 Ongoing Issues
 
-{{< enterprise >}}
+{{< enterprise-error >}}
 We are aware of an issue impacting TrueCommand connections for High Availability (HA) systems.
 TrueNAS Enterprise HA customers should not upgrade to 13.3-BETA1 at this time.
-{{< /enterprise >}}
+{{< /enterprise-error >}}
 
 <a href="https://ixsystems.atlassian.net/issues/?filter=10549" target="_blank">Click here to see the latest information</a> about public issues discovered in 13.3-BETA1 that are being resolved in a future TrueNAS CORE release.
 This list also includes issues that are not to be fixed in CORE and are resolved in TrueNAS SCALE.

--- a/layouts/shortcodes/enterprise-error.html
+++ b/layouts/shortcodes/enterprise-error.html
@@ -1,0 +1,7 @@
+<blockquote class="gdoc-hint danger">
+  <div class="gdoc-hint__title" style="font-weight:bold;color:var(--enterprise-title);">
+	<img class="enterprise-icon" src="/favicon/TNEnt-favicon-32x32.png" style="padding-right:.25rem;padding-bottom:.5rem;">
+    <span>TrueNAS Enterprise Issue</span>
+  </div>
+  <div class="truenas-enterprise__text">{{ .Inner | $.Page.RenderString }}</div>
+</blockquote>


### PR DESCRIPTION
Include a change to the 13.3-BETA.1 release notes to use the new shortcode for the Enterprise-specific issue.
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
