### PR TITLE
Update UpdateSCALE.md (24.04)

### DIFF
--- a/content/SCALETutorials/SystemSettings/UpdateSCALE.md
+++ b/content/SCALETutorials/SystemSettings/UpdateSCALE.md
@@ -64,27 +64,3 @@ When a system update starts, <span class="iconify" data-icon="ic:sharp-system-up
 Click the icon to see the current status of the update and which TrueNAS administrative account initiated the update.
 
 {{< trueimage src="/images/SCALE/SystemSettings/UpdateStatus.png" alt="Update Status" id="Update Status Example" >}}
-
-## Updating Pools
-
-After updating, you might find that you can update your storage pools and boot-pool to enable new supported and requested features that are not enabled on the pool.
-
-Go to **System Settings > Shell** and enter `cli` to enter the CLI if Shell does not open in the CLI.
-
-To show which pools you can update, first enter a query command to see the list of pools on your system and the id number for each pool.
-
-`storage pool query`
-
-Next, check the update status:
-
-<code>storage pool is_upgraded id=<i>2</i></code>
-
-where *2* is the pool ID number you want to check the update status for.
-
-To update the pool, enter:
-
-<code>storage pool upgrade id=<i>2</i></code>
-
-{{< hint type=important >}}
-Upgrading pools is a one-way operation. After upgrading pools to the latest zfs features, you might not be able to boot into older versions of TrueNAS.
-{{< /hint >}}


### PR DESCRIPTION
Remove cli instruction for upgrading pools - this is covered in https://www.truenas.com/docs/scale/24.04/scaletutorials/storage/managepoolsscale/#upgrading-a-pool by the correct UI-centric method.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
