### PR TITLE
Add hint on where to get credentials for ACME DNS authenticator via OVH

### DIFF
--- a/content/SCALETutorials/Credentials/Certificates/AddACMESCALE.md
+++ b/content/SCALETutorials/Credentials/Certificates/AddACMESCALE.md
@@ -33,7 +33,7 @@ If you select **cloudflare** as the authenticator, you must enter your Cloudflar
 
 If you select **route53** as the authenticator, you must enter your Route53 Access key ID and secret access key.
 
-If you select **OVH** as the authenticator, you must enter your OVH application key, application secret, consumer key, and endpoint.  
+If you select **OVH** as the authenticator, you must enter your OVH application key, application secret, consumer key, and endpoint. For information on where and how to get these values and which access rules need to be allowed, consult the documentation of [certbot-dns-ovh](https://certbot-dns-ovh.readthedocs.io/en/stable/).
 
 Click **Save** to add the authenticator.
 

--- a/content/SCALETutorials/Credentials/Certificates/AddACMESCALE.md
+++ b/content/SCALETutorials/Credentials/Certificates/AddACMESCALE.md
@@ -29,11 +29,13 @@ Enter a name, and select the authenticator you want to configure.
 Options are **[cloudflare](https://www.cloudflare.com)**, Amazon **[route53](https://aws.amazon.com/route53/)**, [**OVH**](https://www.ovhcloud.com/en/domains/), and **shell**.
 **Authenticator** selection changes the configuration fields.
 
-If you select **cloudflare** as the authenticator, you must enter your Cloudflare account email address, API key, and API token.
+If you select **cloudflare** as the authenticator, you must enter your Cloudflare account email address, [API key](https://developers.cloudflare.com/fundamentals/api/get-started/keys/), and [API token](https://developers.cloudflare.com/fundamentals/api/get-started/create-token/).
 
 If you select **route53** as the authenticator, you must enter your Route53 Access key ID and secret access key.
+See [AWS](https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html#sec-access-keys-and-secret-access-keys) documentation for information on creating a long-term access key with these credentials.
 
-If you select **OVH** as the authenticator, you must enter your OVH application key, application secret, consumer key, and endpoint. For information on where and how to get these values and which access rules need to be allowed, consult the documentation of [certbot-dns-ovh](https://certbot-dns-ovh.readthedocs.io/en/stable/).
+If you select **OVH** as the authenticator, you must enter your OVH application key, application secret, consumer key, and endpoint. 
+See [OVHcloud](https://support.us.ovhcloud.com/hc/en-us/articles/19901571606547-Using-Service-Accounts-to-Connect-to-OVHcloud-APIs) and [certbot-dns-ovh](https://certbot-dns-ovh.readthedocs.io/en/stable/) for information on retrieving these credentials and configuring access.
 
 Click **Save** to add the authenticator.
 


### PR DESCRIPTION
I was struggling to find where to create the OVH credentials required for the ACME DNS authenticator. I found the site to create the credentials, but had trouble finding which routes to allowlist while creating the credential. So I dug into the code for the authenticator and found that TrueNAS is using the certbot-dns-ovh package. Its documentation contained the necessary information, so I though this PR would help others find the information.

Is this fine or would you like me to structure this differently or reproduce the information on this page instead of referencing the other docs?

> Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.

This is fine.