### PR TITLE
PD-1378 / 24.10 / PD-1378-clarify-auto-unlock-behaviors-for-dataset-encryption-with-key-vs-password

### DIFF
--- a/content/SCALETutorials/Datasets/EncryptionSCALE.md
+++ b/content/SCALETutorials/Datasets/EncryptionSCALE.md
@@ -59,7 +59,7 @@ You can also move data from an unencrypted pool or dataset to an encrypted datas
 {{< /expand >}}
 
 {{< hint type=important >}}
-If your system loses power or you reboot the system, the datasets, zvols, and all data in an encrypted pool automatically lock to protect the data in that encrypted pool.
+If your system loses power or you reboot the system, datasets with and without inheritance within an encrypted pool remain unlocked. Similarly, encrypted and unencrypted datasets remain unlocked in an unencrypted pool following power loss or manual reboots.
 {{< /hint >}}
 
 ### Encryption Visual Cues


### PR DESCRIPTION
Ran tests on my system to confirm these results.
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
