### PR TITLE
Update CloudflareTunnel.md with info to prevent error when setting OVERWRITEHOST

### DIFF
--- a/content/SCALE/SCALETutorials/Apps/AppSecurity/CloudflareTunnel.md
+++ b/content/SCALE/SCALETutorials/Apps/AppSecurity/CloudflareTunnel.md
@@ -111,7 +111,7 @@ The [Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_man
 Depending on the reverse proxy and its configuration, these settings may vary.
 For example, if you don't use a subdomain, but a path like *example.com/nextcloud*.
 
-If you want to access your application via subdomain (shown in this guide) two environment variables must be set in the Nextcloud application: [overwrite.cli.url](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#overwrite-cli-url) and [overwritehost](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#overwritehost).
+If you want to access your application via subdomain (shown in this guide) two environment variables must be set in the Nextcloud application: [overwrite.cli.url](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#overwrite-cli-url) and [overwritehost](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#overwritehost). Additionally, you will need to clear the Host field under Nextcloud Configuration, otherwise the OVERWRITEHOST variable cannot be set.
 
 Enter the two environment variables in **Name** as *OVERWRITECLIURL* and *OVERWRITEHOST*.
 


### PR DESCRIPTION
Added note about clearing Host field when setting OVERWRITEHOST environment variable. Otherwise you will get this error "Environment Variable [OVERWRITEHOST] in [envList] tried to override the Environment Variable that is already defined in [Secret - nextcloud-creds]"

Please see this post where I asked how to fix the error I was getting: https://forums.truenas.com/t/unable-set-set-overwritehost-variable-for-nextcloud-cloudflare-reverse-proxy/5659
