### PR TITLE
PD-1365-update-smb-share-content-for-windows-specific-situations-when-512-snapshots-are-present

### DIFF
--- a/content/SCALE/SCALETutorials/Shares/SMB/SetUpBasicTimeMachineSMBShare.md
+++ b/content/SCALE/SCALETutorials/Shares/SMB/SetUpBasicTimeMachineSMBShare.md
@@ -24,6 +24,10 @@ To set up a basic time machine share:
 
 After creating the share, enable the SMB service.
 
+When accessing from a Windows client, having more than 512 snapshots on the TrueNAS box can lead to performance issues, as the Windows client often attempts to load all snapshots into the 'Previous Versions' tab.
+
+To avoid this, users should maintain fewer than 512 snapshots, or consider accessing from a non-Windows client. Alternatively, configuring snapshot lifetimes or creating an automatic deletion policy via the [Periodic Snapshot Tasks screen]({{< relref "PeriodicSnapshotTasksSCALE.md" >}}) can help users manage the snapshot count more effectively.
+
 ### Creating the Share and Dataset
 You can either [create the dataset]({{< relref "DatasetsSCALE.md" >}}) to use for the share on the **Add Dataset** screen and the share, or create the dataset when you add the share on the **Add SMB** screen.
 If you want to customize the dataset, use the **Add Dataset** screen.


### PR DESCRIPTION
Caveat added to the affected page. Link included to Period Snapshot Tasks screen. 

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
