### PR TITLE
PD-1219-remove-references-to-special-vdev-hot-spare-support

### DIFF
--- a/static/includes/FusionPools.md
+++ b/static/includes/FusionPools.md
@@ -23,15 +23,15 @@ Configure the **Data VDevs**, then click **ADD VDEV** and select **Metadata**.
 Add SSDs to the new **Metadata VDev** and select the same layout as the **Data VDevs**.
 
 {{< hint type=important >}}
-The metadata special VDEV is critical for pool operation and data integrity, so you must protect it with hot spare(s).
+The metadata special VDEV is critical for pool operation and data integrity.
 {{< /hint >}}
 
 {{< expand "UPS Recommendation" "v" >}}
 When using SSDs with an internal cache, add uninterruptible power supply (UPS) to the system to help minimize the risk from power loss.
 {{< /expand >}}
 
-Using special VDEVs identical to the data VDEVs (so they can use the same hot spares) is recommended, but for performance reasons you can make a different type of VDEV (like a mirror of SSDs).
-In that case you must provide hot spare(s) for that drive type as well. Otherwise, if the special VDEV fails and there is no redundancy, the pool becomes corrupted and prevents access to stored data.
+Using special VDEVs identical to the data VDEVs is recommended, but for performance reasons you can make a different type of VDEV (like a mirror of SSDs).
+If the special VDEV fails and there is no redundancy, the pool becomes corrupted and prevents access to stored data.
 
 {{< hint type=important >}}
 Drives added to a metadata VDEV cannot be removed from the pool.


### PR DESCRIPTION
Removed all instances that the ability to configure 'hot spares' for metadata/special VDEVs was found. Conversed with Grace on Tim's 06/11/124 comment, and she advised me that the docs already adequately discussed improved pool performance.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
