### PR TITLE
Add Route53 action names to SettingUpLetsEncryptCertificates.md

### DIFF
--- a/content/SCALETutorials/Credentials/Certificates/SettingUpLetsEncryptCertificates.md
+++ b/content/SCALETutorials/Credentials/Certificates/SettingUpLetsEncryptCertificates.md
@@ -25,9 +25,9 @@ Go to **Credentials > Certificates** and click **ADD** in the **ACME DNS-Authent
 Enter the required fields depending on your provider, then click **Save**.
 
 For Cloudflare, enter either your **Cloudflare Email** and **API Key**, or enter an **API Token**.
-If you create an [API Token](https://dash.cloudflare.com/profile/api-tokens), make sure to give the token the permission **Zone.DNS:Edit** as it's [required by certbot](https://certbot-dns-cloudflare.readthedocs.io/en/stable/).
+If you create an [API Token](https://dash.cloudflare.com/profile/api-tokens), make sure to give the token the permission **Zone.DNS:Edit**, as it's [required by certbot](https://certbot-dns-cloudflare.readthedocs.io/en/stable/).
 
-For Route53, enter your **Access Key ID** and **Secret Access Key**. The associated IAM user must have permission to perform the Route53 actions ListHostedZones, ChangeResourceRecordSets, and GetChange.
+For Route53, enter your **Access Key ID** and **Secret Access Key**. The associated IAM user must have permission to perform the Route53 actions `ListHostedZones`, `ChangeResourceRecordSets`, and `GetChange`.
 
 For OVH, enter your **OVH Application Key**, **OVH Application Secret**, **OVH Consumer Key**, and **OVH Endpoint**.
 

--- a/content/SCALETutorials/Credentials/Certificates/SettingUpLetsEncryptCertificates.md
+++ b/content/SCALETutorials/Credentials/Certificates/SettingUpLetsEncryptCertificates.md
@@ -27,7 +27,7 @@ Enter the required fields depending on your provider, then click **Save**.
 For Cloudflare, enter either your **Cloudflare Email** and **API Key**, or enter an **API Token**.
 If you create an [API Token](https://dash.cloudflare.com/profile/api-tokens), make sure to give the token the permission **Zone.DNS:Edit** as it's [required by certbot](https://certbot-dns-cloudflare.readthedocs.io/en/stable/).
 
-For Route53, enter your **Access Key ID** and **Secret Access Key**.
+For Route53, enter your **Access Key ID** and **Secret Access Key**. The associated IAM user must have permission to perform the Route53 actions ListHostedZones, ChangeResourceRecordSets, and GetChange.
 
 For OVH, enter your **OVH Application Key**, **OVH Application Secret**, **OVH Consumer Key**, and **OVH Endpoint**.
 


### PR DESCRIPTION
When setting up Route53 I wasn't sure which permissions were needed so it took some trial and error to get it to work. Looking at [the code](https://github.com/truenas/middleware/blob/master/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/route53.py) I believe these are the three that are actually used.

It looks like the docs on `master` have been reorganized and no longer include this page; let me know if I should submit a PR for those in addition (or instead).

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.