### PR TITLE
Single-source and clarify Enterprise app messaging (backporting needed)

### DIFF
--- a/content/SCALE/SCALETutorials/Apps/EnterpriseApps/MinIO/ConfigMinioEnterpriseMNMD.md
+++ b/content/SCALE/SCALETutorials/Apps/EnterpriseApps/MinIO/ConfigMinioEnterpriseMNMD.md
@@ -14,11 +14,9 @@ keywords:
 - enterprise data storage
 ---
 
-{{< enterprise >}}
-The instructions in this article apply to the TrueNAS MinIO Enterprise application installed in a Multi-Node Multi-Disk (MNMD) multi mode configuration. 
+{{< include file="/static/includes/SCALEEnterpriseApps.md" >}}
 
-SCALE Enterprise single controller systems with the applications and virtual machines license have access to the **MinIO Official Enterprise** widget. 
-{{< /enterprise >}}
+The instructions in this article apply to the TrueNAS MinIO Enterprise application installed in a Multi-Node Multi-Disk (MNMD) multi mode configuration.
 
 For more information on MinIO multi mode configurations see [MinIO Single-Node Multi-Drive (SNMD)](https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-single-node-multi-drive.html) or [Multi-Node Multi-Drive (MNMD)](https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#minio-mnmd). MinIO recommends using MNMD (distributed) for enterprise-grade performance and scalability.
 

--- a/content/SCALE/SCALETutorials/Apps/EnterpriseApps/MinIO/ConfigMinioEnterpriseMNMD.md
+++ b/content/SCALE/SCALETutorials/Apps/EnterpriseApps/MinIO/ConfigMinioEnterpriseMNMD.md
@@ -16,9 +16,9 @@ keywords:
 
 {{< include file="/static/includes/SCALEEnterpriseApps.md" >}}
 
-The instructions in this article apply to the TrueNAS MinIO Enterprise application installed in a Multi-Node Multi-Disk (MNMD) multi mode configuration.
+The instructions in this article apply to the TrueNAS MinIO Enterprise application installed in a Multi-Node Multi-Disk (MNMD) multi-mode configuration.
 
-For more information on MinIO multi mode configurations see [MinIO Single-Node Multi-Drive (SNMD)](https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-single-node-multi-drive.html) or [Multi-Node Multi-Drive (MNMD)](https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#minio-mnmd). MinIO recommends using MNMD (distributed) for enterprise-grade performance and scalability.
+For more information on MinIO multi-mode configurations see [MinIO Single-Node Multi-Drive (SNMD)](https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-single-node-multi-drive.html) or [Multi-Node Multi-Drive (MNMD)](https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#minio-mnmd). MinIO recommends using MNMD (distributed) for enterprise-grade performance and scalability.
 
 ## Adding MinIO Enterprise App
 Community members can add and use the MinIO Enterprise app or the default community version.
@@ -29,12 +29,12 @@ Community members can add and use the MinIO Enterprise app or the default commun
 Complete these steps for every system (node) in the cluster. 
 
 Assign four sequential IP addresses or host names such as **minio1.*mycompany.com*** through **minio4.*mycompany.com*** to the TrueNAS SCALE system. 
-If you assign IP address numbers such as *#.#.#.*100 - 103 or *#.#.#.134 - .137, you can uses these in the command string in the **Multi Mode** field. 
+If you assign IP address numbers such as *#.#.#.*100 - 103 or *#.#.#.134 - .137, you can use these in the command string in the **Multi Mode** field. 
 If not using sequential IP addresses, use sequentially numbered host names. 
 Add network settings using either the **Network** screen. Enter host names on the **Global Configuration** screen. 
 
 When creating the certificate, enter the system IP addresses for each system in **Subject Alternate Names**. 
-If configuring MinIO in a MNMD cluster, enter the system IP addresses for each system in the cluster.
+If configuring MinIO in an MNMD cluster, enter the system IP addresses for each system in the cluster.
 
 {{< include file="/static/includes/MinIOEnterpriseFirstSteps.md" >}}
 
@@ -51,7 +51,7 @@ Repeat this procedure for every system (node) in the MNND cluster.
 
 Select **Enable Multi Mode (SNMD or MNMD)**, then click **Add**. 
 If the systems in the cluster have sequentially assigned IP addresses, use the IP addresses in the command string you enter in the **Multi Mode (SNMD or MNMD)** field. 
-For example, <b>https://<i>10.123.12.10</i>{0...3}:30000/data{1...4}</b> where the last number in the last octet of IP address number is the first number in the **{0...3}** string. 
+For example, <b>https://<i>10.123.12.10</i>{0...3}:30000/data{1...4}</b> where the last number in the last octet of the IP address number is the first number in the **{0...3}** string. 
 Separate the numbers in the curly brackets with three dots. 
 If your sequential IP addresses are not using 100 - 103, for example *10.123.12.125* through 128, then enter them as <b>https://<i>10.123.12.12</i>{5...8}:30000/data{1...4}</b>.
 Enter the same string in the **Multi Mode (SNMD or MNMD)** field in all four systems in the cluster. 
@@ -69,6 +69,6 @@ Enter <b>https://minio{1...4}.<i>mycompany.com</i>:30000/data{1...4}</b> in the 
 After installing and getting the MinIO Enterprise application running in SCALE, log into the MinIO web portal and complete the MinIO setup.
 
 Go to **Monitoring > Metrics** to verify the servers match the total number of systems (nodes) you configured. 
-Verify the number of drives match the number you configured on each system, four systems each with four drives (4 systems x 4 drives each = 16 drives).
+Verify the number of drives matches the number you configured on each system, four systems each with four drives (4 systems x 4 drives each = 16 drives).
 
 Refer to MinIO documentation for more information.

--- a/content/SCALE/SCALETutorials/Apps/EnterpriseApps/MinIO/ConfigMinioEnterpriseSNMD.md
+++ b/content/SCALE/SCALETutorials/Apps/EnterpriseApps/MinIO/ConfigMinioEnterpriseSNMD.md
@@ -14,11 +14,9 @@ keywords:
 - enterprise data storage
 ---
 
-{{< enterprise >}}
-The instructions in this article apply to the TrueNAS MinIO Enterprise application installed in a Single-Node Multi-Disk (SNMD) multi mode configuration. 
+{{< include file="/static/includes/SCALEEnterpriseApps.md" >}}
 
-SCALE Enterprise single controller systems with the applications and virtual machines license have access to the **MinIO Official Enterprise** widget. 
-{{< /enterprise >}}
+The instructions in this article apply to the TrueNAS MinIO Enterprise application installed in a Single-Node Multi-Disk (SNMD) multi mode configuration.
 
 For more information on MinIO multi mode configurations see [MinIO Single-Node Multi-Drive (SNMD)](https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-single-node-multi-drive.html) or [Multi-Node Multi-Drive (MNMD)](https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#minio-mnmd). MinIO recommends using MNMD (distributed) for enterprise-grade performance and scalability.
 

--- a/content/SCALE/SCALETutorials/Apps/EnterpriseApps/MinIO/ConfigMinioEnterpriseSNMD.md
+++ b/content/SCALE/SCALETutorials/Apps/EnterpriseApps/MinIO/ConfigMinioEnterpriseSNMD.md
@@ -16,9 +16,9 @@ keywords:
 
 {{< include file="/static/includes/SCALEEnterpriseApps.md" >}}
 
-The instructions in this article apply to the TrueNAS MinIO Enterprise application installed in a Single-Node Multi-Disk (SNMD) multi mode configuration.
+The instructions in this article apply to the TrueNAS MinIO Enterprise application installed in a Single-Node Multi-Disk (SNMD) multi-mode configuration.
 
-For more information on MinIO multi mode configurations see [MinIO Single-Node Multi-Drive (SNMD)](https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-single-node-multi-drive.html) or [Multi-Node Multi-Drive (MNMD)](https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#minio-mnmd). MinIO recommends using MNMD (distributed) for enterprise-grade performance and scalability.
+For more information on MinIO multi-mode configurations see [MinIO Single-Node Multi-Drive (SNMD)](https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-single-node-multi-drive.html) or [Multi-Node Multi-Drive (MNMD)](https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#minio-mnmd). MinIO recommends using MNMD (distributed) for enterprise-grade performance and scalability.
 
 ## Adding MinIO Enterprise App
 Community members can add and use the MinIO Enterprise app or the default community version.

--- a/content/SCALE/SCALETutorials/Apps/EnterpriseApps/MinIO/_index.md
+++ b/content/SCALE/SCALETutorials/Apps/EnterpriseApps/MinIO/_index.md
@@ -16,17 +16,11 @@ keywords:
 - enterprise data storage
 ---
 
-{{< enterprise >}}
+{{< include file="/static/includes/SCALEEnterpriseApps.md" >}}
+
 The instructions in this article apply to the Official TrueNAS Enterprise MinIO application.
 This smaller version of MinIO is tested and polished for a safe and supportable experience for TrueNAS Enterprise customers.
-To use the complete MinIO app without iXsystems support, see the application available in the Community Apps catalog.
-
 The Enterprise MinIO application is tested and verified as an immutable target for Veeam Backup and Replication.
-
-We recommend that TrueNAS SCALE Enterprise (HA) systems not deploy applications.
-
-SCALE Enterprise single controller systems with the applications and virtual machines license feature have access to the **MinIO Official Enterprise** widget.
-{{< /enterprise >}}
 
 ## Adding MinIO Enterprise App
 Community members can add and use the MinIO Enterprise app or the default community version.

--- a/content/SCALE/SCALETutorials/Apps/EnterpriseApps/Syncthing.md
+++ b/content/SCALE/SCALETutorials/Apps/EnterpriseApps/Syncthing.md
@@ -32,7 +32,7 @@ Create a self-signed certificate for the Syncthing enterprise app.
 {{< include file="/static/includes/SyncthingFirstSteps.md" >}}
 
 ## Installing the Syncthing Application
-Go to **Apps > Discover Apps**, locate the **Syncthing** enterprise app widget.
+Go to **Apps > Discover Apps**, and locate the **Syncthing** enterprise app widget.
 
 {{< trueimage src="/images/SCALE/Apps/SyncthingEnterpriseAppWidget.png" alt="Syncthing Enterprise App Widget" id="Syncthing Enterprise App Widget" >}}
 
@@ -43,7 +43,7 @@ Click on the widget to open the Syncthing details screen.
 Click **Install** to open the **Install Syncthing** screen.
 
 Application configuration settings are presented in several sections, each explained below.
-To find specific fields click in the **Search Input Fields** search field, scroll down to a particular section or click on the section heading on the navigation area in the upper-right corner.
+To find specific fields click in the **Search Input Fields** search field, scroll down to a particular section, or click on the section heading in the navigation area in the upper-right corner.
 
 {{< trueimage src="/images/SCALE/Apps/InstallSyncthingEnterpriseScreen.png" alt="Install Syncthing Enterprise Screen" id="Install Syncthing Enterprise Screen" >}}
 
@@ -157,10 +157,10 @@ The application might use considerably less system resources.
 {{< trueimage src="/images/SCALE/Apps/InstallSyncthingEnterpriseResourcesConfig.png" alt="Syncthing Enterprise Resource Limits" id="Syncthing Enterprose Resource Limits" >}}
 
 To customize the CPU and memory allocated to the container (pod) Syncthing uses, enter new CPU values as a plain integer value followed by the suffix **m** (milli).
-Default is 4000m.
+The default is 4000m.
 
 Accept the default value 8Gb allocated memory or enter a new limit in bytes.
-Enter a plain integer followed by the measurement suffix, for example 129M or 123MiB.
+Enter a plain integer followed by the measurement suffix, for example, 129M or 123MiB.
 
 ## Increasing inotify Watchers
 
@@ -182,7 +182,7 @@ Click **Add** to open the **Add Sysctl** screen.
 Enter **fs.inotify.max_user_watches** in **Variable**.
 
 Enter a **Value** larger than the number of directories monitored by Syncthing.
-There is a small memory impact for each inotify watcher of 1080 bytes, so it is best to start with a lower number, we suggest 204800, and increase if needed.
+There is a small memory impact for each inotify watcher of 1080 bytes, so it is best to start with a lower number, we suggest 204800 and increase if needed.
 
 Enter a **Description** for the variable, such as *Increase inotify limit*.
 

--- a/content/SCALE/SCALETutorials/Apps/EnterpriseApps/Syncthing.md
+++ b/content/SCALE/SCALETutorials/Apps/EnterpriseApps/Syncthing.md
@@ -14,11 +14,9 @@ keywords:
 - enterprise data storage
 ---
 
-{{< include file="/static/includes/SyncthingArticleIntro.md" >}}
+{{< include file="/static/includes/SCALEEnterpriseApps.md" >}}
 
-{{< enterprise >}}
-Syncthing is available to Enterprise systems with the appropriate VM and applications license.
-{{< /enterprise >}}
+{{< include file="/static/includes/SyncthingArticleIntro.md" >}}
 
 ## Syncthing Overview
 {{< include file="/static/includes/SyncthingOverview.md" >}}

--- a/content/SCALE/SCALETutorials/Apps/EnterpriseApps/_index.md
+++ b/content/SCALE/SCALETutorials/Apps/EnterpriseApps/_index.md
@@ -15,20 +15,10 @@ keywords:
 related: false
 ---
 
+{{< include file="/static/includes/SCALEEnterpriseApps.md" >}}
+
 TrueNAS is certified with leading hypervisors and backup solutions to streamline storage operations and ensure compatibility with your existing IT infrastructure. TrueNAS Enterprise storage appliances deliver a wide range of features and scalability for virtualization and private cloud environments, with the ability to create off-site backups with scheduled sync and replication features.
-
-{{< enterprise >}}
 TrueNAS applications expand the capabilities of your system by adding third-party software but can add significant risk to system stability and security.
-We do not recommend deploying applications on SCALE Enterprise High Availability (HA) systems.
-
-SCALE Enterprise licensed systems do not have applications available by default.
-This feature is enabled as part of the Enterprise license after consulting with iXsystems.
-Only install applications with the assistance of iXsystems Support.
-
-{{< expand "Contacting Support" "v" >}}
-{{< include file="/static/includes/iXsystemsSupportContact.md" >}}
-{{< /expand >}}
-{{< /enterprise >}}
 
 There are general best practices to keep in mind when using applications with TrueNAS SCALE:
 

--- a/static/includes/SCALEEnterpriseApps.md
+++ b/static/includes/SCALEEnterpriseApps.md
@@ -1,0 +1,12 @@
+&NewLine;
+
+{{< enterprise >}}
+SCALE Enterprise licensed systems do not have applications available by default.
+This feature can be enabled as part of the Enterprise license after consulting with iXsystems.
+
+Only install qualified applications from the Enterprise applications train with the assistance of iXsystems Support.
+
+{{< expand "Contacting Support" "v" >}}
+{{< include file="/static/includes/iXsystemsSupportContact.md" >}}
+{{< /expand >}}
+{{< /enterprise >}}


### PR DESCRIPTION
Reviewed the messaging on each article in the Enterprise Applications section.

Single sourced the specific messaging around Enterprise systems needing a specific license and recommendation to only install apps from the Enterprise apps train.

Applied single-sourced snippet across all SCALE Enterprise Apps articles



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
