### PR TITLE
PD-1325-remove-ftp-allow-root-login-setting-content-from-24-10

### DIFF
--- a/content/SCALE/SCALETutorials/SystemSettings/Services/FTPServiceSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Services/FTPServiceSCALE.md
@@ -51,7 +51,7 @@ Configure the options according to your environment and security considerations.
 
 To confine FTP sessions to the home directory of a local user, select both **chroot** and **Allow Local User Login**. 
 
-Do *not* allow anonymous or root access unless it is necessary. 
+Do *not* allow anonymous access unless it is necessary. 
 Enable TLS when possible (especially when exposing FTP to a WAN). TLS effectively makes this [FTPS](https://tools.ietf.org/html/rfc4217) for better security.
 
 Click **Save** and then start the FTP service.
@@ -87,7 +87,7 @@ When configuring FTP bandwidth settings, we recommend manually entering the unit
 
 To confine FTP sessions to the home directory of a local user, select **chroot**. 
 
-Do *not* allow anonymous or root access unless it is necessary. 
+Do *not* allow anonymous access unless it is necessary. 
 Enable TLS when possible (especially when exposing FTP to a WAN). TLS effectively makes this [FTPS](https://tools.ietf.org/html/rfc4217) for better security.
 
 Click **Save**, then start the FTP service.

--- a/content/SCALE/SCALEUIReference/SystemSettings/Services/FTPServiceScreenSCALE.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/Services/FTPServiceScreenSCALE.md
@@ -48,7 +48,6 @@ To configure FTP, go to **System > Services** and find **FTP**, then click <i cl
 | Settings | Description |
 |----------|-------------|
 | **Always Chroot** | Only allows users to access their home directory if they are in the **wheel** group. This option increases security risk. To confine FTP sessions to a local user home directory, enable **chroot** and select **Allow Local User Login**. |
-| **Allow Root Login** | Select to allow root logins. This option increases security risk, so enabling this is discouraged. Do *not* allow anonymous or root access unless it is necessary. 
 Enable TLS when possible (especially when exposing FTP to a WAN). TLS effectively makes this [FTPS](https://tools.ietf.org/html/rfc4217) for better security. |
 | **Allow Anonymous Login** | Select to allow anonymous FTP logins with access to the directory specified in **Path**. Selecting this displays the **Path** field. Enter or browse the location to populate the field. |
 | **Allow Local User Login** | Select to allow any local user to log in. Only members of the **ftp** group may log in by default. |


### PR DESCRIPTION
Removed mentions of FTP root logins in FTPServiceSCALE.md and FTPServiceScreenSCALE.md.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
