### PR TITLE
PD-1265 Add SMB Auxiliary Parameters to the MigratePrep.md Checklist

### DIFF
--- a/content/SCALE/GettingStarted/Migrate/MigratePrep.md
+++ b/content/SCALE/GettingStarted/Migrate/MigratePrep.md
@@ -34,6 +34,7 @@ CORE Enterprise customers are encouraged to contact Support for assistance with 
    CORE systems at the latest 13.0 release can use the [iso upgrade](#migrating-using-an-iso-file-to-upgrade) method to migrate to SCALE.
 
 2. Migrate [GELI-encrypted pools](https://www.truenas.com/docs/core/coretutorials/storage/pools/storageencryption/#geli-pool-migrations) to a non-GELI-encrypted pool before upgrading from CORE 12.0x or earlier releases!
+   If you do not migrate from GELI to ZFS encryption before upgrading to CORE 13.0-Ux or migrating to SCALE you permanently lose access to the data in the GELI encrypted pool(s).
 
 3. Verify the root user is not locked.
    Go to **Accounts > Users**, select the root user and click **Edit** to view current settings and confirm **Lock User** is not selected.
@@ -66,7 +67,12 @@ CORE Enterprise customers are encouraged to contact Support for assistance with 
 
    <input type="checkbox"> Data protection tasks - Write down or take screenshots of replication, periodic snapshot, cloud sync, or other task settings to reconfigure these in SCALE if you want to duplicate these tasks.
 
-5. Write down or take screenshots of your network configuration information.
+5. Remove all CORE SMB auxiliary parameter settings before migrating to SCALE. 
+   As of 23.10 SCALE COBIA, the SMB **Auxiliary Parameters** option is no longer available in the UI.
+   Attempting to migrate with these settings can result in your system experiencing system issues post upgrade that require access to the CLI to fix.
+   We recommend removing these unsupported settings before migrating from CORE to SCALE.
+
+6. Write down or take screenshots of your network configuration information.
    Capture the global network settings, interfaces (LAGG, VLAN, bridge settings), static IP addresses, and aliases.
 
    FreeBSD and Linux use different nomenclature for network interfaces, bridges, LAGGs, and VLANs.
@@ -79,14 +85,14 @@ CORE Enterprise customers are encouraged to contact Support for assistance with 
    If there are issues after a clean install of SCALE from an <file>iso</file> file or you are not using DHCP for network and interface configuration, use the information from your CORE settings to configure your SCALE network settings and to reconfigure your static IPs or aliases.
       {{< include file="/static/includes/NetworkInstallRequirementsSCALE.md" >}}
 
-6. Migrate the deprecated S3 MinIO service (if in use). See [services deprecated in SCALE](#migrating-from-deprecated-services).
+7. Migrate the deprecated S3 MinIO service (if in use). See [services deprecated in SCALE](#migrating-from-deprecated-services).
    This is a lengthy process depending on the amount of data stored while using the S3 service.
    Read and follow instructions in [Migrating MinIO Data from CORE to SCALE](https://www.truenas.com/docs/solutions/miniocoretoscale/)!
    Make sure S3 MinIO data is backed up as a precaution. The migration process from the S3 service requires first [migrating to the MinIO plugin in TrueNAS CORE](https://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/plugins/minioplugin/#migrating-from-s3-service-to-minio-plugin), migrating from CORE to SCALE, then installing the SCALE MinIO app and importing S3 data.
 
-7. Back up any critical data.
+8. Back up any critical data.
 
-8. Download your [system configuration file](https://www.truenas.com/docs/core/coretutorials/systemconfiguration/usingconfigurationbackups/) and a [debug file](https://www.truenas.com/docs/core/uireference/system/advanced/).
+9. Download your [system configuration file](https://www.truenas.com/docs/core/coretutorials/systemconfiguration/usingconfigurationbackups/) and a [debug file](https://www.truenas.com/docs/core/uireference/system/advanced/).
    After updating to the latest publicly-available release of CORE and making any changes to CORE user accounts or any other settings download these files and keep them in a safe place and where you can access them if you need to revert to CORE with a clean install using the CORE <file>iso</file> file.
 
 After completing the steps that apply to your CORE system listed above, download the [SCALE ISO file](https://www.truenas.com/download-tn-scale/) and save it to your computer.

--- a/content/SCALE/GettingStarted/SCALEReleaseNotes.md
+++ b/content/SCALE/GettingStarted/SCALEReleaseNotes.md
@@ -49,8 +49,8 @@ More details are available from [Software Releases]({{< relref "/TrueNASUpgrades
 * TrueNAS SCALE is an appliance built from specific Linux packages.
   Attempting to update SCALE with `apt` or methods other than the SCALE web interface can result in a nonfunctional system.
 
-* All auxiliary parameters can change between TrueNAS major versions due to security and development changes.
-  We recommend removing all auxiliary parameters from TrueNAS configurations before upgrading.
+* All auxiliary parameters can experience changes between TrueNAS major versions due to security and development changes.
+  We recommend removing all auxiliary parameters from TrueNAS configurations before upgrading as these settings can result in system failures after an upgrade.
 
 * {{< include file="/static/includes/UpgradeClearCache.md" >}}
 

--- a/static/includes/COREMigratesList.md
+++ b/static/includes/COREMigratesList.md
@@ -1,7 +1,7 @@
 &NewLine;
 
 Although TrueNAS attempts to keep most of your CORE configuration data when upgrading to SCALE, some CORE-specific items do not transfer.
-These are the items that don't migrate from CORE:
+These are the items that do not migrate from CORE:
 
 * Microsoft OneDrive Cloud Sync credentials and tasks. OneDrive compatibility is not available in TrueNAS SCALE.
 * FreeBSD GELI encryption.
@@ -15,6 +15,9 @@ These are the items that don't migrate from CORE:
 * NIS data.
 * System tunables.
 * ZFS boot environments.
+* SMB auxiliary parameters.
+  As of SCALE 23.10 (Cobia), the **Auxiliary Parameters** option is no longer available in the UI as a configurable option.
+  We recommend removing any auxiliary parameter settings in CORE before migrating to SCALE.
 * AFP shares also do not transfer, but migrate into an SMB share with AFP compatibility enabled.
 * CORE `netcli` utility. A new CLI utility is used for the [Console Setup Menu]({{< relref "ConsoleSetupMenuSCALE.md" >}}) and other commands issued in a CLI.
   By default, any TrueNAS user account with **netcli** as the chosen **Shell** updates to use the **nologin** option instead. See the [Users Screens]({{< relref "LocalUsersScreensSCALE.md#authentication-settings" >}}) reference article for descriptions of all **Shell** options.


### PR DESCRIPTION
This PR adds removing SMB auxiliary parameter settings in CORE before migrating to SCALE to the list of things that cannot migrate, to the step procedure to make sure users remove these settings before saving the CORE config file and migrating to SCALE. It updates the SCALE release notes to clarify the statement to say auxiliary parameters can experience changes between releases to make it clear that changes are subject to changes outside of user input.

The change in the release notes can be backported to 24.04 and 23.10 to clarify the meaning of what is currently written. If backported a separate PR will be created for each branch.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
