### PR TITLE
Pd 1380 update i pv6 content for rsync

### DIFF
--- a/content/SCALE/SCALETutorials/Credentials/BackupCredentials/AddSSHConnectionKeyPair.md
+++ b/content/SCALE/SCALETutorials/Credentials/BackupCredentials/AddSSHConnectionKeyPair.md
@@ -29,89 +29,25 @@ To begin setting up an SSH connection, go to **Credentials > Backup Credentials*
 Click **Add** on the **SSH Connections** widget.
 
 ### Configuring a Semi-Automatic SSH Connection
+The procedure in this section covers the semi-automatic setup method for creating an SSH connection with another TrueNAS system.
 
-This procedure uses the semi-automatic setup method for creating an SSH connection with another TrueNAS system.
-{{< expand "Click here for more information" "v" >}}
 **Semi-automatic** simplifies setting up an SSH connection with another TrueNAS system without logging in to that system to transfer SSH keys.
 This requires an SSH key pair on the local system and administrator account credentials for the remote TrueNAS.
 You must configure the remote system to allow root access with SSH.
 You can generate the key pair as part of the semiautomatic configuration or a manually created one using **SSH Keypairs**.
 
-Using the **SSH Connections** configuration screen:
-
-1. Enter a name and select the **Setup Method**. If establishing an SSH connection to another TrueNAS server use the default **Semi-automatic (TrueNAS only)** option.
-   If connecting to a non-TrueNAS server select **Manual** from the dropdown list.
-
-{{< trueimage src="/images/SCALE/Credentials/NewSSHConnectNameMethodAuto.png" alt="Name and Method Settings" id="Name and Method Settings" >}}
-
-2. Enter the authentication settings.
-
-{{< trueimage src="/images/SCALE/Credentials/NewSSHConnectAuthentication.png" alt="Authentication Settings" id="Authentication Settings" >}}
-
-   a. Enter a valid URL scheme for the remote TrueNAS URL in **TrueNAS URL**.
-      This is a required field.
-
-   b. Enter an admin user name, which is the username on the remote system entered to log in via the web UI to set up the connection.
-      Or, leave **Admin Username** set to the default **root** user and enter the user password in **Admin Password**.
-
-   c. If two-factor authentication is enabled, enter the one-time password in **One-Time Password (if necessary)**.
-
-   d. Enter a **Username**, which is the user name on the remote system to log in via SSH.
-
-   e. Enter or import the private key from a previously created SSH key pair, or create a new one using the **SSH Keypair** widget.
-
-4. (Optional) Enter the number of seconds you want to have SCALE wait for the remote TrueNAS system to connect in **Connect Timeout**.
-
-{{< trueimage src="/images/SCALE/Credentials/NewSSHConnectMoreOptions.png" alt="More Options Settings" id="More Options Settings" >}}
-
-5. Click **Save**. Saving a new connection automatically opens a connection to the remote TrueNAS and exchanges SSH keys.
-   The new SSH connection displays on the **SSH Connection** widget.
-   To edit it, click on the name to open the **SSH Connections** configuration screen populated with the saved settings.
-{{< /expand >}}
+{{< include file="/static/includes/AddSSHConnection.md" >}}
 
 ### Configuring a Manual SSH Connection
-
-Follow these instructions to set up an SSH connection to a non-TrueNAS system.
+The instructions in this section cover how to set up an SSH connection to a non-TrueNAS system.
 To manually set up an SSH connection, you must copy a public encryption key from the local system to the remote system.
 A manual setup allows a secure connection without a password prompt.
-{{< expand "Click here for more information" "v" >}}
 
-Using the **SSH Connections** configuration screen:
-
-1. Enter a name and select **Manual** from the **Setup Method** dropdown list.
-
-{{< trueimage src="/images/SCALE/Credentials/NewSSHConnectNameMethodManual.png" alt="Manual Name and Method" id="Manual Name and Method" >}}
-
-2. Enter the authentication settings.
-
-{{< trueimage src="/images/SCALE/Credentials/NewSSHConnectAuthenticationManual.png" alt="Manual Authentication Settings" id="Manual Authentication Settings" >}}
-
-   a. Enter a host name or host IP address for the remote non-TrueNAS system as a valid URL.
-   An IP address example is *https://10.231.3.76*.
-   This is a required field.
-
-   b. Enter the port number of the remote system to use for the SSH connection.
-
-   c. Enter a user name for logging into the remote system in **Username**.
-
-   c. Select the private key from the SSH key pair that you use to transfer the public key on the remote NAS from the **Private Key** dropdown.
-
-   d. Click **Discover Remote Host Key** after properly configuring all other fields to query the remote system and automatically populate the **Remote Host Key** field.
-
-4. (Optional) Enter the number of seconds you want SCALE to wait for the remote TrueNAS system to connect in **Connect Timeout**.
-
-{{< trueimage src="/images/SCALE/Credentials/NewSSHConnectMoreOptions.png" alt="Manual More Options" id="Manual More Options" >}}
-
-5. Click **Save**. Saving a new connection automatically opens a connection to the remote TrueNAS and exchanges SSH keys.
-   The new SSH connection displays on the **SSH Connection** widget.
-   To edit it, click on the name to open the **SSH Connections** configuration screen populated with the saved settings.
-
-{{< /expand >}}
+{{< include file="/static/includes/AddManualSSHConnection.md" >}}
 
 ### Adding a Public SSH Key to an Admin User Account
-
 This procedure covers adding a public SSH key to the admin account on the TrueNAS SCALE system and generating a new SSH Keypair to add to the remote system (TrueNAS or other).
-{{< expand "Click here for more information" "v" >}}
+
 1. Copy the SSH public key text or download it to a text file:
 
    Log into the TrueNAS system that generated the SSH key pair and go to **Credentials > Backup Credentials**.
@@ -139,18 +75,11 @@ This procedure covers adding a public SSH key to the admin account on the TrueNA
 
 3. Click **Save**.
 
-If you need to generate a new SSH key pair:
-
-1. Go to **Credentials > Backup Credentials**.
-2. Click **Add** on the **SSH Keypairs** widget and select **Generate New**.
-3. Copy or download the value for the new public key.
-4. Add the new public key to the remote NAS.
+If you need to generate a new SSH key pair, see [Generating SSH Keypairs](#generating-ssh-keypairs).
 
 If the remote NAS is not a TrueNAS system, refer to the documentation for that system, and find their instructions on adding a public SSH key.
-{{< /expand >}}
 
 ## Generating SSH Keypairs
-
 TrueNAS generates and stores [RSA-encrypted](https://tools.ietf.org/html/rfc8017) SSH public and private key pairs on the **SSH Keypairs** widget found on the **Credentials > Backup Credentials** screen.
 Key pairs are generally used when configuring **SSH Connections** or SFTP **Cloud Credentials**.
 TrueNAS does not support encrypted key pairs or key pairs with passphrases.

--- a/content/SCALE/SCALETutorials/DataProtection/RsyncTasksSCALE.md
+++ b/content/SCALE/SCALETutorials/DataProtection/RsyncTasksSCALE.md
@@ -28,69 +28,69 @@ See [Adding SSH Credentials]({{< relref "AddSSHConnectionKeyPair.md" >}}) for mo
 
 After setting up the SSH connection, [configure the rsync task](#creating-an-ssh-mode-rsync-task) on the TrueNAS host.
 
-### Setting up an SSH Connection
+### Setting Up an SSH Connection
+You can set up a new SSH connection on the **Credentials > Backup Credentials** screen by clicking **Add** on the **SSH Connections** widget, or while setting up a new rsync task using the option to select **SSH connection from the keychain** in the **Connect using** field and selecting **Add New** in **SSH Connection** on the **Add Rsync Task** screen.
 
-1. Enable SSH on the remote system and on the TrueNAS local host system. Go to **System > Services** and toggle **SSH** on.
+The following procedure provides instructions on setting up an SSH connection using the **New SSH Connection** screen.
 
-3. Add an SSH connection to the remote server.
+1. Enable SSH on both the local and remote systems.
+
+   On the local TrueNAS host system, go to **System > Services** and toggle **SSH** to on, and enable the SSH service on the remote host system.
+
+2. Set up a home directory for the remote system administrator on the remote system.
+   Note the path to where home directories are stored to enter on the local host TrueNAS.
+   
+   If the remote system is also a TrueNAS, go to **Credentials**, select **Users** to see the list of users.
+   Select the administration user and click **Edit**.
+
+   If creating a new administration user, for rsync functions, click **Add**.
+   See [Managing Users]({{< relref "managelocalusersscale.md#creating-an-administrator-user-account" >}}) for more information.
+   Take note of the path to the home directory to use in setting up the connection.
+
+3. Add an SSH connection for the remote server on the local TrueNAS host system. If the remote system is a TrueNAS:
    
    {{< include file="/static/includes/AddSSHConnection.md" >}}
 
-   To add a connection to a non-TrueNAS remote host system
+   You can add a connection to a non-TrueNAS remote host system.
 
    {{< include file="/static/includes/AddManualSSHConnection.md" >}}
     
-   If you generated a new keypair, click <i class="material-icons" aria-hidden="true" title="Download">file_download</i> **Add** on the **SSH Keypairs** widget to download the public and private keys.
+   The generated keypair shows on the **SSH Keypair** widget.
+   To download the public and private keypairs, click the <i class="material-icons" aria-hidden="true" title="Download">file_download</i> for the new keypair on the **SSH Keypairs** widget.
    TrueNAS automatically adds the public key to **Authorized Keys** for the admin user.
 
-4. Add the keypair and SSH connection to the remote system.
-  
-   If the remote system is another TrueNAS SCALE system, go to **Credentials > Backup Credentials** and add the keypair first.
-   Paste in the public and private keys that you created on the host.
-   Then create the SSH connection as above.
-   Select the new key from the **Private Key** dropdown.
+### Adding an Rsync Task
+Enabled SSH on both the local host TrueNAS and the remote destination system.
 
-5. Go to **Credentials > Local Users**, select the admin user, and click **Edit**.
-   Check **Authentication** to ensure the SSH public key is present.
-   If needed, paste the public key in **Authorized Keys** or click **Choose File** then browse to and upload the public key file.
-
-   (Optional) If selecting **SSH private key stored in user's home directory** for **Connect Using** in the rsync task configuration, add the private key to the home directory for the user to perform the task.
-   For the admin user, the default location is <file>/home/admin/.ssh/*private_key*</file>.
-
-6. If not already present, add the public key to the home directory of the remote user with permission to write to the destination dataset.
-   Follow the procedure above for remote TrueNAS SCALE systems.
-
-   (Optional) If selecting **SSH private key stored in user's home directory** for **Connect Using** in the rsync task configuration, add the private key to the home directory for the remote user.
-
-### Creating an SSH Mode Rsync Task
+You can use the SSS connection created in [Setting Up an SSH Connection](#setting-up-an-ssh-connection) or create a new connection while configuring the rsync task.
 
 1. Go to **Data Protection** and click **Add** on the **Rsync Tasks** widget to open the **Add Rsync Task** screen.
 
-{{< trueimage src="/images/SCALE/DataProtection/AddRsyncTaskSourceRemoteSSH.png" alt="Add Rsync Task - SSH Mode" id="Add Rsync Task - SSH Mode" >}}
+   {{< trueimage src="/images/SCALE/DataProtection/AddRsyncTaskSourceRemoteSSH.png" alt="Add Rsync Task - SSH Mode" id="Add Rsync Task - SSH Mode" >}}
 
 2. Enter or browse to the dataset or folder to sync with the remote server.
    Use the <span class="material-icons">arrow_right</span> to the left of the **/mnt** folder and each folder listed on the tree to expand and browse through, then click on the name to populate the path field.
 
     {{< include file="/static/includes/FileExplorerFolderIcons.md" >}}
 
-3. Select a **User** account to perform the rsync task.
-   The user must have permissions to run an rsync on the remote server and read/write permission for the local dataset.
+3. Select the administration user for the local host TrueNAS system from the **User** dropdown. This is the user account to perform the rsync task.
+   The user must have read/write permissions for the local dataset.
 
 4. Set the **Direction** for the rsync task.
    Select **Pull** to copy from the remote server to TrueNAS or **Push** to copy to the remote server.
 
-5. Select **SSH** as the connection mode from the **Rsync Mode** dropdown.
-   The SSH settings fields show.
-
+5. Select **SSH** as the connection mode from the **Rsync Mode** dropdown to use an SSH connection. The settings fields show.
+   
+   Set this to **Module** if syncing with a non-TrueNAS remote system. See [Setting Up an Rsync Task Using Module Mode](#setting-up-an-rsync-task-using-module-modek) for more information.
+  
 6. Choose a connection method from the **Connect using** dropdown list.
 
-   If selecting **SSH private key stored in user's home directory**, enter the IP address or hostname of the remote system in **Remote Host**.
-   Use the format *username@remote_host* if the username differs on the remote host.
-   Enter the SSH port number for the remote system in **Remote SSH Port**. By default, **22** is reserved in TrueNAS.
+   If selecting **SSH private key stored in user's home directory**, the public key for the SSH connection must be saved in the home directory for administration user.
+   To accomplish this, copy the public key from the **SSH Keypair** and paste into the **Authorized Keys** field on the **Edit User** screen.
 
-   If selecting **SSH connection from the keychain**, select an existing **SSH connection** to a remote system or choose **Create New** to add a new SSH connection.
+   If selecting **SSH connection from the keychain** the system grabs the key for you, and select either the existing SSH credential from the **SSH Connection** dropdown list or select **Add New** to open the **New SSH Connection** configuration screen.
 
-7. Enter in **Remote Path** the full path to a location on the remote server to pull from or push to.
+7. Enter the full path to the dataset on the remote server to either pull from or push to in **Remote Path**.
    Maximum path length is 255 characters.
 
    If the remote path location does not exist, select **Validate Remote Path** to create and define it in **Remote Path**.
@@ -106,28 +106,30 @@ After setting up the SSH connection, [configure the rsync task](#creating-an-ssh
 
 9. Select the **Enabled** to enable the task.
    Leave cleared to disable the task but not delete the configuration.
-   You can still run the rsync task by going to **Data Protection** and clicking <i class="fa fa-chevron-right"></i> then the **Run Now** <i class="material-icons" aria-hidden="true" title="play_arrow">play_arrow</i> icon for the rsync task.
+   You can run the rsync task at any time from the **Rsync Taks** widget by the **Run Now** <i class="material-icons" aria-hidden="true" title="play_arrow">play_arrow</i> icon for the rsync task.
 
 10. Click **Save**.
+   The system verifies the SSH connection and adds the task to the **Rsync Tasks** widget.
+   If the connection fails the system lets you know what went wrong so you can correct the issue with the connection.
 
 ## Configuring Module Mode Rsync Tasks
 
 Before you create an rsync task in module mode, you must [define at least one module](#defining-an-rsync-module) per [rsyncd.conf(5)](https://www.samba.org/ftp/rsync/rsyncd.conf.html) on the remote rsync server.
 The [Rsync Daemon]({{< relref "Rsyncd.md" >}}) application is available in situations where configuring TrueNAS as an rsync server with an rsync module is necessary.
 
-After configuring the rsync server, [configure the rsync task](#creating-a-module-mode-rsync-task).
+After configuring the rsync server, configure the rsync task.
 
 ### Defining an Rsync Module
 
 If the non-TruNAS remote server includes an rsync service, make sure it is turned on.
 
-1. Create a [dataset]({{< relref "DatasetsSCALE.md" >}}) on the remote TrueNAS (or other system).
+1. Create a dataset on the remote system.
    Write down the host and path to the data on the remote system you plan to sync with.
 
-2. Create a module on the remote system.
+2. Create an rsync module on the remote system.
    On TrueNAS, install an rsync app (such as [Rsyncd]({{< relref "Rsyncd.md" >}})) and configure the module.
 
-### Creating a Module Mode Rsync Task
+### Setting Up an Rsync Task Using Module Mode
 
 1. Go to **Data Protection** and click **Add** on the **Rsync Tasks** widget to open the **Add Rsync Task** screen.
 
@@ -136,7 +138,7 @@ If the non-TruNAS remote server includes an rsync service, make sure it is turne
 2. Enter or browse to the dataset or folder to sync with the remote server.
    Use the <span class="material-icons">arrow_right</span> to the left of the **/mnt** folder and each folder listed on the tree to expand and browse through, then click on the name to populate the path field.
 
-    {{< include file="/static/includes/FileExplorerFolderIcons.md" >}}
+   {{< include file="/static/includes/FileExplorerFolderIcons.md" >}}
 
 3. Select a **User** account to perform the rsync task.
    The user must have permissions to run an rsync on the remote server and read/write permission for the local dataset.
@@ -161,6 +163,7 @@ If the non-TruNAS remote server includes an rsync service, make sure it is turne
 
 8. Select the **Enabled** to enable the task.
    Leave cleared to disable the task but not delete the configuration.
-   You can still run the rsync task by going to **Data Protection** and clicking <i class="fa fa-chevron-right"></i> then the **Run Now** <i class="material-icons" aria-hidden="true" title="play_arrow">play_arrow</i> icon for the rsync task.
+
+   You can run the rsync task by clicking <i class="fa fa-chevron-right"></i> then the **Run Now** <i class="material-icons" aria-hidden="true" title="play_arrow">play_arrow</i> icon for the rsync task.
 
 9. Click **Save**.

--- a/content/SCALE/SCALETutorials/DataProtection/RsyncTasksSCALE.md
+++ b/content/SCALE/SCALETutorials/DataProtection/RsyncTasksSCALE.md
@@ -33,31 +33,34 @@ You can set up a new SSH connection on the **Credentials > Backup Credentials** 
 
 The following procedure provides instructions on setting up an SSH connection using the **New SSH Connection** screen.
 
-1. Enable SSH on both the local and remote systems.
+Enable SSH on both the local and remote systems.
+On the local TrueNAS host system, go to **System > Services** and toggle **SSH** to on, and enable the SSH service on the remote host system.
 
-   On the local TrueNAS host system, go to **System > Services** and toggle **SSH** to on, and enable the SSH service on the remote host system.
-
-2. Set up a home directory for the remote system administrator on the remote system.
-   Note the path to where home directories are stored to enter on the local host TrueNAS.
+Set up a home directory for the remote system administrator on the remote system.
+Note the path to where home directories are stored to enter on the local host TrueNAS.
    
-   If the remote system is also a TrueNAS, go to **Credentials**, select **Users** to see the list of users.
-   Select the administration user and click **Edit**.
+If the remote system is also a TrueNAS, go to **Credentials**, select **Users** to see the list of users.
+Select the administration user and click **Edit**.
 
-   If creating a new administration user, for rsync functions, click **Add**.
-   See [Managing Users]({{< relref "managelocalusersscale.md#creating-an-administrator-user-account" >}}) for more information.
-   Take note of the path to the home directory to use in setting up the connection.
+If creating a new administration user, for rsync functions, click **Add**.
+See [Managing Users]({{< relref "managelocalusersscale.md #creating-an-administrator-user-account" >}}) for more information.
+Take note of the path to the home directory to use in setting up the connection.
 
-3. Add an SSH connection for the remote server on the local TrueNAS host system. If the remote system is a TrueNAS:
-   
-   {{< include file="/static/includes/AddSSHConnection.md" >}}
+Add an SSH connection for the remote server on the local TrueNAS host system. 
 
-   You can add a connection to a non-TrueNAS remote host system.
+{{< expand "Adding a remote TrueNAS system" "v" >}}
 
-   {{< include file="/static/includes/AddManualSSHConnection.md" >}}
-    
-   The generated keypair shows on the **SSH Keypair** widget.
-   To download the public and private keypairs, click the <i class="material-icons" aria-hidden="true" title="Download">file_download</i> for the new keypair on the **SSH Keypairs** widget.
-   TrueNAS automatically adds the public key to **Authorized Keys** for the admin user.
+{{< include file="/static/includes/AddSSHConnection.md" >}}
+
+{{< /expand >}}
+
+{{< expand "Adding a connection to a non-TrueNAS remote host system" "v" >}}
+
+{{< include file="/static/includes/AddManualSSHConnection.md" >}}
+{{< /expand >}}
+
+The generated keypair shows on the **SSH Keypair** widget.
+To download the public and private keypairs, click the <i class="material-icons" aria-hidden="true" title="Download">file_download</i> for the new keypair on the **SSH Keypairs** widget.
 
 ### Adding an Rsync Task
 Enabled SSH on both the local host TrueNAS and the remote destination system.

--- a/content/SCALE/SCALETutorials/DataProtection/RsyncTasksSCALE.md
+++ b/content/SCALE/SCALETutorials/DataProtection/RsyncTasksSCALE.md
@@ -16,12 +16,13 @@ keywords:
 
 [Rsync](https://rsync.samba.org/) provides fast incremental data transfer to synchronize files between a TrueNAS host and a remote system.
 The **Push** function copies data from TrueNAS to a remote system.
-The **Pull** function copies data from a remote system and stores it in the defined **Path** on the TrueNAS host system.
+The **Pull** function copies data from a remote system to the TrueNAS local host system, and stores it in the dataset defined in the **Path** field.
 
-There are two ways to connect to a remote system and run an rsync task: setting up an [SSH connection](#configuring-ssh-mode-rsync-tasks) to the remote server or an [rsync module](#configuring-module-mode-rsync-tasks) on the remote server.
+There are two ways to connect to a remote system and run an rsync task: 
+* Set up an [SSH connection](#configuring-ssh-mode-rsync-tasks) to the remote server.
+* Set up an [rsync module](#configuring-module-mode-rsync-tasks) for the remote server.
 
 ## Configuring SSH Mode Rsync Tasks
-
 Before you create an rsync task in SSH mode, [add an SSH connection and keypair](#setting-up-an-ssh-connection) between the TrueNAS host and remote system.
 See [Adding SSH Credentials]({{< relref "AddSSHConnectionKeyPair.md" >}}) for more information.
 
@@ -29,53 +30,37 @@ After setting up the SSH connection, [configure the rsync task](#creating-an-ssh
 
 ### Setting up an SSH Connection
 
-1. Enable SSH on the remote system.
-
-2. Enable SSH in TrueNAS.
-  Go to **System > Services** and toggle **SSH** on.
+1. Enable SSH on the remote system and on the TrueNAS local host system. Go to **System > Services** and toggle **SSH** on.
 
 3. Add an SSH connection to the remote server.
-Go to **Credentials > Backup Credentials** and use **SSH Connections** and **SSH Keypairs**.
+   
+   {{< include file="/static/includes/AddSSHConnection.md" >}}
 
-   Populate the **SSH Connections** configuration fields as follows:
+   To add a connection to a non-TrueNAS remote host system
 
-   **TrueNAS Host to TrueNAS Remote**
-
-     a. Select **Semi-automatic (TrueNAS only)** in **Setup Method**.<br>
-     b. Enter the remote **TrueNAS URL**.<br>
-     c. Fill in the remaining credentials for this TrueNAS to authenticate to the remote TrueNAS and exchange SSH keys.<br>
-     d. Select **Generate New** in **Private Key**.<br>
-     e. Enter a number of seconds for TrueNAS to attempt the connection before timing out and closing the connection.<br>
-
-   **TrueNAS Host to Non-TrueNAS Remote**
-
-     a. Select **Manual** in **Setup Method**.<br>
-     b. Enter the remote host name, port number, and user in the appropriate fields.<br>
-     c. Select **Generate New** in **Private Key** or click **Discover Remote Host Key** to connect to the remote system and automatically populate the **Remote Host Key** field.<br>
-     d. Enter a number of seconds for TrueNAS to attempt the connection before timing out and closing the connection.<br>
-
-    Click **Save.**
-    If you generated a new keypair, click <i class="material-icons" aria-hidden="true" title="Download">file_download</i> on **SSH Keypairs** to download the public and private keys.
-    TrueNAS automatically adds the public key to **Authorized Keys** for the admin user.
+   {{< include file="/static/includes/AddManualSSHConnection.md" >}}
+    
+   If you generated a new keypair, click <i class="material-icons" aria-hidden="true" title="Download">file_download</i> **Add** on the **SSH Keypairs** widget to download the public and private keys.
+   TrueNAS automatically adds the public key to **Authorized Keys** for the admin user.
 
 4. Add the keypair and SSH connection to the remote system.
   
-    If the remote system is another TrueNAS SCALE system, go to **Credentials > Backup Credentials** and add the keypair first.
-    Paste in the public and private keys that you created on the host.
-    Then create the SSH connection as above.
-    Select the new key from the **Private Key** dropdown.
+   If the remote system is another TrueNAS SCALE system, go to **Credentials > Backup Credentials** and add the keypair first.
+   Paste in the public and private keys that you created on the host.
+   Then create the SSH connection as above.
+   Select the new key from the **Private Key** dropdown.
 
 5. Go to **Credentials > Local Users**, select the admin user, and click **Edit**.
-    Check **Authentication** to ensure the SSH public key is present.
-    If needed, paste the public key in **Authorized Keys** or click **Choose File** then browse to and upload the public key file.
+   Check **Authentication** to ensure the SSH public key is present.
+   If needed, paste the public key in **Authorized Keys** or click **Choose File** then browse to and upload the public key file.
 
-    (Optional) If selecting **SSH private key stored in user's home directory** for **Connect Using** in the rsync task configuration, add the private key to the home directory for the user to perform the task.
-    For the admin user, the default location is <file>/home/admin/.ssh/*private_key*</file>.
+   (Optional) If selecting **SSH private key stored in user's home directory** for **Connect Using** in the rsync task configuration, add the private key to the home directory for the user to perform the task.
+   For the admin user, the default location is <file>/home/admin/.ssh/*private_key*</file>.
 
 6. If not already present, add the public key to the home directory of the remote user with permission to write to the destination dataset.
-    Follow the procedure above for remote TrueNAS SCALE systems.
+   Follow the procedure above for remote TrueNAS SCALE systems.
 
-    (Optional) If selecting **SSH private key stored in user's home directory** for **Connect Using** in the rsync task configuration, add the private key to the home directory for the remote user.
+   (Optional) If selecting **SSH private key stored in user's home directory** for **Connect Using** in the rsync task configuration, add the private key to the home directory for the remote user.
 
 ### Creating an SSH Mode Rsync Task
 
@@ -84,44 +69,44 @@ Go to **Credentials > Backup Credentials** and use **SSH Connections** and **SSH
 {{< trueimage src="/images/SCALE/DataProtection/AddRsyncTaskSourceRemoteSSH.png" alt="Add Rsync Task - SSH Mode" id="Add Rsync Task - SSH Mode" >}}
 
 2. Enter or browse to the dataset or folder to sync with the remote server.
-    Use the <span class="material-icons">arrow_right</span> to the left of the **/mnt** folder and each folder listed on the tree to expand and browse through, then click on the name to populate the path field.
+   Use the <span class="material-icons">arrow_right</span> to the left of the **/mnt** folder and each folder listed on the tree to expand and browse through, then click on the name to populate the path field.
 
     {{< include file="/static/includes/FileExplorerFolderIcons.md" >}}
 
 3. Select a **User** account to perform the rsync task.
-    The user must have permissions to run an rsync on the remote server and read/write permission for the local dataset.
+   The user must have permissions to run an rsync on the remote server and read/write permission for the local dataset.
 
 4. Set the **Direction** for the rsync task.
-    Select **Pull** to copy from the remote server to TrueNAS or **Push** to copy to the remote server.
+   Select **Pull** to copy from the remote server to TrueNAS or **Push** to copy to the remote server.
 
 5. Select **SSH** as the connection mode from the **Rsync Mode** dropdown.
-    The SSH settings fields show.
+   The SSH settings fields show.
 
 6. Choose a connection method from the **Connect using** dropdown list.
 
-    If selecting **SSH private key stored in user's home directory**, enter the IP address or hostname of the remote system in **Remote Host**.
-        Use the format *username@remote_host* if the username differs on the remote host.
-        Enter the SSH port number for the remote system in **Remote SSH Port**. By default, **22** is reserved in TrueNAS.
+   If selecting **SSH private key stored in user's home directory**, enter the IP address or hostname of the remote system in **Remote Host**.
+   Use the format *username@remote_host* if the username differs on the remote host.
+   Enter the SSH port number for the remote system in **Remote SSH Port**. By default, **22** is reserved in TrueNAS.
 
-    If selecting **SSH connection from the keychain**, select an existing **SSH connection** to a remote system or choose **Create New** to add a new SSH connection.
+   If selecting **SSH connection from the keychain**, select an existing **SSH connection** to a remote system or choose **Create New** to add a new SSH connection.
 
 7. Enter in **Remote Path** the full path to a location on the remote server to pull from or push to.
-    Maximum path length is 255 characters.
+   Maximum path length is 255 characters.
 
-    If the remote path location does not exist, select **Validate Remote Path** to create and define it in **Remote Path**.
+   If the remote path location does not exist, select **Validate Remote Path** to create and define it in **Remote Path**.
 
 8. Set the schedule for when to run this task, and any other options you want to use.
 
-    {{< trueimage src="/images/SCALE/DataProtection/AddRsyncTaskSchedOpt.png" alt="Add Rsync Task Schedule and More Options" id="Add Rsync Task Schedule and More Options" >}}
+   {{< trueimage src="/images/SCALE/DataProtection/AddRsyncTaskSchedOpt.png" alt="Add Rsync Task Schedule and More Options" id="Add Rsync Task Schedule and More Options" >}}
 
-    If you need a custom schedule, select **Custom** to open the advanced scheduler window.
-  {{< expand "Advanced Scheduler" "v" >}}
-  {{< include file="/static/includes/SCALEAdvancedScheduler.md" >}}
-  {{< /expand >}}
+   If you need a custom schedule, select **Custom** to open the advanced scheduler window.
+   {{< expand "Advanced Scheduler" "v" >}}
+   {{< include file="/static/includes/SCALEAdvancedScheduler.md" >}}
+   {{< /expand >}}
 
 9. Select the **Enabled** to enable the task.
-    Leave cleared to disable the task but not delete the configuration.
-    You can still run the rsync task by going to **Data Protection** and clicking <i class="fa fa-chevron-right"></i> then the **Run Now** <i class="material-icons" aria-hidden="true" title="play_arrow">play_arrow</i> icon for the rsync task.
+   Leave cleared to disable the task but not delete the configuration.
+   You can still run the rsync task by going to **Data Protection** and clicking <i class="fa fa-chevron-right"></i> then the **Run Now** <i class="material-icons" aria-hidden="true" title="play_arrow">play_arrow</i> icon for the rsync task.
 
 10. Click **Save**.
 
@@ -137,45 +122,45 @@ After configuring the rsync server, [configure the rsync task](#creating-a-modul
 If the non-TruNAS remote server includes an rsync service, make sure it is turned on.
 
 1. Create a [dataset]({{< relref "DatasetsSCALE.md" >}}) on the remote TrueNAS (or other system).
-    Write down the host and path to the data on the remote system you plan to sync with.
+   Write down the host and path to the data on the remote system you plan to sync with.
 
 2. Create a module on the remote system.
-    On TrueNAS, install an rsync app (such as [Rsyncd]({{< relref "Rsyncd.md" >}})) and configure the module.
+   On TrueNAS, install an rsync app (such as [Rsyncd]({{< relref "Rsyncd.md" >}})) and configure the module.
 
 ### Creating a Module Mode Rsync Task
 
 1. Go to **Data Protection** and click **Add** on the **Rsync Tasks** widget to open the **Add Rsync Task** screen.
 
-{{< trueimage src="/images/SCALE/DataProtection/AddRsyncTaskSourceAndRemoteSettings.png" alt="Add Rsync Task - Module Mode" id="Add Rsync Task - Module Mode" >}}
+   {{< trueimage src="/images/SCALE/DataProtection/AddRsyncTaskSourceAndRemoteSettings.png" alt="Add Rsync Task - Module Mode" id="Add Rsync Task - Module Mode" >}}
 
 2. Enter or browse to the dataset or folder to sync with the remote server.
-    Use the <span class="material-icons">arrow_right</span> to the left of the **/mnt** folder and each folder listed on the tree to expand and browse through, then click on the name to populate the path field.
+   Use the <span class="material-icons">arrow_right</span> to the left of the **/mnt** folder and each folder listed on the tree to expand and browse through, then click on the name to populate the path field.
 
     {{< include file="/static/includes/FileExplorerFolderIcons.md" >}}
 
 3. Select a **User** account to perform the rsync task.
-    The user must have permissions to run an rsync on the remote server and read/write permission for the local dataset.
+   The user must have permissions to run an rsync on the remote server and read/write permission for the local dataset.
 
 4. Set the **Direction** for the rsync task.
-    Select **Pull** to copy from the remote server to TrueNAS or **Push** to copy to the remote server.
+   Select **Pull** to copy from the remote server to TrueNAS or **Push** to copy to the remote server.
 
 5. Select **Module** as the connection mode from the **Rsync Mode** dropdown.
-    The module settings fields show.
+   The module settings fields show.
 
 6. Enter the remote host name or IP in **Remote Host**.
-    Use the format *username@remote_host* when the username differs from the host entered into the **Remote Host** field.
+   Use the format *username@remote_host* when the username differs from the host entered into the **Remote Host** field.
 
 7. Set the schedule for when to run this task, and any other options you want to use.
 
-    {{< trueimage src="/images/SCALE/DataProtection/AddRsyncTaskSchedOpt.png" alt="Add Rsync Task Schedule and More Options" id="Add Rsync Task Schedule and More Options" >}}
+   {{< trueimage src="/images/SCALE/DataProtection/AddRsyncTaskSchedOpt.png" alt="Add Rsync Task Schedule and More Options" id="Add Rsync Task Schedule and More Options" >}}
 
-    If you need a custom schedule, select **Custom** to open the advanced scheduler window.
-  {{< expand "Advanced Scheduler" "v" >}}
-  {{< include file="/static/includes/SCALEAdvancedScheduler.md" >}}
-  {{< /expand >}}
+   If you need a custom schedule, select **Custom** to open the advanced scheduler window.
+   {{< expand "Advanced Scheduler" "v" >}}
+   {{< include file="/static/includes/SCALEAdvancedScheduler.md" >}}
+   {{< /expand >}}
 
 8. Select the **Enabled** to enable the task.
-    Leave cleared to disable the task but not delete the configuration.
-    You can still run the rsync task by going to **Data Protection** and clicking <i class="fa fa-chevron-right"></i> then the **Run Now** <i class="material-icons" aria-hidden="true" title="play_arrow">play_arrow</i> icon for the rsync task.
+   Leave cleared to disable the task but not delete the configuration.
+   You can still run the rsync task by going to **Data Protection** and clicking <i class="fa fa-chevron-right"></i> then the **Run Now** <i class="material-icons" aria-hidden="true" title="play_arrow">play_arrow</i> icon for the rsync task.
 
 9. Click **Save**.

--- a/content/SCALE/SCALETutorials/Network/ConfigureIPv6.md
+++ b/content/SCALE/SCALETutorials/Network/ConfigureIPv6.md
@@ -140,14 +140,6 @@ Both replication to a remote server and rscyn tasks require configuring an SSH c
 When both systems are using IPv6 addresses and the protocol to communicate, you must enclose the IPv6 address in square brackets when defining the remote system URL in the **TrueNAS URL** field on the **New SSH Connection** configuration screen.
 <!-- 
 
-### Setting up Rsync Tasks
-
-Commenting out this section Until I can test rsync tasks using module and ssh modes.
-
-### Setting Up Cloud Sync Tasks  
-
-Commented out until we have Internet access over our IPv6 network so we can test. 
-
 ### Using IPv6 with Applications
 Commented out until we have Internet access over our IPv6 network so we can test. 
 

--- a/content/SCALE/SCALETutorials/Network/ConfigureIPv6.md
+++ b/content/SCALE/SCALETutorials/Network/ConfigureIPv6.md
@@ -135,7 +135,11 @@ Enter two forward slashes, followed by the IPv6 address with **.ipv6-literal.net
 
 For example, <code>\\<i>ffff-ff-59f8-100--12</i>.ipv6-literal.net\<i>v6smbshare</i></code>.
 
+### Configuring an SSH Connection
+Both replication to a remote server and rscyn tasks require configuring an SSH connection credential.
+When both systems are using IPv6 addresses and the protocol to communicate, you must enclose the IPv6 address in square brackets when defining the remote system URL in the **TrueNAS URL** field on the **New SSH Connection** configuration screen.
 <!-- 
+
 ### Setting up Rsync Tasks
 
 Commenting out this section Until I can test rsync tasks using module and ssh modes.

--- a/static/includes/AddManualSSHConnection.md
+++ b/static/includes/AddManualSSHConnection.md
@@ -1,0 +1,33 @@
+&NewLine;
+
+Click **Add** on the **SSH Connections** widget to open the configuration screen:
+
+1. Enter a name for the connection, then select **Manual** from the **Setup Method** dropdown list.
+
+   {{< trueimage src="/images/SCALE/Credentials/NewSSHConnectNameMethodManual.png" alt="Manual Name and Method" id="Manual Name and Method" >}}
+
+2. Enter the authentication settings.
+
+   {{< trueimage src="/images/SCALE/Credentials/NewSSHConnectAuthenticationManual.png" alt="Manual Authentication Settings" id="Manual Authentication Settings" >}}
+
+   a. Enter a host name or host IP address for the remote non-TrueNAS system as a valid URL.
+      An IP address example is *https://10.231.3.76*.
+      This is a required field.
+
+   b. Enter the port number of the remote system to use for the SSH connection.
+
+   c. Enter a user name for logging into the remote system in **Username**.
+
+   c. Select the private key from the SSH key pair that you use to transfer the public key on the remote NAS from the **Private Key** dropdown.
+
+   d. Click **Discover Remote Host Key** after properly configuring all other fields to query the remote system and automatically populate the **Remote Host Key** field.
+
+4. (Optional) Enter the number of seconds you want SCALE to wait for the remote TrueNAS system to connect in **Connect Timeout**.
+
+   {{< trueimage src="/images/SCALE/Credentials/NewSSHConnectMoreOptions.png" alt="Manual More Options" id="Manual More Options" >}}
+
+5. Click **Save**. 
+
+   Saving a new connection automatically opens a connection to the remote TrueNAS and exchanges SSH keys.
+   The new SSH connection displays on the **SSH Connection** widget.
+   To edit it, click on the name to open the **SSH Connections** configuration screen populated with the saved settings.

--- a/static/includes/AddSSHConnection.md
+++ b/static/includes/AddSSHConnection.md
@@ -1,0 +1,38 @@
+&NewLine;
+
+Click **Add** on the **SSH Connections** widget to open the configuration screen:
+
+1. Enter a name for the connection, then select the **Setup Method**. 
+
+   If establishing an SSH connection to another TrueNAS server use the default **Semi-automatic (TrueNAS only)** option.
+
+   If connecting to a non-TrueNAS server select **Manual** from the dropdown list.
+
+   {{< trueimage src="/images/SCALE/Credentials/NewSSHConnectNameMethodAuto.png" alt="Name and Method Settings" id="Name and Method Settings" >}}
+
+2. Enter the authentication settings.
+
+   {{< trueimage src="/images/SCALE/Credentials/NewSSHConnectAuthentication.png" alt="Authentication Settings" id="Authentication Settings" >}}
+
+   a. Enter a valid URL scheme for the remote TrueNAS URL in **TrueNAS URL**.
+      If specifying an IPv6 address, you must enter the IPv6 address enclosed in square brackets.
+      For example, **https://[*ffff:ff:59f1:123::12*]**.
+
+   b. Enter an admin user name, which is the username on the remote system entered to log in via the web UI to set up the connection.
+      You can leave **Admin Username** set to the default **root** user, then enter the user password in **Admin Password**.
+
+   c. (Optional) Enter the one-time password in **One-Time Password (if necessary)** if two-factor authentication is enabled.
+
+   d. Enter a **Username**, which is the user name on the remote system to log in via SSH.
+
+   e. Enter or import the private key from a previously created SSH key pair, or select **Generate New** to create a new one.
+
+4. (Optional) Enter the number of seconds you want to have SCALE wait for the remote TrueNAS system to connect in **Connect Timeout**.
+
+   {{< trueimage src="/images/SCALE/Credentials/NewSSHConnectMoreOptions.png" alt="More Options Settings" id="More Options Settings" >}}
+
+5. Click **Save**. 
+   
+   Saving a new connection automatically opens a connection to the remote TrueNAS and exchanges SSH keys.
+   The new SSH connection displays on the **SSH Connection** widget.
+   To edit it, click on the name to open the **SSH Connections** configuration screen populated with the saved settings.


### PR DESCRIPTION
This PR updates the instructions for creating an SSH Connection tutorials by converting instructions to snippets to use in other articles that include the same instructions.
It updates the RsyncTasksSCALE.md tutorial with new content, uses the new snippets, and reorganizes the procedure flow for better readability. It corrects inaccurate information.

This PR can backport to 24.10 branch.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
