### PR TITLE
(24.04) Update SCALEUpgradePaths.md

### DIFF
--- a/data/properties/scale-releases.yaml
+++ b/data/properties/scale-releases.yaml
@@ -17,10 +17,10 @@ majorVersions:
     name: "TrueNAS SCALE 24.04 - Dragonfish"
     releaseName: "Dragonfish"
     releases:
-      - name: "24.04.1"
+      - name: "24.04.1.1"
         type: "Maintenance"
-        link: "https://www.truenas.com/docs/scale/24.04/gettingstarted/scalereleasenotes/#24041-changelog"
-        releaseDate: "2024-05-28"
+        link: "https://www.truenas.com/docs/scale/24.04/gettingstarted/scalereleasenotes/#240411-changelog"
+        releaseDate: "2024-05-29"
         latest: true
       - name: "24.04.2"
         type: "Maintenance"

--- a/static/includes/SCALEUpgradePaths.md
+++ b/static/includes/SCALEUpgradePaths.md
@@ -15,7 +15,7 @@
         B["CORE 13.0-U6.1"] -->|ISO install| E
         C["22.12.4.2 (Bluefin)"] -->|update| D
         D["23.10.2 (Cobia)"] -->|update| E
-        E["24.04.0 (Dragonfish)"]
+        E["24.04.1.1 (Dragonfish)"]
       {{< /mermaid >}}
     </div>
     <div class="upgrade-paths-container">
@@ -25,7 +25,7 @@
         A["CORE 13.0-U6.1"] -->|ISO install| D
         B["Current 23.10 (Cobia) release"] -->|update| C
         C["23.10.2 (Cobia)"] -->|update| D
-        D["24.04.0 (Dragonfish)"]
+        D["24.04.1.1 (Dragonfish)"]
       {{< /mermaid >}}
     </div>
 </div>


### PR DESCRIPTION
Adjust the pathways to show 24.04.1.1

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
