### PR TITLE
Expand debug generate with SCALE CLI (midcli) instruction

### DIFF
--- a/static/includes/CreateDebugSCALE.md
+++ b/static/includes/CreateDebugSCALE.md
@@ -2,3 +2,16 @@
 
 On TrueNAS SCALE systems, go to **System Settings > Advanced**, then click **Save Debug** and wait for the file to download to your local system. 
 Generating the debug file might take a few minutes to complete. After that, it downloads to your system.
+
+To generate a debug from the SCALE CLI, enter <command>system debug > <i>debugname</i>.tgz</command>, replacing <i>debugname</i> with your chosen filename.
+You'll need use SFTP or similar method to connect to TrueNAS and download the file from the /home/<i>username</i> location, replacing <i>username</i> with the account name that generated the debug.
+SFTP Example:
+```
+PS C:\Users\tester> sftp admin@exampletruenas.net
+Connected to exampletruenas.net.
+sftp> cd /home/admin
+sftp> get testdebug.tgz
+Fetching /home/admin/testdebug.tgz to testdebug.tgz
+/home/admin/testdebug.tgz						100% 7110KB	4.1MB/s	00.01
+sftp> exit
+```

--- a/static/includes/CreateDebugSCALE.md
+++ b/static/includes/CreateDebugSCALE.md
@@ -4,7 +4,7 @@ On TrueNAS SCALE systems, go to **System Settings > Advanced**, then click **Sav
 Generating the debug file might take a few minutes to complete. After that, it downloads to your system.
 
 To generate a debug from the SCALE CLI, enter <command>system debug > <i>debugname</i>.tgz</command>, replacing <i>debugname</i> with your chosen filename.
-You'll need use SFTP or similar method to connect to TrueNAS and download the file from the /home/<i>username</i> location, replacing <i>username</i> with the account name that generated the debug.
+You must use SFTP or a similar method to connect to TrueNAS and download the file from the /home/<i>username</i> location, replacing <i>username</i> with the account name that generated the debug.
 SFTP Example:
 ```
 PS C:\Users\tester> sftp admin@exampletruenas.net


### PR DESCRIPTION
Add SCALE CLI instruction for debug generation when UI access is not possible. Included a rudimentary sftp example.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
