### PR TITLE
PD-1405 / 25.04 / PD-1405-the-static-ip-settings-from-console-are-inaccurate (by linzi-ix)

### DIFF
--- a/content/SCALE/GettingStarted/Install/ConsoleSetupMenuScale.md
+++ b/content/SCALE/GettingStarted/Install/ConsoleSetupMenuScale.md
@@ -33,7 +33,7 @@ For network configuration options **1**, **2**, and **3**, we recommend using th
 
   Use this to configure the primary network interface with a static IP.
   This is for switching away from the DHCP-assigned IP address TrueNAS provides when the system boots after installing SCALE.
-  Also, use this to set up other network interfaces or to add alias IP addresses for the primary interface.
+  Also, use this to set up other network interfaces or to add alias IP addresses, also referred to as static IP addresses, for the primary interface.
 
 * **2) Configure network settings**
   


### PR DESCRIPTION
Updated singular instance of alias/static IP address referral as instructed by Tim.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.


Original PR: https://github.com/truenas/documentation/pull/3049
Jira URL: https://ixsystems.atlassian.net/browse/PD-1405