### PR TITLE
Update "Nightly" naming on Version dropdown, page header, and home page nav tree (temporary for master branch)

### DIFF
--- a/layouts/partials/docs-nav.html
+++ b/layouts/partials/docs-nav.html
@@ -148,7 +148,7 @@ function updateDropdownPlaceholderText() {
 	} else if (path.includes('/22.12/')) {
       versionButton.textContent = 'Archive';
     } else {
-	  versionButton.textContent = 'Nightly';
+	  versionButton.textContent = '24.10';
 	}
     versionUpdated = true;
   } else if (path.includes('/truecommand/')) {
@@ -212,7 +212,7 @@ updateDropdownPlaceholderText();
       `;
     } else if (product === 'TrueNAS SCALE') {
       versionDropdown.innerHTML = `
-        <div class="truenas-dropdown-item" onclick="selectVersion('scale-nightly')" id="scale-nightly">Nightly</div>
+        <div class="truenas-dropdown-item" onclick="selectVersion('scale-nightly')" id="scale-nightly">24.10</div>
         <div class="truenas-dropdown-item" onclick="selectVersion('24.04')" id="2404">24.04</div>
         <div class="truenas-dropdown-item" onclick="selectVersion('23.10')" id="2310">23.10</div>
         <div class="truenas-dropdown-item" onclick="selectVersion('Archive')" id="Archive">Archive</div>
@@ -444,7 +444,7 @@ updateDropdownPlaceholderText();
 	  versionDropdown.style.display = 'none';
     } else if (productButton.textContent === 'TrueNAS SCALE ') {
       selectProduct('TrueNAS SCALE');
-      versionButton.innerHTML = currentPath.includes('/24.04/') ? '24.04 <i class="fa fa-angle-down"></i>' : currentPath.includes('/23.10/') ? '23.10 <i class="fa fa-angle-down"></i>' : currentPath.includes('/22.12/') ? '22.12 <i class="fa fa-angle-down"></i>' : 'Nightly <i class="fa fa-angle-down"></i>';
+      versionButton.innerHTML = currentPath.includes('/24.04/') ? '24.04 <i class="fa fa-angle-down"></i>' : currentPath.includes('/23.10/') ? '23.10 <i class="fa fa-angle-down"></i>' : currentPath.includes('/22.12/') ? '22.12 <i class="fa fa-angle-down"></i>' : '24.10 <i class="fa fa-angle-down"></i>';
 	  versionDropdown.style.display = 'none';
     } else if (productButton.textContent === 'TrueCommand ') {
       selectProduct('TrueCommand');

--- a/layouts/partials/menu-filetree.html
+++ b/layouts/partials/menu-filetree.html
@@ -80,7 +80,7 @@
             <li><a href="https://www.truenas.com/docs/core/13.0/" class="gdoc-nav__entry">13.0</a></li>
             <li><a href="/archive/" class="gdoc-nav__entry">Archive</a></li>
           {{ else if (eq (path.Base .RelPermalink) "scale") }}
-            <li><a href="/scale/" class="gdoc-nav__entry">Nightly</a></li>
+            <li><a href="/scale/" class="gdoc-nav__entry">24.10</a></li>
             <li><a href="https://www.truenas.com/docs/scale/24.04/" class="gdoc-nav__entry">24.04</a></li>
             <li><a href="https://www.truenas.com/docs/scale/23.10/" class="gdoc-nav__entry">23.10</a></li>
             <li><a href="/archive/" class="gdoc-nav__entry">Archive</a></li>

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -91,9 +91,9 @@
 </article>
 {{ else if in .Section "SCALE" }}
 <article class="gdoc-markdown">
-<blockquote class="gdoc-hint warning">
+<blockquote class="gdoc-hint caution">
   <div class="gdoc-hint__title flex align-center">
-    <img src="/favicon/TNScale-favicon-32x32.png" alt="TrueNAS SCALE" title="SCALE Nightly Development Documentation" style="padding-right:.75rem;"></img>TrueNAS SCALE Nightly Development Documentation
+    <img src="/favicon/TNScale-favicon-32x32.png" alt="TrueNAS SCALE" title="TrueNAS Early Release Documentation" style="padding-right:.75rem;"></img>TrueNAS Early Release Documentation
   </div>
   <div class="gdoc-hint__text" style="font-size:smaller;">
     This content follows experimental early release software. Use the <b>Product</b> and <b>Version</b> selectors above to view content specific to a stable software release.


### PR DESCRIPTION
This is to cover a temporary state while master is 24.10 docs only before version branching and rebuilding to track 25.04 nightly docs.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
