### PR TITLE
PD-1430 / 24.04 / PD-1430 Update 24.04 Migration Articles with Approved Migration Path

### DIFF
--- a/content/GettingStarted/Migrate/ComponentNaming.md
+++ b/content/GettingStarted/Migrate/ComponentNaming.md
@@ -2,6 +2,9 @@
 title: "Component Naming"
 description: "Provides information on disk and interface naming changes related to the change from FreeBSD storage and sharing in CORE to Linux in TrueNAS SCALE."
 weight: 35
+aliases:
+ - /scale/gettingstarted/migrate/componentnaming/
+ - /scale/24.10/gettingstarted/migrate/componentnaming/
 tags:
  - migrate
 ---

--- a/content/GettingStarted/Migrate/MigrateCOREHAtoSCALEHA.md
+++ b/content/GettingStarted/Migrate/MigrateCOREHAtoSCALEHA.md
@@ -2,6 +2,9 @@
 title: "Enterprise HA Migrations"
 description: "Discusses migrating a TrueNAS CORE High Availability (HA) system to SCALE."
 weight: 25
+aliases:
+ - /scale/gettingstarted/migrate/migratecorehatoscaleha/
+ - /scale/24.10/gettingstarted/migrate/migratecorehatoscaleha/
 tags:
 - migrate
 - install

--- a/content/GettingStarted/Migrate/MigratePrep.md
+++ b/content/GettingStarted/Migrate/MigratePrep.md
@@ -2,6 +2,9 @@
 title: "Preparing to Migrate"
 description: "Guides CORE users through preparation elements and steps before beginning the one-way CORE to SCALE migration process."
 weight: 10
+aliases:
+ - /scale/gettingstarted/migrate/migrateprep/
+ - /scale/24.10/gettingstarted/migrate/migrateprep/
 tags:
 - migrate
 ---

--- a/content/GettingStarted/Migrate/MigratingFromCORE.md
+++ b/content/GettingStarted/Migrate/MigratingFromCORE.md
@@ -2,6 +2,9 @@
 title: "Migrating TrueNAS CORE to SCALE"
 description: "Provides instructions on migrating from TrueNAS CORE to SCALE. Migration methods include using an ISO or manual update file."
 weight: 15
+aliases:
+ - /scale/gettingstarted/migrate/migratingfromcore/
+ - /scale/24.10/gettingstarted/migrate/migratingfromcore/ 
 tags:
 - migrate
 - install

--- a/content/GettingStarted/Migrate/SCALEZFSFlagRemoval.md
+++ b/content/GettingStarted/Migrate/SCALEZFSFlagRemoval.md
@@ -2,6 +2,9 @@
 title: "ZFS Feature Flags Removed (obsolete)"
 description: "(obsolete) Provides legacy information for users of a deprecated ZFS feature flag merged into TrueNAS SCALE 22.02 and removed in 22.12."
 weight: 40
+aliases:
+ - /scale/gettingstarted/migrate/scalezfsflagremoval/
+ - /scale/24.10/gettingstarted/migrate/scalezfsflagremoval/
 tags:
 - migrate
 ---

--- a/content/GettingStarted/Migrate/_index.md
+++ b/content/GettingStarted/Migrate/_index.md
@@ -3,6 +3,9 @@ title: "CORE to SCALE Migrations"
 description: "Information on preparing for and migrating TrueNAS CORE to TrueNAS SCALE."
 geekdocCollapseSection: true
 weight: 40
+aliases:
+ - /scale/gettingstarted/migrate/
+ - /scale-24.10/gettingstarted/migrate/
 tags:
 - migrate
 related: false

--- a/content/GettingStarted/Migrate/_index.md
+++ b/content/GettingStarted/Migrate/_index.md
@@ -4,8 +4,6 @@ description: "Information on preparing for and migrating TrueNAS CORE to TrueNAS
 geekdocCollapseSection: true
 weight: 40
 aliases:
- - /scale/gettingstarted/migrate/
- - /scale-24.10/gettingstarted/migrate/
 tags:
 - migrate
 related: false

--- a/static/includes/MigrateCOREtoSCALEWarning.md
+++ b/static/includes/MigrateCOREtoSCALEWarning.md
@@ -5,4 +5,8 @@ Migrating TrueNAS from CORE to SCALE is a one-way operation.
 Attempting to activate or roll back to a CORE boot environment can break the system.
 
 Upgrade your CORE system to the latest publicly-available 13.0-U6.1 (or later) release before attempting to migrate from CORE to SCALE.
+
+The only path to side-grade or migrate from CORE 13.0-U6.2 or CORE 13.3 to SCALE is to install or upgrade to 24.04 (latest).
+Later releases of SCALE do not support migrations from CORE releases. These migration cannot be done, and either fail or result in error conditions that cannot be resolved.
+Download the <file>iso</file> for the [latest maintenace release of SCALE 24.04](https://download.truenas.com/TrueNAS-SCALE-Dragonfish/24.04.2.3/) and follow the instruction articles in this section.
 {{< /hint >}}

--- a/static/includes/MigrateCOREtoSCALEWarning.md
+++ b/static/includes/MigrateCOREtoSCALEWarning.md
@@ -7,6 +7,6 @@ Attempting to activate or roll back to a CORE boot environment can break the sys
 Upgrade your CORE system to the latest publicly-available 13.0-U6.1 (or later) release before attempting to migrate from CORE to SCALE.
 
 The only path to side-grade or migrate from CORE 13.0-U6.2 or CORE 13.3 to SCALE is to install or upgrade to 24.04 (latest).
-Later releases of SCALE do not support migrations from CORE releases. These migration cannot be done, and either fail or result in error conditions that cannot be resolved.
+Later releases of SCALE do not support migrations from CORE releases. These migrations cannot be done, and either fail or result in error conditions that cannot be resolved.
 Download the <file>iso</file> for the [latest maintenace release of SCALE 24.04](https://download.truenas.com/TrueNAS-SCALE-Dragonfish/24.04.2.3/) and follow the instruction articles in this section.
 {{< /hint >}}


### PR DESCRIPTION
This PR updates the migration articles in 24.04 with the approved migration path and aliases from articles in both Master and 24.10 branches. It updates the MigrateCOREtoSCALEWarning.md snippet with the migration path information.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
