### PR TITLE
Update RESTAPIDeprecationNotice.md (24.10)

### DIFF
--- a/static/includes/RESTAPIDeprecationNotice.md
+++ b/static/includes/RESTAPIDeprecationNotice.md
@@ -1,11 +1,11 @@
 &NewLine;
 
 {{< hint type="info" title="REST API Deprecation Notice" >}}
-The TrueNAS REST API is being deprecated in TrueNAS 25.04 and replaced by the [TrueNAS API Client](https://github.com/truenas/api_client).
-Full removal of the REST API is targeted for a later release.
+The TrueNAS REST API is deprecated in TrueNAS 25.04 and replaced by the [TrueNAS API Client](https://github.com/truenas/api_client).
+Full removal of the REST API is planned for a future release.
 
-These new API Clients are not the deprecated TrueNAS CLI (midcli).
-The API Client is pre-installed in TrueNAS 25.04 onwards.
+This new API Client is not the deprecated TrueNAS CLI (midcli).
+The API Client is integrated in TrueNAS 25.04 onwards.
 It provides the `midclt` command-line tool, and the means to easily communicate with middleware using Python to make calls through the websocket API.
 
 This API client allows for better integration of TrueNAS into third-party solutions.

--- a/static/includes/RESTAPIDeprecationNotice.md
+++ b/static/includes/RESTAPIDeprecationNotice.md
@@ -1,13 +1,15 @@
 &NewLine;
 
 {{< hint type="info" title="REST API Deprecation Notice" >}}
-The TrueNAS REST API is being deprecated in Release 25.04 and replaced by the [TrueNAS API Client](https://github.com/truenas/api_client) and [TrueNAS Golang API Client](https://github.com/truenas/api_client_golang).
+The TrueNAS REST API is being deprecated in TrueNAS 25.04 and replaced by the [TrueNAS API Client](https://github.com/truenas/api_client).
+Full removal of the REST API is targeted for a later release.
 
-These new API Clients are not the deprecated TrueNAS CLI.
-The API Clients come pre-installed in TrueNAS.
+These new API Clients are not the deprecated TrueNAS CLI (midcli).
+The API Client is pre-installed in TrueNAS 25.04 onwards.
 It provides the `midclt` command-line tool, and the means to easily communicate with middleware using Python to make calls through the websocket API.
-The Golang API Client parallels the Python TrueNAS API client. Both API clients allow for better integration of TrueNAS into third-party solutions.
-Use these new API clients as a reference for projects that require direct TrueNAS integration.
+
+This API client allows for better integration of TrueNAS into third-party solutions.
+Use this as a reference for projects that require direct TrueNAS integration.
 
 TrueNAS API documentation remains available in the UI and through the [TrueNAS Documentation Hub]({{< relref "/content/api/_index.md" >}}).
 {{< /hint >}}


### PR DESCRIPTION
Feedback from Engineering:
- Note that REST API removal is targeted for later to avoid the impression that it is going away immediately.
- remove mentions of experimental golang client in favor of focusing on the recommended initial client.
- small cleanup of text



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
