### PR TITLE
Update reldates from 24.04.1 release (master branch followup)

### DIFF
--- a/data/properties/core-releases.yaml
+++ b/data/properties/core-releases.yaml
@@ -36,7 +36,7 @@ majorVersions:
         link: "https://www.truenas.com/docs/core/13.3/gettingstarted/corereleasenotes/"
         releaseDate: "2024-01-01"
         latest: false
-      - name: "13.3-RC1"
+      - name: "13.3-BETA2"
         type: "Early"
         releaseDate: "2024-06-18"
         latest: false

--- a/data/properties/scale-downloads.yaml
+++ b/data/properties/scale-downloads.yaml
@@ -73,6 +73,9 @@ majorVersions:
     majorVersion: "24.04 (Dragonfish)"
     releaseName: "Dragonfish"
     releases:
+      - name: "24.04.1"
+        link: "https://download.truenas.com/TrueNAS-SCALE-Dragonfish/24.04.1/"
+        date: "2024-05-28"
       - name: "24.04.0"
         link: "https://download.truenas.com/TrueNAS-SCALE-Dragonfish/24.04.0/"
         date: "2024-04-23"

--- a/data/properties/scale-releases.yaml
+++ b/data/properties/scale-releases.yaml
@@ -17,14 +17,14 @@ majorVersions:
     name: "TrueNAS SCALE 24.04 - Dragonfish"
     releaseName: "Dragonfish"
     releases:
-      - name: "24.04.0"
-        type: "Stable"
-        link: "https://www.truenas.com/docs/scale/24.04/gettingstarted/scalereleasenotes/"
-        releaseDate: "2024-04-23"
-        latest: true
       - name: "24.04.1"
         type: "Maintenance"
-        link: 
+        link: "https://www.truenas.com/docs/scale/24.04/gettingstarted/scalereleasenotes/#24041-changelog"
+        releaseDate: "2024-05-28"
+        latest: true
+      - name: "24.04.2"
+        type: "Maintenance"
+        link: ""
         releaseDate: ""
         latest: false
         


### PR DESCRIPTION
- Cherry-pick 24.04.1 release date and 24.04.2 potential entry
- CORE 13.3-RC1 rename to BETA2
- SCALE 24.04.1 release added to downloads list
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
