### PR TITLE
PD-1357: 13.3-RELEASE docs updates and changelog (13.3 branch)

### DIFF
--- a/content/CORETutorials/Getting Support.md
+++ b/content/CORETutorials/Getting Support.md
@@ -57,6 +57,7 @@ You are always welcome to network with other TrueNAS users using the various soc
 * [LinkedIn](https://www.linkedin.com/groups/3903140/)
 * [Facebook](https://www.facebook.com/truenascommunity)
 
+<!-- Comment out Enterprise support as not used in 13.3-RELEASE
 ## TrueNAS Enterprise
 
 {{< enterprise >}}
@@ -114,3 +115,4 @@ Use the same email address submitted with the ticket when registering.
 ## Contacting iXsystems Support
 
 {{< include file="/static/includes/iXsystemsSupportContact.md" >}}
+-->

--- a/content/CORETutorials/Network/Interfaces/SettingStaticIP.md
+++ b/content/CORETutorials/Network/Interfaces/SettingStaticIP.md
@@ -56,9 +56,11 @@ This contains creation and configuration options for physical and virtual networ
 
 You can configure static IP addresses while creating or editing an interface.
 
+<!-- Enterprise specific comment that doesn't apply in 13.3-RELEASE
 {{< hint type=tip >}}
-To edit an active interface on TrueNAS Enterprise systems, you must first disable [High Availability]({{< relref "/UIReference/System/Failover.md" >}}).
+To edit an active interface on TrueNAS Enterprise systems, you must first disable High Availability relref "/UIReference/System/Failover.md" .
 {{< /hint >}}
+-->
 
 {{< trueimage src="/images/CORE/Network/NetworkInterfacesEdit.png" alt="Editing an Interface" id="Editing an Interface" >}}
 

--- a/content/CORETutorials/Sharing/iSCSI/SettingUpFibreChannel.md
+++ b/content/CORETutorials/Sharing/iSCSI/SettingUpFibreChannel.md
@@ -4,6 +4,7 @@ description: "Describes how to set up Fibre Channel on TrueNAS CORE."
 weight: 20
 tags:
 - iscsi
+draft: true
 ---
 
 {{< hint type=note >}}

--- a/content/CORETutorials/Storage/Pools/StorageEncryption.md
+++ b/content/CORETutorials/Storage/Pools/StorageEncryption.md
@@ -23,7 +23,7 @@ Data-at-rest encryption is available with:
 
 The local TrueNAS system manages keys for data-at-rest.
 The user is responsible for storing and securing their keys.
-The [Key Management Interface Protocol (KMIP)](https://docs.oasis-open.org/kmip/spec/v1.1/os/kmip-spec-v1.1-os.html) is included in TrueNAS 12.0.
+<!-- The [Key Management Interface Protocol KMIPhttps://docs.oasis-open.org/kmip/spec/v1.1/os/kmip-spec-v1.1-os.html is included in TrueNAS 12.0.-->
 
 {{< expand "Encryption Drawbacks and Considerations" "v" >}}
 Always consider the following drawbacks/considerations when encrypting data:
@@ -171,9 +171,9 @@ Set the rest of the options:
 
 ## Unlocking a Replicated Encrypted Dataset or Zvol Without a Passphrase
 
-TrueNAS Enterprise users can connect a Key Management Interoperability Protocol ([KMIP]({{< relref "/UIReference/System/KMIP.md" >}})) server to centralize keys when they are not using passphrases to unlock a dataset or zvol.
+<!-- TrueNAS Enterprise users can connect a Key Management Interoperability Protocol KMIPrelref "/UIReference/System/KMIP.md" server to centralize keys when they are not using passphrases to unlock a dataset or zvol.-->
 
-Users with TrueNAS CORE or Enterprise installations without [KMIP]({{< relref "/UIReference/System/KMIP.md" >}}) should either replicate the dataset or zvol without properties to disable encryption at the remote end or construct a special json manifest to unlock each child dataset/zvol with a unique key.
+Users with TrueNAS CORE or Enterprise installations without KMIP should either replicate the dataset or zvol without properties to disable encryption at the remote end or construct a special json manifest to unlock each child dataset/zvol with a unique key.
 
 ### Unlocking Methods
 {{< expand "Method 1: Construct JSON Manifest" >}}
@@ -193,10 +193,11 @@ To not encrypt the dataset on the remote side so it does not require a key to un
 4. Click **SUBMIT**.
 {{< /expand >}}
 
+<!-- Comment out Enterprise content not applicable in 13.3-RELEASE
 {{< hint type=tip >}}
-This does not affect TrueNAS Enterprise installs with [KMIP]({{< relref "/UIReference/System/KMIP.md" >}}).
+This does not affect TrueNAS Enterprise installs with KMIPrelref "/UIReference/System/KMIP.md".
 {{< /hint >}}
-
+-->
 ## Legacy GELI Encryption
 
 TrueNAS no longer supports GELI encryption (deprecated).

--- a/content/CORETutorials/SystemConfiguration/ConfiguringFailover.md
+++ b/content/CORETutorials/SystemConfiguration/ConfiguringFailover.md
@@ -5,6 +5,7 @@ weight: 150
 tags:
 - HA
 - failover
+draft: true
 ---
 
 {{< enterprise >}}

--- a/content/CORETutorials/SystemConfiguration/ConfiguringKMIP.md
+++ b/content/CORETutorials/SystemConfiguration/ConfiguringKMIP.md
@@ -5,14 +5,13 @@ weight: 170
 tags:
 - kmip
 - enterprise
+draft: true
 ---
 
 {{< enterprise >}}
 KMIP is only available for TrueNAS Enterprise licensed systems.
 Contact the [iXsystems Sales Team](mailto:sales@ixsystems.com) to inquire about purchasing TrueNAS Enterprise licenses.
 {{< /enterprise >}}
-
-
 
 The [Key Management Interoperability Protocol (KMIP)](https://docs.oasis-open.org/kmip/spec/v1.1/os/kmip-spec-v1.1-os.html) is an extensible client/server communication protocol for storing and maintaining keys, certificates, and secret objects.
 KMIP on TrueNAS Enterprise integrates the system within an existing centralized key management infrastructure and uses a single trusted source for creating, using, and destroying SED passwords and ZFS encryption keys.

--- a/content/CORETutorials/UpdatingTrueNAS/UpdatingENTERPRISE.md
+++ b/content/CORETutorials/UpdatingTrueNAS/UpdatingENTERPRISE.md
@@ -5,6 +5,8 @@ geekdocCollapseSection: true
 weight: 20
 tags:
 - enterprise
+draft:
+ - true
 ---
 
 {{< enterprise >}}

--- a/content/CORETutorials/UpdatingTrueNAS/_index.md
+++ b/content/CORETutorials/UpdatingTrueNAS/_index.md
@@ -7,12 +7,16 @@ related: false
 tags:
 - configbackup
 - update
+aliases:
+ - /coretutorials/updatingtruenas/updatingenterprise/
 ---
 
 TrueNAS CORE has an integrated update system to make it easy to keep up to date.
 
 {{< enterprise >}}
-TrueNAS CORE Enterprise High Availability (HA) customers should see [Updating CORE Enterprise]({{< relref "/CORETutorials/UpdatingTrueNAS/UpdatingENTERPRISE.md" >}}) for additional considerations.
+TrueNAS 13.3 is not available for Enterprise deployments.
+Instead, 13.0 support continues with security and major bug fix releases.
+See the [official announcement](https://forums.truenas.com/t/truenas-core-13-3-release-in-august/10344) for details and [software status page](https://www.truenas.com/software-status/) for up to date deployment recommendations.
 {{< /enterprise >}}
 
 ## Prepare the System
@@ -23,7 +27,7 @@ Plan updates around scheduled maintenance times to avoid disrupting user activit
 
 The update process does not proceed unless there is enough free space in the boot pool for the new update files.
 If a space warning displays, go to **System > Boot** to remove unneeded boot environments.
-
+<!-- Comment out automatic update content for 13.3 Community release.
 {{< expand "Updates and Trains" "v" >}}
 TrueNAS uses cryptographically signed update files to update.
 Update files provide flexibility in deciding when to upgrade the system.
@@ -70,7 +74,7 @@ To go back to an earlier version after testing or running a more recent version,
 
 Information about the update displays with a link to the release notes.
 Always read the release notes before updating to determine if any of the changes in that release impact system use.
-
+-->
 ### Save the Configuration File
 
 A dialog to save the system configuration file appears before installing updates.
@@ -85,6 +89,14 @@ The security information in the configuration file can grant unauthorized access
 ## Update the System
 
 Ensure the system is in a low-usage state as described above in [Preparing for Updates](#prepare-the-system).
+
+Each update creates a boot environment.
+If the update process needs more space, it attempts to remove old boot environments.
+TrueNAS does not remove boot environments marked with the *Keep* attribute as shown in **System > Boot**.
+The upgrade fails if your system does not have space for a new boot environment.
+Space on the operating system device can be manually freed by going to **System > Boot** and removing the *Keep* attribute or deleting any boot environments that are no longer needed.
+
+<!-- Commented out automatic update content as inapplicable to 13.3
 Click **DOWNLOAD UPDATES** to download and install an update.
 
 The **Save Configuration** dialog appears so you can save the current configuration to external media.
@@ -95,14 +107,6 @@ The update can be downloaded for a later manual installation by unsetting **Appl
 
 **APPLY PENDING UPDATE** displays when an update is downloaded and ready to install.
 Setting **Confirm** and clicking **CONTINUE** updates and reboots the system.
-
-{{< hint type=important >}}
-Each update creates a boot environment.
-If the update process needs more space, it attempts to remove old boot environments.
-TrueNAS does not remove boot environments marked with the *Keep* attribute as shown in **System > Boot**.
-The upgrade fails if your system does not have space for a new boot environment.
-Space on the operating system device can be manually freed by going to **System > Boot** and removing the *Keep* attribute or deleting any boot environments that are no longer needed.
-{{< /hint >}}
 
 {{< expand "Can I force a full update?" "v" >}}
 TrueNAS defaults to delta packages for updates.
@@ -121,16 +125,13 @@ To force a full update, open the shell and enter this command:
 The updater downloads the full package containing all the files from the latest software release.
 When the download completes, the system reboots with the standard configuration.
 {{< /expand >}}
+-->
 
 ### Manual Updates
 
 You can manually download and apply updates in **System > Update**.
 
-{{< hint type=note >}}
-You cannot use manual updates to upgrade from older major versions.
-{{< /hint >}}
-
-Go to https://download.freenas.org/ and find an update file of the desired version.
+Go to https://www.truenas.com/download-truenas-core/ to find the latest 13.3 manual update file.
 Manual update file names end with <file>manual-update.tar</file>.
 
 Download the desired update file to your local system.
@@ -142,7 +143,7 @@ You can save a copy of the current configuration to external media for backup in
 
 After the dialog closes, the manual update screen displays.
 
-The current version of TrueNAS displays for verification.
+The current TrueNAS version displays for verification.
 
 ![Update Manual](/images/CORE/System/UpdateManual.png "Manual Update")
 
@@ -150,14 +151,10 @@ Select the manual update file saved to your local system using **Browse**.
 Set **Reboot After Update** to reboot the system after the update installs.
 Click **APPLY UPDATE** to begin the update.
 
-{{< hint type=important >}}
-**Update in Progress**
-
 Starting an update shows a progress dialog.
 When an update is in progress, the web interface shows an animated <i class="material-icons" aria-hidden="true" title="System Update">system_update_alt</i> icon in the top row.
 Dialogs also appear in every active web interface session to warn that a system update is in progress.
 **Do not** interrupt a system update.
-{{< /hint >}}
 
 ## Upgrade Via ISO
 

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -40,7 +40,7 @@ aliases:
 
 ## Obtaining a Release
 
-13.3 releases are only available as manual update **.tar** or full installation **.iso** files.
+13.3 releases are only available as manual update <file>.tar</file> or full installation <file>.iso</file> files.
 Go to https://www.truenas.com/download-truenas-core/ to download either file type.
 
 See [Updating TrueNAS]({{< relref "/CORETutorials/UpdatingTrueNAS/_index.md" >}}) for instructions about updating with either file type.

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -7,27 +7,7 @@ related: false
 
 {{< header logo="/images/truenas-core-logo.png" logo_alt="TrueNAS CORE Logo" version="13.3" icon="" icon_alt="" >}}
 
-{{< hint type="tip" title="13.3 Early Release Documentation">}}
-This page tracks the latest development roadmap and release notes for the upcoming TrueNAS CORE major version, 13.3.
-The latest [TrueNAS CORE **13.0** version release notes](https://www.truenas.com/docs/core/13.0/gettingstarted/corereleasenotes/) are available from the TrueNAS CORE 13.0 documentation section.
-{{< /hint >}}
-
 {{< include file="/static/includes/13.3Overview.md" >}}
-
-## Obtaining a Release
-
-{{< include file="/static/includes/EarlyReleaseWarning.md" >}}
-
-To download a <file>.tar</file> file for installing or upgrading to a CORE 13.3 nightly version, go to https://www.truenas.com/download-truenas-core/ and click **Download Future Previews**.
-Select the latest <file>.tar</file> file and click **Download**.
-
-Log in to the web interface and go to **System > Update**.
-Click **INSTALL MANUAL UPDATE FILE**.
-Select **SAVE CONFIGURATION** when prompted.
-Select an **Update File Temporary Storage Location** then click **Chose File** and browse to select the <file>.tar</file> file.
-Click **APPLY UPDATE**.
-
-More details are available from [Updating Core]({{< relref "/CORETutorials/UpdatingTrueNAS/_index.md" >}}).
 
 ## Release Schedule
 
@@ -54,6 +34,13 @@ More details are available from [Updating Core]({{< relref "/CORETutorials/Updat
   Users with a critical need to use containers or virtualization solutions in production should migrate to the tested and supported virtualization features available in [TrueNAS SCALE](https://www.truenas.com/download-truenas-scale/).
   [TrueNAS Enterprise customers](https://www.truenas.com/truenas-enterprise/) can contact iXsystems to schedule a TrueNAS SCALE deployment.
   See [CORE to SCALE Migrations](https://www.truenas.com/docs/scale/gettingstarted/migrate/) for more information.
+
+## Obtaining a Release
+
+13.3 releases are only available as manual update **.tar** or full installation **.iso** files.
+Go to https://www.truenas.com/download-truenas-core/ to download either file type.
+
+See [Updating TrueNAS]({{< relref "/CORETutorials/UpdatingTrueNAS/_index.md" >}}) for instructions about updating with either file type.
 
 ### Upgrade Paths
 
@@ -85,6 +72,10 @@ The items listed here represent new feature flags implemented since the previous
 {{< /truetable >}}
 
 For more details on feature flags see [OpenZFS Feature Flags](https://openzfs.github.io/openzfs-docs/Basic%20Concepts/Feature%20Flags.html) and [OpenZFS zpool-feature.7](https://openzfs.github.io/openzfs-docs/man/7/zpool-features.7.html).
+
+## 13.3-RELEASE Changelog
+
+
 
 ## 13.3-BETA2 Changelog
 

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -78,10 +78,29 @@ For more details on feature flags see [OpenZFS Feature Flags](https://openzfs.gi
 
 ## 13.3-RELEASE Changelog
 
+**August 13, 2024**
 
+iXsystems is pleased to release TrueNAS CORE 13.3-RELEASE!
+This stabilized release is intended only for community users that are looking for upstream incremental fixes that are included in this release.
+See the 13.3 introduction at the top of this page or the [official announcement](https://forums.truenas.com/t/truenas-core-13-3-release-in-august/10344) for more details.
+
+This release includes a very small number of notable changes from the BETA2 release:
+
+* Update openssh package to address CVE-2024-6387 ([NAS-129828](https://ixsystems.atlassian.net/browse/NAS-129828))
+* VNC functionality fixes ([NAS-130278](https://ixsystems.atlassian.net/browse/NAS-130278))
+* Fix image placeholders for iX Plugins ([NAS-129352](https://ixsystems.atlassian.net/browse/NAS-129352))
+* Updated samba and fix issue with Time Machine share and snapshot creation ([NAS-130169](https://ixsystems.atlassian.net/browse/NAS-130169))
+
+<a href="https://ixsystems.atlassian.net/issues/?filter=10582" target="_blank">Click here for the full changelog</a> of completed tickets that are included in this release.
+{{< include file="/static/includes/JiraFilterInstructions.md" >}}
+
+### 13.3-RELEASE Ongoing Issues
+
+<a href="https://ixsystems.atlassian.net/issues/?filter=10583" target="_blank">Click here to see the latest information</a> about issues discovered in this release, including future fix versions.
 
 ## 13.3-BETA2 Changelog
 
+{{< expand "Click to expand" "v" >}}
 {{< include file="/static/includes/EarlyReleaseWarning.md" >}}
 
 **June 4, 2024**
@@ -103,6 +122,8 @@ Notable changes:
 ### 13.3-BETA2 Ongoing Issues
 
 <a href="https://ixsystems.atlassian.net/issues/?filter=10568" target="_blank">Click here to see the latest information</a> about issues discovered in 13.3-BETA2 that are being resolved in a future TrueNAS CORE release.
+
+{{< /expand >}}
 
 ## 13.3-BETA1 Changelog
 

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -87,9 +87,9 @@ See the 13.3 introduction at the top of this page or the [official announcement]
 This release includes a very small number of notable changes from the BETA2 release:
 
 * Update openssh package to address CVE-2024-6387 ([NAS-129828](https://ixsystems.atlassian.net/browse/NAS-129828))
-* VNC functionality fixes ([NAS-130278](https://ixsystems.atlassian.net/browse/NAS-130278))
-* Fix image placeholders for iX Plugins ([NAS-129352](https://ixsystems.atlassian.net/browse/NAS-129352))
-* Updated samba and fix issue with Time Machine share and snapshot creation ([NAS-130169](https://ixsystems.atlassian.net/browse/NAS-130169))
+* Includes VNC functionality fixes ([NAS-130278](https://ixsystems.atlassian.net/browse/NAS-130278))
+* Fixes image placeholders for iX Plugins ([NAS-129352](https://ixsystems.atlassian.net/browse/NAS-129352))
+* Updates samba and fixes issue with Time Machine share and snapshot creation ([NAS-130169](https://ixsystems.atlassian.net/browse/NAS-130169))
 
 <a href="https://ixsystems.atlassian.net/issues/?filter=10582" target="_blank">Click here for the full changelog</a> of completed tickets that are included in this release.
 {{< include file="/static/includes/JiraFilterInstructions.md" >}}

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -15,11 +15,6 @@ related: false
 
 {{< releaselist name=core-releases defaultTab=3 >}}
 
-{{< expand "Software Lifecycle" "v" >}}
-{{< include file="/static/includes/LifecycleTable.md" >}}
-{{< include file="/static/includes/SoftwareStatusPage.md" >}}
-{{< /expand >}}
-
 ## Upgrade Notes
 
 * Due to security vulnerabilities and maintainability issues, the S3 service is deprecated in TrueNAS CORE 13.0 and removed in CORE 13.3 ([NAS-127694](https://ixsystems.atlassian.net/browse/NAS-127694)).

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -3,6 +3,14 @@ title: 13.3 Version Notes
 description: "Highlights and change log for each TrueNAS CORE 13.3 release."
 weight: 3
 related: false
+aliases:
+ - /coretutorials/systemconfiguration/configuringfailover/
+ - /coretutorials/systemconfiguration/configuringkmip/
+ - /coretutorials/sharing/iscsi/settingupfibrechannel/
+ - /uireference/system/failover/
+ - /uireference/system/viewenclosure/
+ - /uireference/system/kmip/
+ - /uireference/sharing/iscsi/fibrechannel/
 ---
 
 {{< header logo="/images/truenas-core-logo.png" logo_alt="TrueNAS CORE Logo" version="13.3" icon="" icon_alt="" >}}

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -81,7 +81,7 @@ For more details on feature flags see [OpenZFS Feature Flags](https://openzfs.gi
 **August 13, 2024**
 
 iXsystems is pleased to release TrueNAS CORE 13.3-RELEASE!
-This stabilized release is intended only for community users that are looking for upstream incremental fixes that are included in this release.
+This stabilized release is intended only for community users who are looking for the upstream incremental fixes included in this release.
 See the 13.3 introduction at the top of this page or the [official announcement](https://forums.truenas.com/t/truenas-core-13-3-release-in-august/10344) for more details.
 
 This release includes a very small number of notable changes from the BETA2 release:

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -86,7 +86,7 @@ See the 13.3 introduction at the top of this page or the [official announcement]
 
 This release includes a very small number of notable changes from the BETA2 release:
 
-* Update openssh package to address CVE-2024-6387 ([NAS-129828](https://ixsystems.atlassian.net/browse/NAS-129828))
+* Updates openssh package to address CVE-2024-6387 ([NAS-129828](https://ixsystems.atlassian.net/browse/NAS-129828))
 * Includes VNC functionality fixes ([NAS-130278](https://ixsystems.atlassian.net/browse/NAS-130278))
 * Fixes image placeholders for iX Plugins ([NAS-129352](https://ixsystems.atlassian.net/browse/NAS-129352))
 * Updates samba and fixes issue with Time Machine share and snapshot creation ([NAS-130169](https://ixsystems.atlassian.net/browse/NAS-130169))

--- a/content/UIReference/Sharing/iSCSI/FibreChannel.md
+++ b/content/UIReference/Sharing/iSCSI/FibreChannel.md
@@ -12,8 +12,6 @@ Fibre Channel is an Enterprise feature in TrueNAS CORE.
 Only TrueNAS systems licensed for Fibre Channel have the **Fibre Channel Ports** tab on the **Sharing > Block Shares (iSCSI)** screen.
 {{< /enterprise >}}
 
-
-
 Fibre Channel is a high-speed data transfer protocol providing in-order, lossless delivery of raw block data.
 Fibre Channel is primarily used to connect computer data storage to servers in storage area networks in commercial data centers.
 The Fibre Channel protocol is fast, cost-effective, and reliable over a wide variety of storage workloads.

--- a/content/UIReference/Sharing/iSCSI/FibreChannel.md
+++ b/content/UIReference/Sharing/iSCSI/FibreChannel.md
@@ -4,6 +4,7 @@ description: "Provides information about using Fibre Channel with TrueNAS CORE."
 weight: 20
 tags:
 - iscsi
+draft: true
 ---
 
 {{< enterprise >}}

--- a/content/UIReference/System/Failover.md
+++ b/content/UIReference/System/Failover.md
@@ -5,6 +5,7 @@ weight: 178
 tags:
 - HA
 - failover
+draft: true
 ---
 
 {{< enterprise >}}

--- a/content/UIReference/System/KMIP.md
+++ b/content/UIReference/System/KMIP.md
@@ -5,6 +5,7 @@ weight: 175
 tags:
 - kmip
 - enterprise
+draft: true
 ---
 
 {{< enterprise >}}

--- a/content/UIReference/System/Support.md
+++ b/content/UIReference/System/Support.md
@@ -24,7 +24,7 @@ The **Support** screen displays system information. Users may also manage thier 
 | Description | A one to three paragraph summary of the issue. |
 | Browse... | Attaches screenshots that illustrate the problem. |
 {{< /truetable >}}
-
+<!-- Comment out Enterprise-specific content as not relevent in 13.3-RELEASE
 ## TrueNAS Enterprise
 
 {{< enterprise >}}
@@ -64,3 +64,4 @@ Contact the [iXsystems Sales Team](mailto:sales@ixsystems.com) to inquire about 
 | Description | A one to three paragraph summary of the issue. |
 | Choose Files | Attaches screenshots that illustrate the problem. |
 {{< /truetable >}}
+-->

--- a/content/UIReference/System/ViewEnclosure.md
+++ b/content/UIReference/System/ViewEnclosure.md
@@ -4,6 +4,7 @@ description: "Provides information about the View Enclosure screen on TrueNAS CO
 weight: 45
 tags:
 - enclosure
+draft: true
 ---
 
 {{< enterprise >}}

--- a/data/properties/core-releases.yaml
+++ b/data/properties/core-releases.yaml
@@ -17,30 +17,32 @@ majorVersions:
     name: "TrueNAS CORE 13.0"
     releaseName: "13.0"
     releases:
-      - name: "13.0-U6.1"
+      - name: "13.0-U6.2"
         type: "Maintenance"
         link: "https://www.truenas.com/docs/core/13.0/gettingstarted/corereleasenotes/"
-        releaseDate: "2023-12-07"
+        releaseDate: "2024-07-03"
         latest: true
   - lifecycle: "Next"
     name: "TrueNAS CORE 13.3"
     releaseName: "13.3"
     releases:
+      - name: "13.3-RELEASE"
+        type: "Stable"
+        link: "https://www.truenas.com/docs/core/13.3/gettingstarted/corereleasenotes/#133-release-changelog"
+        releaseDate: "2024-08-13"
+        latest: true
       - name: "13.3-BETA2"
         type: "Early"
         link: "https://www.truenas.com/docs/core/13.3/gettingstarted/corereleasenotes/#133-beta2-changelog"
         releaseDate: "2024-06-04"
-        latest: true
+        latest: false
+      - name: "13.3-BETA1"
+        type: "Early"
+        link: "https://www.truenas.com/docs/core/13.3/gettingstarted/corereleasenotes/#133-beta1-changelog"
+        releaseDate: "2024-05-07"
+        latest: false        
       - name: "13.3 Nightlies"
         type: "Experimental"
         link: "https://www.truenas.com/docs/core/13.3/gettingstarted/corereleasenotes/"
         releaseDate: "2024-01-01"
-        latest: false
-      - name: "13.3-RC1"
-        type: "Early"
-        releaseDate: ""
-        latest: false
-      - name: "13.3.0"
-        type: "Stable"
-        releaseDate: ""
         latest: false

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -56,37 +56,13 @@
     </div>
   {{ end }}
 </div>
-{{ if in .Section "CORE" }}
 <article class="gdoc-markdown">
-<blockquote class="gdoc-hint warning version-note" style="margin-bottom:1rem;">
+<blockquote class="gdoc-hint tip" style="margin-bottom:1rem;">
   <div class="gdoc-hint__title flex align-center vnote-title">
-    <img src="/favicon/TN-favicon-32x32.png" alt="TrueNAS CORE" title="CORE Nightly Development Documentation" style="padding-right:.75rem;"></img>TrueNAS CORE Nightly Development Documentation
+    <img src="/favicon/TN-favicon-32x32.png" alt="TrueNAS CORE" title="CORE Community Release Documentation" style="padding-right:.75rem;"></img>TrueNAS CORE Community Release Documentation
   </div>
   <div class="gdoc-hint__text" style="font-size:smaller;">
-    This content follows experimental early release software. Use the <b>Product</b> and <b>Version</b> selectors above to view content specific to a stable software release.
+    This content documents the 13.3 TrueNAS Community release. <a href="https://www.truenas.com/docs/core/13.0/">Click here</a> for the latest Enterprise release documentation.
   </div>
 </blockquote>
 </article>
-{{ else if in .Section "SCALE" }}
-<article class="gdoc-markdown">
-<blockquote class="gdoc-hint warning">
-  <div class="gdoc-hint__title flex align-center">
-    <img src="/favicon/TNScale-favicon-32x32.png" alt="TrueNAS SCALE" title="SCALE Nightly Development Documentation" style="padding-right:.75rem;"></img>TrueNAS SCALE Nightly Development Documentation
-  </div>
-  <div class="gdoc-hint__text" style="font-size:smaller;">
-    This content follows experimental early release software. Use the <b>Product</b> and <b>Version</b> selectors above to view content specific to a stable software release.
-  </div>
-</blockquote>
-</article>
-{{ else if in .Section "TrueCommand" }}
-<article class="gdoc-markdown">
-<blockquote class="gdoc-hint warning version-note">
-  <div class="gdoc-hint__title flex align-center vnote-title">
-    <img src="/favicon/TN-favicon-32x32.png" alt="TrueNAS CORE" title="CORE Version Documentation" style="padding-right:.75rem;"></img>TrueNAS CORE Version Documentation
-  </div>
-  <div class="gdoc-hint__text" style="font-size:smaller;">
-    This content follows experimental early release software. Use the <b>Product</b> and <b>Version</b> selectors above to view content specific to a stable software release.
-  </div>
-</blockquote>
-</article>
-{{ end }}

--- a/static/includes/13.3Overview.md
+++ b/static/includes/13.3Overview.md
@@ -2,9 +2,9 @@
 
 TrueNAS CORE 13.3, the latest version of the most reliable and [highest-quality](https://www.truenas.com/blog/gartner-peer-insights-customer-choice-for-primary-storage-in-2024/) platform for traditional primary storage use cases, continues to focus on ensuring storage reliability, stability, and security for existing users.
 
-With this release, TrueNAS CORE is now entering a sustaining engineering phase within the TrueNAS project. Users can expect to receive maintenance updates for many years still to come.
+With this release, TrueNAS CORE enters a sustaining engineering phase within the TrueNAS project.
 
-TrueNAS CORE 13.3 will include the following updates:
+TrueNAS CORE 13.3 includes these updates:
 
 * [FreeBSD 13.3](https://www.freebsd.org/releases/13.3R/relnotes/)
 * [OpenZFS 2.2.3](https://github.com/openzfs/zfs/releases/tag/zfs-2.2.3)
@@ -12,4 +12,13 @@ TrueNAS CORE 13.3 will include the following updates:
 * Updates to SMART, Network UPS Tools (NUT), and other services
 * Various security and bug fixes
 
-TrueNAS CORE 13.3 will continue to receive bug fixes related to stability and security. These updates will ensure that 13.3 is a reliable platform for both homelab and enterprise customers, as well as a staging version for those users who wish to [migrate to SCALE](https://www.truenas.com/docs/scale/gettingstarted/migrate/) at a later date.
+{{< hint type="tip" title="13.3 - Community Edition">}}
+TrueNAS 13.3-RELEASE is intended solely for community users looking for incremental fixes specific to FreeBSD 13.3, Jails, Bhyve, OpenZFS, and Samba.
+See the [official announcement](https://forums.truenas.com/t/truenas-core-13-3-release-in-august/10344) for details and upgrade recommendations.
+
+13.3-RELEASE is not available for Enterprise system upgrades.
+[TrueNAS 13.0](https://www.truenas.com/docs/core/13.0/) remains the recommended option for Enterprise deployments in a stable production environment.
+TrueNAS 13.0 continues to be supported with security hotfixes and resolutions for any newly discovered major bugs.
+
+See the [software status page](https://www.truenas.com/software-status/) for up to date deployment recommendations for different TrueNAS user types.
+{{< /hint >}}

--- a/static/includes/COREUpgradePaths.md
+++ b/static/includes/COREUpgradePaths.md
@@ -13,7 +13,7 @@
       flowchart LR
       A["11.3-U5"] -->|update| B["12.0-U2"]
       B -->|update| C["13.0-U6.2"]
-      C -->|update| D["13.3.0"]
+      C -->|update| D["13.3-RELEASE"]
       {{< /mermaid >}}
     </div>
     <div class="upgrade-paths-container">

--- a/static/includes/COREUpgradePaths.md
+++ b/static/includes/COREUpgradePaths.md
@@ -12,8 +12,8 @@
       {{< mermaid class="mermaid_sizing" >}}
       flowchart LR
       A["11.3-U5"] -->|update| B["12.0-U2"]
-      B -->|update| C["13.0-U6.1"]
-      C -->|"(anticipated)"| D["13.3.0"]
+      B -->|update| C["13.0-U6.2"]
+      C -->|update| D["13.3.0"]
       {{< /mermaid >}}
     </div>
     <div class="upgrade-paths-container">
@@ -21,7 +21,8 @@
       {{< mermaid class="mermaid_sizing" >}}
       flowchart LR
       A["11.3-U5"] -->|update| B["12.0-U2"]
-      B -->|update| C["13.0-U6.1"]
+      B -->|update| C["13.0-U6.2"]
+	  C -.-|X| D["13.3-RELEASE"]
       {{< /mermaid >}}
     </div>
 </div>

--- a/static/includes/S3Deprecation.md
+++ b/static/includes/S3Deprecation.md
@@ -3,10 +3,11 @@
 {{< hint type=important title="Deprecation Notice" >}}
 Due to security vulnerabilities and maintainability issues, the S3 service is deprecated in TrueNAS CORE 13.0 and scheduled for removal in CORE 13.3.
 Beginning in CORE 13.0-U6, the CORE web interface generates an alert when the deprecated service is either actively running or is enabled to start on boot.
-
+<!-- Comment out enterprise-specific content as not applicable in 13.3-RELEASE
 {{< enterprise >}}
 Beginning in CORE 13.0-U6, Enterprise customers with the S3 service running or enabled are prevented from upgrading to the next major version.
 {{< /enterprise >}}
+-->
 
 Users should plan to migrate to a separately maintained MinIO plugin or otherwise move any production data away from the S3 service storage location.
 Migrating from the built-in S3 service to the plugin could result in an extended data migration window and potential disruption to S3 data access.

--- a/static/includes/iSCSIRef.md
+++ b/static/includes/iSCSIRef.md
@@ -47,7 +47,7 @@ iSCSI exports disk devices (zvols on TrueNAS) over a network that other iSCSI cl
 * **Jumbo Frames**: Jumbo frames are the name given to Ethernet frames that exceed the default 1500 byte size. This parameter is typically referenced by the nomenclature as a maximum transmission unit (MTU). A MTU that exceeds the default 1500 bytes necessitates that all devices transmitting Ethernet frames between the source and destination support the specific jumbo frame MTU setting, which means that NICs, dependent hardware iSCSI, independent hardware iSCSI cards, ingress and egress Ethernet switch ports, and the NICs of the storage array must all support the same jumbo frame MTU value. So, how does one decide if they should use jumbo frames?
 
   Administrative time is consumed configuring jumbo frames and troubleshooting if/when things go sideways. Some network switches might also have ASICs optimized for processing MTU 1500 frames while others might be optimized for larger frames. Systems administrators should also account for the impact on host CPU utilization. Although jumbo frames are designed to increase data throughput, it may measurably increase latency (as is the case with some un-optimized switch ASICs); latency is typically more important than throughput in a VMware environment. Some iSCSI applications might see a net benefit running jumbo frames despite possible increased latency. Systems administrators should test jumbo frames on their workload with lab infrastructure as much as possible before updating the MTU on their production network.
-
+<!-- Comment out enterprise-specific content as not applicable in 13.3-RELEASE
 {{< enterprise >}}
 * **Asymmetric Logical Unit Access (ALUA)**: ALUA allows a client computer to discover the best path to the storage on a TrueNAS system.
   HA storage clusters can provide multiple paths to the same storage.
@@ -60,17 +60,18 @@ iSCSI exports disk devices (zvols on TrueNAS) over a network that other iSCSI cl
 
 Do not enable ALUA on TrueNAS unless it is also supported by and enabled on the client computers. ALUA only works when enabled on both the client and server.
 {{< /enterprise >}}
+-->
 {{< /expand >}}
 
 ## iSCSI Configuration Methods
 
 There are a few different approaches for configuring and managing iSCSI-shared data:
-
+<!-- Comment out enterprise-specific content as not applicable in 13.3-RELEASE
 {{< enterprise >}}
 TrueNAS Enterprise customers that use vCenter to manage their systems can use the TrueNAS vCenter Plugin to connect their TrueNAS systems to vCenter and create and share iSCSI datastores.
 This is all managed through the vCenter web interface.
 {{< /enterprise >}}
-
+-->
 * TrueNAS CORE web interface: the TrueNAS web interface is fully capable of configuring iSCSI shares. This requires creating and populating zvol block devices with data, then setting up the iSCSI Share. TrueNAS Enterprise licensed customers also have additional options to configure the share with Fibre Channel.
 
 * TrueNAS SCALE web interface: TrueNAS SCALE offers a similar experience to TrueNAS CORE for managing data with iSCSI; create and populate the block storage, then configure the iSCSI share.

--- a/words-to-ignore.txt
+++ b/words-to-ignore.txt
@@ -2030,3 +2030,11 @@ Bugfix
 zettarepl
 bugfix
 COREUpgradePaths
+openssh
+fibrechannel
+uireference
+viewenclosure
+settingupfibrechannel
+coretutorials
+configuringkmip
+systemconfiguration

--- a/words-to-ignore.txt
+++ b/words-to-ignore.txt
@@ -2038,3 +2038,4 @@ settingupfibrechannel
 coretutorials
 configuringkmip
 systemconfiguration
+configuringfailover


### PR DESCRIPTION
- Write the Community release messaging based from the official announcement.
- Disable Enterprise-specific content
- Write 13.3-RELEASE changelog
- Update release dates, upgrade path chart, and other content pulled into the release notes article

Note - Enterprise-specific content is moved to draft or otherwise commented out while 13.3 is a Community-only release. We can go back and restore this when ready to make a recommendation about Enterprise updates.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
