### PR TITLE
PD-1500 / 13.0 / PD-1500 Add Aliases for Articles in Master not in 13.0

### DIFF
--- a/content/CORETutorials/Services/ConfiguringOpenVPN.md
+++ b/content/CORETutorials/Services/ConfiguringOpenVPN.md
@@ -1,6 +1,8 @@
 ---
 title: "Configuring OpenVPN"
 description: "Provices information on how to configure Open Virtual Private Network (OpenVPN) services on your TrueNAS."
+aliases:
+ - /core/coretutorials/communityguides/openvpn/
 weight: 70
 tags:
 - coreopenvpn

--- a/content/CORETutorials/Sharing/SMB/ManagingSMBShares.md
+++ b/content/CORETutorials/Sharing/SMB/ManagingSMBShares.md
@@ -2,6 +2,8 @@
 title: "Managing SMB Shares"
 description: "Provides information on how to manage Server Message Block (SMB) shares on your TrueNAS."
 weight: 10
+aliases: 
+ - /core/13.0/coretutorials/sharing/smb/manag
 tags:
 - coresmb
 ---

--- a/content/CORETutorials/Storage/Pools/Permissions.md
+++ b/content/CORETutorials/Storage/Pools/Permissions.md
@@ -2,6 +2,8 @@
 title: "Permissions"
 description: "This articled describes permissions configuration on TrueNAS CORE."
 weight: 22
+aliases:
+ - /core/coretutorials/communityguides/aclpermissionsjails/
 tags:
 - corepermissions
 - coredataset

--- a/content/CORETutorials/Tasks/CreatingReplicationTasks/AdvancedReplication.md
+++ b/content/CORETutorials/Tasks/CreatingReplicationTasks/AdvancedReplication.md
@@ -2,6 +2,8 @@
 title: "Advanced Replication"
 description: "Describes how to configure advanced replication tasks on TrueNAS CORE."
 weight: 30
+aliases:
+ - /core/coretutorials/communityguides/legacyreplication/
 tags:
 - coreadvancedreplication
 - corereplication

--- a/content/GettingStarted/Applications.md
+++ b/content/GettingStarted/Applications.md
@@ -2,6 +2,8 @@
 title: "Applications"
 description: "Describes how to install applications on TrueNAS CORE."
 weight: 90
+aliases:
+ - /core/coretutorials/jailspluginsvms/plugins/plexplugin/
 tags:
 - coregettingstarted
 - coreapplications

--- a/content/UIReference/System/Advanced.md
+++ b/content/UIReference/System/Advanced.md
@@ -2,6 +2,8 @@
 title: "Advanced"
 description: "Describes the System > Advanced screen on TrueNAS CORE."
 weight: 40
+aliases:
+ - /core/coretutorials/systemconfiguration/settingupsyslogserver/
 tags:
 - coreconfiguration
 - coresettings

--- a/words-to-ignore.txt
+++ b/words-to-ignore.txt
@@ -1497,3 +1497,6 @@ BCA
 AGIGA
 Hotfix
 regreSSHion
+coretutorials
+jailspluginsvms
+plexplugin


### PR DESCRIPTION
This PR adds aliases for CORE articles in Master not present in the 13.0 branch.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
