### PR TITLE
PD-1466: (NAS-130436) pool expand on disk replace procedure

### DIFF
--- a/content/SCALETutorials/Storage/ManagePoolsScale.md
+++ b/content/SCALETutorials/Storage/ManagePoolsScale.md
@@ -265,7 +265,9 @@ Click anywhere on the VDEV to expand it and select one of the existing disks.
 Wait for the resilver to complete before replacing the next disk.
 Repeat steps 1-4 for all attached disks.
 
-TrueNAS SCALE automatically expands the usable capacity of the pool to fit all available space once the last attached disk is replaced.
+When all disk replacements are finished, expand the pool to fill all available space.
+Go to the **Storage** page, click **Expand**, and confirm the action.
+This action is permanent and cannot be reverted.
 
 ## Removing VDEVs
 

--- a/content/SCALEUIReference/Storage/_index.md
+++ b/content/SCALEUIReference/Storage/_index.md
@@ -74,7 +74,9 @@ After adding pools, the dashboard shows [storage widgets](#storage-dashboard-wid
 
 * {{< expand "Expand (Click to expand)" "v" >}}
   Select **Expand Pool** to increase the pool size to match all available disk space.
-  Users with pools using virtual disks use this option to resize these virtual disks apart from TrueNAS.
+  This is used as the final step to resize disk partitions when [expanding a pool capacity with disk replacements]({{< relref "ManagePoolsScale.md#replacing-disks-to-expand-a-pool" >}}).
+  Also, users with pools of virtual disks use this option to resize these virtual disks apart from TrueNAS.
+  This is a permament action that can't be reverted.
 
   {{< trueimage src="/images/SCALE/Storage/ExpandPoolDialog.png" alt="Expand Pool Dialog" id="Expand Pool Dialog" >}}
 

--- a/content/SCALEUIReference/Storage/_index.md
+++ b/content/SCALEUIReference/Storage/_index.md
@@ -76,7 +76,7 @@ After adding pools, the dashboard shows [storage widgets](#storage-dashboard-wid
   Select **Expand Pool** to increase the pool size to match all available disk space.
   This is used as the final step to resize disk partitions when [expanding a pool capacity with disk replacements]({{< relref "ManagePoolsScale.md#replacing-disks-to-expand-a-pool" >}}).
   Also, users with pools of virtual disks use this option to resize these virtual disks apart from TrueNAS.
-  This is a permament action that can't be reverted.
+  This is a permament action that cannot be reverted.
 
   {{< trueimage src="/images/SCALE/Storage/ExpandPoolDialog.png" alt="Expand Pool Dialog" id="Expand Pool Dialog" >}}
 


### PR DESCRIPTION
There was an erroneous sentence about pool autoexpand when the disks are replaced with larger capacities. Discussed with Caleb and Mav and determined autoexpand is not present in this situation, so rewrote the procedure to add an extra step to manually expand the pool after disks are replaced.

Final version of the PR needs to be ported to `master` branch.


Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
