### PR TITLE
Update AccessSettingsWidget.md

### DIFF
--- a/static/includes/AccessSettingsWidget.md
+++ b/static/includes/AccessSettingsWidget.md
@@ -36,7 +36,7 @@ The default lifetime setting is 300 seconds, or five minutes.
 
 The minimum value allowed is 30 seconds.
 
-The maximum is 2147482 seconds, or 20 hours, 31 minutes, and 22 seconds.
+The maximum is 2147482 seconds, or 24 days, 20 hours, 31 minutes, and 22 seconds.
 {{< /hint >}}
 
 Click **Save**.


### PR DESCRIPTION
The maximum token lifetime of 2147482 seconds omits the days



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
