### PR TITLE
Update Rsyncd.md

### DIFF
--- a/content/SCALETutorials/Apps/CommunityApps/Rsyncd.md
+++ b/content/SCALETutorials/Apps/CommunityApps/Rsyncd.md
@@ -137,7 +137,7 @@ Parameter: "secrets file"
 Value: path to the rsyncd.secrets file
 
 You will have to place the file inside your module dataset and use the value:
-"/data/<module name>/rsynd.secrets"
+"/data/<module name>/rsyncd.secrets"
 
 The file will have to be chmod 600 and owned by root:root in order for the rsync daemon to accept it for authentication.
 


### PR DESCRIPTION
Fixed filename typo for rsyncd.secrets.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
