### PR TITLE
PD-1264-fix-ambiguity-with-ftp-documentation

### DIFF
--- a/content/SCALE/SCALETutorials/SystemSettings/Services/FTPServiceSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Services/FTPServiceSCALE.md
@@ -30,7 +30,7 @@ Go to **Storage** to add a new [dataset]({{< relref "DatasetsSCALE.md" >}}) to u
 Next, add a new user. Go to **Credentials > Local Users**  and click **Add** to create a local user on the TrueNAS.
 
 Assign a user name and password, and link the newly created FTP dataset as the user home directory.
-You can do this for every user or create a global account for FTP (for example, *OurOrgFTPaccnt*).
+You can do this for every user or create a global account for FTP (for example, *OurOrgFTPaccnt*). Note, however, that you cannot create multiple accounts utilizing the same dataset as your home directory.
 
 Edit the file permissions for the new dataset. Go to **Datasets**, then click on the name of the new dataset. Scroll down to **Permissions** and click **Edit**.
 


### PR DESCRIPTION
Added "Note, however, that you cannot create multiple accounts utilizing the same dataset as your home directory," to ensure that future readers understand that they can't create multiple accounts using the same dataset as their home directory. 

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
