### PR TITLE
Pd 1326 docs lifecycle standardize 22.12 archival changes

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -38,6 +38,16 @@ Bluefin introduced many new features and general improvements to the TrueNAS SCA
 
 The [22.12 release notes article]({{< relref "SCALEReleaseNotes.md" >}}) has additional details.
 
+## Documentation End of Life (EOL)
+
+**22.12 (Bluefin) Documentation EOL: 05-03-2024**
+
+iXsystems employees maintain documentation and provide regular updates for current and in development (future) versions of TrueNAS software.
+For documentation purposes, current and future releases are those recommended by the TrueNAS [Software Status page](https://www.truenas.com/software-status/) for one or more user type.
+
+Documentation for previous releases, that are no longer recommended for any user type, is archived and unmaintained.
+All documentation provided here is end-of-life (EOL), intended for reference only, and no longer receives *any* updates.
+
 ## 22.12 Featured Content
 
 <div class="docs-sections">

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "TrueNAS SCALE 22.12 (Archived)"
-description: "Documentation for the SCALE 22.12 major version."
+description: "Archival documentation for the TrueNAS SCALE 22.12 (Bluefin) major version. This documentation is End of Life (EOL) and presented for reference only."
 geekdocCollapseSection: true
 weight: 10
 ---
@@ -8,9 +8,11 @@ weight: 10
 {{< columns size="small" >}}
 <img src="/images/SCALE/Bluefin.png" alt="TrueNAS SCALE 22.12 Logo" style="margin: 1rem 0 0 2rem;">
 <--->
-iXsystems is pleased to introduce TrueNAS SCALE 22.12 (Bluefin)!
+iXsystems released TrueNAS SCALE 22.12.0 (Bluefin) on December 13, 2022.
+It received its final update on October 13, 2023.
+The terminal version of Bluefin is 22.12.4.2.
 
-This release has many new features and general improvements to the TrueNAS SCALE experience:
+Bluefin introduced many new features and general improvements to the TrueNAS SCALE experience:
 {{< /columns >}}
 
 {{< columns >}}

--- a/layouts/partials/docs-nav.html
+++ b/layouts/partials/docs-nav.html
@@ -78,7 +78,7 @@ function updateDropdownPlaceholderText() {
 	if (path.includes('/3.0/')) {
 	  versionButton.textContent = '3.0';
 	} else if (path.includes('/2.3/')) {
-	  versionButton.textContent = '2.3';
+	  versionButton.textContent = 'Archive';
 	} else {
 	  versionButton.textContent = 'Nightly';
 	}
@@ -143,7 +143,6 @@ updateDropdownPlaceholderText();
       versionDropdown.innerHTML = `
         <div class="truenas-dropdown-item" onclick="selectVersion('tc-nightly')" id="tc-nightly">Nightly</div>
 		<div class="truenas-dropdown-item" onclick="selectVersion('3.0')" id="30">3.0</div>
-		<div class="truenas-dropdown-item" onclick="selectVersion('2.3')" id="23">2.3</div>
     <div class="truenas-dropdown-item" onclick="selectVersion('Archive')" id="Archive">Archive</div>
       `;
     }

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -64,7 +64,7 @@
   <div class="gdoc-hint__text" style="font-size:smaller;">
     This content follows the TrueNAS SCALE 22.12 (Bluefin) releases. Archival documentation is provided for reference only and not actively maintained.
     <br>  
-    Use the <b>Product</b> and <b>Version</b> selectors above to view content specific to different TrueNAS software or major version.
+    Use the <b>Product</b> and <b>Version</b> selectors above to view content specific to different TrueNAS software or major versions.
   </div>
 </blockquote>
 </article>


### PR DESCRIPTION
A few minor updates to the archived documentation to make it consistent with the archiving procedure that will be used starting with TC 2.3 and SCALE 23.10. 

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
