### PR TITLE
PD-1403: redirect CORE nightly content to maintenance version

### DIFF
--- a/content/CORE/API/_index.md
+++ b/content/CORE/API/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "API Reference"
+redirect: "https://www.truenas.com/docs/core/13.0/api/"
 description: "Describes how to access the API documentation in TrueNAS 13."
 geekdocCollapseSection: true
 weight: 160

--- a/content/CORE/COREPrint.md
+++ b/content/CORE/COREPrint.md
@@ -5,4 +5,4 @@ weight: 1
 no_print: "true"
 related: false
 ---
-<meta http-equiv="Refresh" content="0; url='/core/printview'" />
+<meta http-equiv="Refresh" content="0; url='https://www.truenas.com/docs/core/13.0/printview'" />

--- a/content/CORE/COREPrint.md
+++ b/content/CORE/COREPrint.md
@@ -1,5 +1,6 @@
 ---
 title: "⎙ Download or Print"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/printview/"
 description: "View all CORE Documentation in a single page that can be downloaded or printed."
 weight: 1
 no_print: "true"

--- a/content/CORE/CORETutorials/CORETutorialsPrint.md
+++ b/content/CORE/CORETutorials/CORETutorialsPrint.md
@@ -1,5 +1,6 @@
 ---
 title: "⎙ Download or Print"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/printview/"
 description: "View all CORE tutorials as a single html file suitable for download or print."
 weight: 1
 no_print: "true"

--- a/content/CORE/CORETutorials/CORETutorialsPrint.md
+++ b/content/CORE/CORETutorials/CORETutorialsPrint.md
@@ -6,4 +6,4 @@ no_print: "true"
 related: false
 ---
 
-<meta http-equiv="Refresh" content="0; url='/core/coretutorials/printview'" />
+<meta http-equiv="Refresh" content="0; url='/core/13.0/coretutorials/printview'" />

--- a/content/CORE/CORETutorials/ChangingDefaultShell.md
+++ b/content/CORE/CORETutorials/ChangingDefaultShell.md
@@ -1,5 +1,6 @@
 ---
 title: "Changing the Default Shell"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/changingdefaultshell/"
 description: "Describes how to change the default shell on TrueNAS CORE."
 weight: 30
 Aliases:

--- a/content/CORE/CORETutorials/CommunityGuides/ACLPermissionsJails.md
+++ b/content/CORE/CORETutorials/CommunityGuides/ACLPermissionsJails.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting ACL Permissions for Jailed Applications"
+redirect: "https://www.truenas.com/docs/core/13.3/coretutorials/communityguides/aclpermissionsjails/"
 description: "Describes how to configure ACL permissions for jailed applications on TrueNAS CORE."
 geekdocCollapseSection: true
 weight: 20

--- a/content/CORE/CORETutorials/CommunityGuides/ETCHostsPersistence.md
+++ b/content/CORE/CORETutorials/CommunityGuides/ETCHostsPersistence.md
@@ -1,5 +1,6 @@
 ---
 title: "/etc/hosts IP Persistence"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/communityguides/etchostspersistence/"
 description: "Describes the process of mapping host or domain names on TrueNAS CORE."
 weight: 5
 tags:

--- a/content/CORE/CORETutorials/CommunityGuides/LegacyReplication.md
+++ b/content/CORE/CORETutorials/CommunityGuides/LegacyReplication.md
@@ -1,5 +1,6 @@
 ---
 title: "Legacy Engine (11.3) Replication"
+redirect: "https://www.ixsystems.com/documentation/freenas/11.3-U5/FreeNAS-11.3-U5-User-Guide_screen.pdf"
 description: "Describes legacy replication on FreeNAS or TrueNAS 11.3."
 weight: 10
 tags:

--- a/content/CORE/CORETutorials/CommunityGuides/LegacySMBACLs.md
+++ b/content/CORE/CORETutorials/CommunityGuides/LegacySMBACLs.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting SMB ACLs on Legacy FreeNAS systems"
+redirect: "https://www.ixsystems.com/documentation/freenas/11.3-U5/FreeNAS-11.3-U5-User-Guide_screen.pdf"
 description: "Describes how to configure SMB ACLs on legacy FreeNAS or TrueNAS released before 12.0."
 weight: 20
 tags:

--- a/content/CORE/CORETutorials/CommunityGuides/OpenVPN.md
+++ b/content/CORE/CORETutorials/CommunityGuides/OpenVPN.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring a 3rd Party VPN service on TrueNAS"
+redirect: "https://www.truenas.com/docs/files/CORE12.0Docs.pdf"
 description: "Describes how to configure OpenVPN client on TrueNAS 12.0."
 geekdocCollapseSection: true
 weight: 20

--- a/content/CORE/CORETutorials/CommunityGuides/_index.md
+++ b/content/CORE/CORETutorials/CommunityGuides/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Community Guides"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/communityguides/"
 description: "Additional tutorials written by the TrueNAS Community about TrueNAS CORE configuration and use cases."
 geekdocCollapseSection: true
 weight: 30

--- a/content/CORE/CORETutorials/DirectoryServices/ActiveDirectory.md
+++ b/content/CORE/CORETutorials/DirectoryServices/ActiveDirectory.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting Up Active Directory"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/directoryservices/activedirectory/"
 description: "Provides information on how to configure Active Directory (AD) on your TrueNAS."
 weight: 10
 aliases: /core/directoryservices/activedirectory/

--- a/content/CORE/CORETutorials/DirectoryServices/Kerberos.md
+++ b/content/CORE/CORETutorials/DirectoryServices/Kerberos.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting Up Kerberos"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/directoryservices/kerberos/"
 description: "Use the Kerberos screen to configure Kerberos realms and keytabs on your TrueNAS."
 weight: 40
 aliases: /core/directoryservices/kerberos/

--- a/content/CORE/CORETutorials/DirectoryServices/LDAP.md
+++ b/content/CORE/CORETutorials/DirectoryServices/LDAP.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting Up LDAP"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/directoryservices/ldap/"
 description: "Use the LDAP screen to configure Lightweight Directory Access Protocol (LDAP) server settings on your TrueNAS."
 weight: 20
 aliases: /core/directoryservices/ldap/

--- a/content/CORE/CORETutorials/DirectoryServices/NIS.md
+++ b/content/CORE/CORETutorials/DirectoryServices/NIS.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting up NIS"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/directoryservices/nis/"
 description: "Use the NIS screen to configure Network Information System (NIS) on your TrueNAS."
 weight: 30
 aliases: /core/directoryservices/nis/

--- a/content/CORE/CORETutorials/DirectoryServices/_index.md
+++ b/content/CORE/CORETutorials/DirectoryServices/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Directory Services"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/directoryservices/"
 description: "Accessing Directory Services on your TrueNAS"
 geekdocCollapseSection: true
 weight: 100

--- a/content/CORE/CORETutorials/Getting Support.md
+++ b/content/CORE/CORETutorials/Getting Support.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Support"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/getting-support/"
 description: "Describes different options for getting support for TrueNAS CORE."
 weight: 16
 aliases:

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Jails/AccessingJailsUsingSSH.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Jails/AccessingJailsUsingSSH.md
@@ -1,5 +1,6 @@
 ---
 title: "Accessing Jails Using SSH"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/jails/accessingjailsusingssh/"
 description: "Describes how to access Jails using SSH in TrueNAS CORE."
 weight: 20
 tags:

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Jails/InstallingJailSoftware.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Jails/InstallingJailSoftware.md
@@ -1,5 +1,6 @@
 ---
 title: "Installing Software"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/jails/installingsoftware/"
 description: "Describes how to install software using Jails in TrueNAS CORE."
 weight: 20
 Aliases: /core/applications/jails/software/

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Jails/ManagingJails.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Jails/ManagingJails.md
@@ -1,5 +1,6 @@
 ---
 title: "Managing Jails"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/jails/managingjails/"
 description: "Describes how to manage Jails in TrueNAS CORE."
 weight: 10
 aliases: /core/applications/jails/manage/

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Jails/SettingUpJailStorage.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Jails/SettingUpJailStorage.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting Up Jail Storage"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/jails/settingupjailstorage/"
 description: "Describes how to set up jail storage in TrueNAS CORE."
 weight: 30
 aliases: /core/applications/jails/storage/

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Jails/_index.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Jails/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Jails"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/jails/creatingjails/"
 description: "Information on creating jails, and articles related to jails, plugins and virtual machines in TrueNAS CORE."
 geekdocCollapseSection: true
 aliases:

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/CreatingCustomPlugin.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/CreatingCustomPlugin.md
@@ -1,5 +1,6 @@
 ---
 title: "Custom Plugins"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/plugins/creatingcustomplugin/"
 description: "Describes how to configure plugins on TrueNAS CORE."
 weight: 30
 Aliases: /core/applications/plugins/createplugin/

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/MinIOPlugin.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/MinIOPlugin.md
@@ -1,5 +1,6 @@
 ---
 title: "MinIO Plugin (Deprecated)"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/plugins/minioplugin/"
 description: "Describes how to configure the MinIO plugin on TrueNAS CORE and gives migration instructions from the deprecated S3 built-in service. Deprecated content."
 weight: 20
 tags:

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/PlexPlugin.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/PlexPlugin.md
@@ -1,5 +1,6 @@
 ---
 title: "Plex Plugin"
+redirect: "https://www.truenas.com/docs/core/13.3/coretutorials/jailspluginsvms/plugins/plexplugin/"
 description: "Describes how to install the Plex application as a plugin on TrueNAS CORE."
 weight: 20
 tags:

--- a/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/_index.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/Plugins/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Plugins"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/plugins/managingplugins/"
 description: "How to install plugins in TrueNAS CORE, and more articles."
 geekdocCollapseSection: true
 weight: 20 

--- a/content/CORE/CORETutorials/JailsPluginsVMs/UpdateJailsPlugins.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/UpdateJailsPlugins.md
@@ -1,5 +1,6 @@
 ---
 title: "Updating Jails and Plugins"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/updatejailsplugins/"
 description: "Describes how to update jails and plugins in TrueNAS CORE."
 weight: 25
 tags:

--- a/content/CORE/CORETutorials/JailsPluginsVMs/VirtualMachines/SettingUpNPIV.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/VirtualMachines/SettingUpNPIV.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting Up NPIV"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/virtualmachines/settingupnpiv/"
 description: "Describes how to configure NPIV on TrueNAS CORE."
 weight: 20
 tags:

--- a/content/CORE/CORETutorials/JailsPluginsVMs/VirtualMachines/_index.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/VirtualMachines/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Virtual Machines"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/virtualmachines/creatingbasicvm/"
 description: "Provides instructions on creating and managing a basic virtual machine, and lists other tutorials about virtual machines in TrueNAS CORE."
 geekdocCollapseSection: true
 weight: 30

--- a/content/CORE/CORETutorials/JailsPluginsVMs/_index.md
+++ b/content/CORE/CORETutorials/JailsPluginsVMs/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Jails, Plugins, and VMs"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/jailspluginsvms/"
 description: "Tutorials about configuring TrueNAS CORE jails, specialized jails called plugins, and virtual machines for full operating system deployments."
 geekdocCollapseSection: true
 weight: 130

--- a/content/CORE/CORETutorials/ManagingTLSCiphers.md
+++ b/content/CORE/CORETutorials/ManagingTLSCiphers.md
@@ -1,5 +1,6 @@
 ---
 title: "Managing TLS Ciphers"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/managingtlsciphers/"
 description: "Describes how to manage TLS ciphers on TrueNAS CORE." 
 weight: 30
 aliases:

--- a/content/CORE/CORETutorials/Network/IPMI.md
+++ b/content/CORE/CORETutorials/Network/IPMI.md
@@ -1,5 +1,6 @@
 ---
 title: "IPMI"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/network/ipmi/"
 description: "Provides instructions on setting up Intelligent Platform Management Interface (IPMI) on TrueNAS CORE."
 weight: 50
 aliases: /core/network/ipmi/

--- a/content/CORE/CORETutorials/Network/Interfaces/BridgeCreate.md
+++ b/content/CORE/CORETutorials/Network/Interfaces/BridgeCreate.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting Up a Network Bridge"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/network/interfaces/bridgecreate/"
 description: "Provides instructions on setting up a network bridge interface on TrueNAS CORE."
 weight: 10
 tags:

--- a/content/CORE/CORETutorials/Network/Interfaces/LAGGCreate.md
+++ b/content/CORE/CORETutorials/Network/Interfaces/LAGGCreate.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting Up Link Aggregations"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/network/interfaces/laggcreate/"
 description: "Provides instructions on setting up a network link aggregation (LAGG) interface on TrueNAS CORE."
 weight: 20
 tags:

--- a/content/CORE/CORETutorials/Network/Interfaces/SettingStaticIP.md
+++ b/content/CORE/CORETutorials/Network/Interfaces/SettingStaticIP.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting a Static IP Address for the TrueNAS UI"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/network/interfaces/settingstaticip/"
 description: "Provides instructions on configuring a network interface for static routes on TrueNAS CORE."
 weight: 40
 aliases: /core/network/interfaces/settingstaticip/

--- a/content/CORE/CORETutorials/Network/Interfaces/VLANCreate.md
+++ b/content/CORE/CORETutorials/Network/Interfaces/VLANCreate.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting Up a Network VLAN"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/network/interfaces/vlancreate/"
 description: "Provides instructions on setting up a network VLAN interface on TrueNAS CORE."
 weight: 30
 tags:

--- a/content/CORE/CORETutorials/Network/Interfaces/_index.md
+++ b/content/CORE/CORETutorials/Network/Interfaces/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Interfaces"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/network/interfaces/"
 description: "Provides instructions on how to edit a network physical interface and a list of other TrueNAS CORE network interface tutorials."
 geekdocCollapseSection: true
 weight: 30

--- a/content/CORE/CORETutorials/Network/StaticRoutes.md
+++ b/content/CORE/CORETutorials/Network/StaticRoutes.md
@@ -1,5 +1,6 @@
 ---
 title: "Define Static Routes"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/network/staticroutes/"
 description: "Provides instructions on setting up static routes on TrueNAS CORE."
 weight: 40
 tags:

--- a/content/CORE/CORETutorials/Network/Wireguard.md
+++ b/content/CORE/CORETutorials/Network/Wireguard.md
@@ -1,5 +1,6 @@
 ---
 title: "Enabling WireGuard"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/network/wireguard/"
 description: "Provides instructions on setting up WireGuard on TrueNAS CORE."
 weight: 50
 aliases: /core/network/wireguard/

--- a/content/CORE/CORETutorials/Network/_index.md
+++ b/content/CORE/CORETutorials/Network/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Network"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/network/"
 description: "Provides information on using the Network Summary screen and lists other tutorials related to configuring CORE networking."
 geekdocCollapseSection: true
 weight: 80

--- a/content/CORE/CORETutorials/Services/ConfigureDynamicDNS.md
+++ b/content/CORE/CORETutorials/Services/ConfigureDynamicDNS.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring Dynamic DNS"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/configuredynamicdns/"
 description: "Provides instructions on how to configure Dynamic Domain Name Service (DDNS) on your TrueNAS system."
 weight: 20
 aliases: /core/services/dynamicdns/

--- a/content/CORE/CORETutorials/Services/ConfigureUPS.md
+++ b/content/CORE/CORETutorials/Services/ConfigureUPS.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring UPS"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/configuringups/"
 description: "Provides information on configuring UPS service on your TrueNAS."
 weight: 150
 alias: /core/services/ups/

--- a/content/CORE/CORETutorials/Services/ConfiguringFTP.md
+++ b/content/CORE/CORETutorials/Services/ConfiguringFTP.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring FTP"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/configuringftp/"
 description: "Provides information on how to configure File Transfer Protocol (FTP) on your TrueNAS."
 weight: 30
 tags:

--- a/content/CORE/CORETutorials/Services/ConfiguringLLDP.md
+++ b/content/CORE/CORETutorials/Services/ConfiguringLLDP.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring LLDP"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/configuringlldp/"
 description: "Provides information on how to configure Link Layer Discovery Protocol (LLDP) on your TrueNAS."
 weight: 50
 aliases: /core/services/lldp/

--- a/content/CORE/CORETutorials/Services/ConfiguringOpenVPN.md
+++ b/content/CORE/CORETutorials/Services/ConfiguringOpenVPN.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring OpenVPN"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/configuringopenvpn/"
 description: "Provices information on how to configure Open Virtual Private Network (OpenVPN) services on your TrueNAS."
 weight: 70
 aliases: /core/services/openvpn/

--- a/content/CORE/CORETutorials/Services/ConfiguringRsync.md
+++ b/content/CORE/CORETutorials/Services/ConfiguringRsync.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring Rsync"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/configuringrsync/"
 description: "Provides information on how to configure remote sync (rsync) on your TrueNAS."
 weight: 43
 aliases: 

--- a/content/CORE/CORETutorials/Services/ConfiguringS3.md
+++ b/content/CORE/CORETutorials/Services/ConfiguringS3.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring S3"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/configurings3/"
 description: "Provides information on how to start a local S3 service on your TrueNAS."
 weight: 100
 aliases: /core/services/s3/

--- a/content/CORE/CORETutorials/Services/ConfiguringSFTP.md
+++ b/content/CORE/CORETutorials/Services/ConfiguringSFTP.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring SFTP"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/configuringsftp/"
 description: "Configuring SSH File Transfer Protocol (SFTP) service on your TrueNAS."
 weight: 20
 aliases:

--- a/content/CORE/CORETutorials/Services/ConfiguringSMART.md
+++ b/content/CORE/CORETutorials/Services/ConfiguringSMART.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring S.M.A.R.T."
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/configuringsmart/"
 description: "Configurinng Self-Monitoring, Analysis and Reporting Technology (S.M.A.R.T.) on your TrueNAS."
 weight: 90
 aliases: /core/services/smart/

--- a/content/CORE/CORETutorials/Services/ConfiguringSNMP.md
+++ b/content/CORE/CORETutorials/Services/ConfiguringSNMP.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring SNMP"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/configuringsnmp/"
 description: "Provides information on how to configure Simple Network Management Protocol (SNMP) on your TrueNAS."
 weight: 120
 aliases: /core/services/snmp/

--- a/content/CORE/CORETutorials/Services/ConfiguringSSH.md
+++ b/content/CORE/CORETutorials/Services/ConfiguringSSH.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring SSH"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/configuringssh/"
 description: "Provides instructions on configuring Secure Shell (SSH) on your TrueNAS."
 weight: 130
 tags:

--- a/content/CORE/CORETutorials/Services/ConfiguringTFTP.md
+++ b/content/CORE/CORETutorials/Services/ConfiguringTFTP.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring TFTP"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/configuringtftp/"
 description: "Configuring Trivial File Transfer Protocol (TFTP) on your TrueNAS."
 weight: 140
 tags:

--- a/content/CORE/CORETutorials/Services/FTPTFTP.md
+++ b/content/CORE/CORETutorials/Services/FTPTFTP.md
@@ -1,5 +1,6 @@
 ---
 title: "FTP, SFTP, and TFTP"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/ftptftp/"
 description: "Configuring FTP, SFTP and TFTP on your TrueNAS."
 weight: 160
 aliases: /core/services/ftptftp/

--- a/content/CORE/CORETutorials/Services/S3forMinIO.md
+++ b/content/CORE/CORETutorials/Services/S3forMinIO.md
@@ -1,5 +1,6 @@
 ---
 title: "S3 for MinIO"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/configurings3forminio/"
 description: "Provides information on how to configure S3 for MinIO on your TrueNAS."
 weight: 105
 tags:

--- a/content/CORE/CORETutorials/Services/_index.md
+++ b/content/CORE/CORETutorials/Services/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Services"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/services/"
 description: "Provides information on the Services screen and lists other service tutorial articles."
 geekdocCollapseSection: true
 weight: 120

--- a/content/CORE/CORETutorials/SettingUIPreferences.md
+++ b/content/CORE/CORETutorials/SettingUIPreferences.md
@@ -1,5 +1,6 @@
 ---
 title: Setting UI Preferences
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/settinguipreferences/"
 description: "Use the Interface Preferences screen to display a list of general preferences or to change preference settings for your TrueNAS."
 weight: 1000
 tags:

--- a/content/CORE/CORETutorials/SettingUpUsersAndGroups.md
+++ b/content/CORE/CORETutorials/SettingUpUsersAndGroups.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting Up Users and Groups"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/settingupusersandgroups/"
 description: "Describes how to set up users and groups in TrueNAS CORE."
 weight: 19
 aliases:

--- a/content/CORE/CORETutorials/Sharing/AFPShare.md
+++ b/content/CORE/CORETutorials/Sharing/AFPShare.md
@@ -1,5 +1,6 @@
 ---
 title: "AFP Share Creation"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/sharing/afpshare/"
 description: "Provides information on how to create Apple Filing Protocol (AFP) shares on your TrueNAS."
 weight: 10
 aliases:

--- a/content/CORE/CORETutorials/Sharing/NFSShare.md
+++ b/content/CORE/CORETutorials/Sharing/NFSShare.md
@@ -1,5 +1,6 @@
 ---
 title: "NFS Share Creation"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/sharing/nfsshare/"
 description: "Provides information on how to create a Network File Share (NFS) on your TrueNAS."
 weight: 30
 aliases:

--- a/content/CORE/CORETutorials/Sharing/SMB/HomeShare.md
+++ b/content/CORE/CORETutorials/Sharing/SMB/HomeShare.md
@@ -1,5 +1,6 @@
 ---
 title: "Home Shares"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/sharing/smb/homeshare/"
 description: "Describes how to configure a Home Share on TrueNAS CORE."
 weight: 20
 aliases: /core/sharing/smb/homeshare/

--- a/content/CORE/CORETutorials/Sharing/SMB/ManagingSMBShares.md
+++ b/content/CORE/CORETutorials/Sharing/SMB/ManagingSMBShares.md
@@ -1,5 +1,6 @@
 ---
 title: "Managing SMB Shares"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/sharing/smb/managingsmbshares/"
 description: "Provides information on how to manage Server Message Block (SMB) shares on your TrueNAS."
 weight: 10
 tags:

--- a/content/CORE/CORETutorials/Sharing/SMB/ShadowCopies.md
+++ b/content/CORE/CORETutorials/Sharing/SMB/ShadowCopies.md
@@ -1,5 +1,6 @@
 ---
 title: "Shadow Copies"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/sharing/smb/shadowcopies/"
 description: "Describes how to configure shadow copies on TrueNAS CORE."
 weight: 30
 aliases: /core/sharing/smb/shadowcopies/

--- a/content/CORE/CORETutorials/Sharing/SMB/_index.md
+++ b/content/CORE/CORETutorials/Sharing/SMB/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Windows Shares (SMB)"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/sharing/smb/smbshare/"
 description: "Tutorials for SMB sharing scenarios."
 geekdocCollapseSection: true
 weight: 50

--- a/content/CORE/CORETutorials/Sharing/WebDAVShare.md
+++ b/content/CORE/CORETutorials/Sharing/WebDAVShare.md
@@ -1,5 +1,6 @@
 ---
 title: "WebDav Share Creation"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/sharing/webdavshare/"
 description: "Contains information on how to create a Web-based Distributed Authoring and Versioning (WebDAV) share on your TrueNAS."
 weight: 40
 aliases:

--- a/content/CORE/CORETutorials/Sharing/_index.md
+++ b/content/CORE/CORETutorials/Sharing/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Sharing"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/sharing/"
 description: "Tutorials for configuring different storage sharing protocols in TrueNAS."
 geekdocCollapseSection: true
 weight: 110

--- a/content/CORE/CORETutorials/Sharing/iSCSI/AddingiSCSIShare.md
+++ b/content/CORE/CORETutorials/Sharing/iSCSI/AddingiSCSIShare.md
@@ -1,5 +1,6 @@
 ---
 title: "Adding an iSCSI Share"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/sharing/iscsi/addingiscsishare/"
 description: "Describes how to add an iSCSI share on TrueNAS CORE."
 weight: 10
 aliases: /core/sharing/iscsi/iscsishare/

--- a/content/CORE/CORETutorials/Sharing/iSCSI/IncreasingiSCSIAvailableStorage.md
+++ b/content/CORE/CORETutorials/Sharing/iSCSI/IncreasingiSCSIAvailableStorage.md
@@ -1,5 +1,6 @@
 ---
 title: "Increasing iSCSI Share Available Storage"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/sharing/iscsi/increasingiscsiavailablestorage/"
 description: "Describes how to increase iSCSI share available storage on TrueNAS CORE."
 weight: 10
 tags:

--- a/content/CORE/CORETutorials/Sharing/iSCSI/SettingUpFibreChannel.md
+++ b/content/CORE/CORETutorials/Sharing/iSCSI/SettingUpFibreChannel.md
@@ -1,5 +1,6 @@
 ---
 title: "Fibre Channel"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/sharing/iscsi/settingupfibrechannel/"
 description: "Describes how to set up Fibre Channel on TrueNAS CORE."
 weight: 20
 aliases: /core/sharing/iscsi/fibrechannel/

--- a/content/CORE/CORETutorials/Sharing/iSCSI/UsingiSCSIShare.md
+++ b/content/CORE/CORETutorials/Sharing/iSCSI/UsingiSCSIShare.md
@@ -1,5 +1,6 @@
 ---
 title: "Using the iSCSI Share"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/sharing/iscsi/usingiscsishare/"
 description: "Describes how to use the iSCSI share in TrueNAS CORE."
 weight: 10
 tags:

--- a/content/CORE/CORETutorials/Sharing/iSCSI/_index.md
+++ b/content/CORE/CORETutorials/Sharing/iSCSI/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Block Shares (iSCSI)"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/sharing/iscsi/"
 description: "Describes how to configure iSCSI shares on TrueNAS CORE."
 geekdocCollapseSection: true
 weight: 20

--- a/content/CORE/CORETutorials/Storage/Disks/DiskReplace.md
+++ b/content/CORE/CORETutorials/Storage/Disks/DiskReplace.md
@@ -1,5 +1,6 @@
 ---
 title: "Disk Replacement"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/disks/diskreplace/"
 description: "Describes how to replace a disk and restore the hot spare in TrueNAS CORE."
 weight: 20
 aliases: /core/storage/disks/diskreplace/

--- a/content/CORE/CORETutorials/Storage/Disks/DiskWipe.md
+++ b/content/CORE/CORETutorials/Storage/Disks/DiskWipe.md
@@ -1,5 +1,6 @@
 ---
 title: "Wiping a Disk"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/disks/diskwipe/"
 description: "Describes how to wipe a disk in TrueNAS CORE."
 weight: 10
 aliases: /core/storage/disks/diskwipe/

--- a/content/CORE/CORETutorials/Storage/Disks/_index.md
+++ b/content/CORE/CORETutorials/Storage/Disks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Disks"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/disks/"
 description: "Tutorials about managing disks in TrueNAS CORE."
 geekdocCollapseSection: true
 weight: 40

--- a/content/CORE/CORETutorials/Storage/ImportDisk.md
+++ b/content/CORE/CORETutorials/Storage/ImportDisk.md
@@ -1,5 +1,6 @@
 ---
 title: "Import Disk"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/importdisk/"
 description: "Describes how to import a disk on TrueNAS CORE."
 weight: 50
 aliases: /core/storage/importdisk/

--- a/content/CORE/CORETutorials/Storage/Pools/Datasets.md
+++ b/content/CORE/CORETutorials/Storage/Pools/Datasets.md
@@ -1,5 +1,6 @@
 ---
 title: "Creating Datasets"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/pools/datasets/"
 description: "Describes how to create and configure a dataset on TrueNAS CORE."
 weight: 17
 aliases: /core/storage/pools/datasets/

--- a/content/CORE/CORETutorials/Storage/Pools/FusionPool.md
+++ b/content/CORE/CORETutorials/Storage/Pools/FusionPool.md
@@ -1,5 +1,6 @@
 ---
 title: "Fusion Pools"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/fusionpool/"
 description: "Describes how to create a Fusion Pool on TrueNAS CORE."
 weight: 30
 aliases: /core/storage/pools/fusionpool/

--- a/content/CORE/CORETutorials/Storage/Pools/ManagingPools.md
+++ b/content/CORE/CORETutorials/Storage/Pools/ManagingPools.md
@@ -1,5 +1,6 @@
 ---
 title: "Managing Pools"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/pools/managingpools/"
 description: "Describes how to manage storage pools on TrueNAS CORE."
 weight: 16
 Aliases: /core/storage/pools/managingpools/

--- a/content/CORE/CORETutorials/Storage/Pools/Permissions.md
+++ b/content/CORE/CORETutorials/Storage/Pools/Permissions.md
@@ -1,5 +1,6 @@
 ---
 title: "Permissions"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/pools/permissions/"
 description: "This articled describes permissions configuration on TrueNAS CORE."
 weight: 22
 aliases: /core/storage/pools/permissions/

--- a/content/CORE/CORETutorials/Storage/Pools/PoolImport.md
+++ b/content/CORE/CORETutorials/Storage/Pools/PoolImport.md
@@ -1,5 +1,6 @@
 ---
 title: "Importing Pools"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/pools/poolimport/"
 description: "Describes how to import storage pools on TrueNAS CORE."
 weight: 15
 Aliases: /core/storage/pools/poolimport/

--- a/content/CORE/CORETutorials/Storage/Pools/SLOGOverprovision.md
+++ b/content/CORE/CORETutorials/Storage/Pools/SLOGOverprovision.md
@@ -1,5 +1,6 @@
 ---
 title: "SLOG Overprovisioning"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/slogoverprovision/"
 description: "Describes how to configure SLOG over-provisioning on TrueNAS CORE."
 weight: 50
 aliases: /core/storage/pools/slogoverprovision/

--- a/content/CORE/CORETutorials/Storage/Pools/StorageEncryption.md
+++ b/content/CORE/CORETutorials/Storage/Pools/StorageEncryption.md
@@ -1,5 +1,6 @@
 ---
 title: "Storage Encryption"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/storageencryption/"
 description: "Describes how to encrypt a storage pool in TrueNAS CORE."
 weight: 25
 aliases: /core/storage/pools/storageencryption/

--- a/content/CORE/CORETutorials/Storage/Pools/Zvols.md
+++ b/content/CORE/CORETutorials/Storage/Pools/Zvols.md
@@ -1,5 +1,6 @@
 ---
 title: "Adding Zvols"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/pools/zvols/"
 description: "Describes how to create a Zvol on TrueNAS CORE."
 weight: 19
 aliases: /core/storage/pools/zvols/

--- a/content/CORE/CORETutorials/Storage/Pools/_index.md
+++ b/content/CORE/CORETutorials/Storage/Pools/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Pools"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/pools/"
 description: "Provides instructions on creating and pool, and lists other pool and storage articles in TrueNAS CORE."
 geekdocCollapseSection: true
 weight: 10

--- a/content/CORE/CORETutorials/Storage/SED.md
+++ b/content/CORE/CORETutorials/Storage/SED.md
@@ -1,5 +1,6 @@
 ---
 title: "Self-Encrypting Drives"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/sed/"
 description: "Describes Self-Encrypting Drive (SED) support on TrueNAS CORE."
 weight: 40
 aliases: /core/storage/sed/

--- a/content/CORE/CORETutorials/Storage/Snapshots.md
+++ b/content/CORE/CORETutorials/Storage/Snapshots.md
@@ -1,5 +1,6 @@
 ---
 title: "Creating Snapshots"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/snapshots/"
 description: "Describes how to create snapshots on TrueNAS CORE."
 weight: 20
 aliases:

--- a/content/CORE/CORETutorials/Storage/VMware-Snapshots.md
+++ b/content/CORE/CORETutorials/Storage/VMware-Snapshots.md
@@ -1,5 +1,6 @@
 ---
 title: "Creating VMware-Snapshots"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/vmware-snapshots/"
 description: "Describes how to create a VMWare snapshot on TrueNAS CORE."
 weight: 30
 aliases:

--- a/content/CORE/CORETutorials/Storage/_index.md
+++ b/content/CORE/CORETutorials/Storage/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Storage"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/storage/"
 description: "Tutorials about different TrueNAS storage management topics."
 geekdocCollapseSection: true
 weight: 90

--- a/content/CORE/CORETutorials/SystemConfiguration/ConfiguringACMEDNS.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/ConfiguringACMEDNS.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring ACME DNS"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/configuringacmedns/"
 description: "Describes how to configure ACME on the open-source supported TrueNAS CORE."
 weight: 160
 aliases:

--- a/content/CORE/CORETutorials/SystemConfiguration/ConfiguringFailover.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/ConfiguringFailover.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring Failover (HA)"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/configuringfailover/"
 description: "Describes how to configure failover on TrueNAS CORE Enterprise."
 weight: 150
 aliases:

--- a/content/CORE/CORETutorials/SystemConfiguration/ConfiguringKMIP.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/ConfiguringKMIP.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring KMIP"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/configuringkmip/"
 description: "Describes how to configure KMIP on TrueNAS CORE Enterprise." 
 weight: 170
 tags:

--- a/content/CORE/CORETutorials/SystemConfiguration/ConfiguringSSHConnections.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/ConfiguringSSHConnections.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring SSH Connections"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/configuringsshconnections/"
 description: "Provides information on how to configure Secure Socket Shell (SSH) connections on your TrueNAS."
 weight: 110
 aliases:

--- a/content/CORE/CORETutorials/SystemConfiguration/ConfiguringTunables.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/ConfiguringTunables.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring Tunables"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/configuringtunables/"
 description: "Describes how to add or edit tunables on TrueNAS CORE."
 weight: 120
 tags:

--- a/content/CORE/CORETutorials/SystemConfiguration/ConfiguringtheSystemEmail.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/ConfiguringtheSystemEmail.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuring the System Email"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/configuringthesystememail/"
 description: "Provides information on how to set up system email on TrueNAS CORE."
 weight: 60
 aliases:

--- a/content/CORE/CORETutorials/SystemConfiguration/CreatingAlerts.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/CreatingAlerts.md
@@ -1,5 +1,6 @@
 ---
 title: "Creating Alerts"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/creatingalerts/"
 description: "Describes how to create an alert on TrueNAS CORE."
 weight: 90
 aliases:

--- a/content/CORE/CORETutorials/SystemConfiguration/CreatingCAsandCertificates/CreatingCertificateAuthorities.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/CreatingCAsandCertificates/CreatingCertificateAuthorities.md
@@ -1,5 +1,6 @@
 ---
 title: "Creating Certificate Authorities (CAs)"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/creatingcasandcertificates/creatingcertificateauthorities/"
 description: "Describes how to create or import certificates using TrueNAS CORE."
 weight: 10
 aliases:

--- a/content/CORE/CORETutorials/SystemConfiguration/CreatingCAsandCertificates/CreatingCertificates.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/CreatingCAsandCertificates/CreatingCertificates.md
@@ -1,5 +1,6 @@
 ---
 title: "Adding Certificates or CSRs"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/creatingcasandcertificates/creatingcertificates/"
 description: "Provides instructions on adding or importing certificates and certificate signing requests (CSRs) in TrueNAS CORE."
 weight: 20
 aliases:

--- a/content/CORE/CORETutorials/SystemConfiguration/CreatingCAsandCertificates/_index.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/CreatingCAsandCertificates/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Adding Certs, CAs, and CSRs"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/creatingcasandcertificates/"
 description: "Tutorial articles about adding or importing certificates, certificate signing requests (CSRs), and certificate authorities (CAs) in TrueNAS."
 weight: 140
 geekdocCollapseSection: true

--- a/content/CORE/CORETutorials/SystemConfiguration/ManagingBootEnvironments.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/ManagingBootEnvironments.md
@@ -1,5 +1,6 @@
 ---
 title: "Managing Boot Environments"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/managingbootenvironments/"
 description: "Provides information about managing boot environments on TrueNAS CORE."
 weight: 30
 aliases:

--- a/content/CORE/CORETutorials/SystemConfiguration/MirroringtheBootPool.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/MirroringtheBootPool.md
@@ -1,5 +1,6 @@
 ---
 title: "Mirroring the Boot Pool"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/mirroringthebootpool/"
 description: "Provides information on how to mirror the boot pool on TrueNAS CORE."
 weight: 35
 tags:

--- a/content/CORE/CORETutorials/SystemConfiguration/SettingUpSyslogServer.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/SettingUpSyslogServer.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting Up a Remote Syslog Server"
+redirect: "https://www.truenas.com/docs/core/13.3/coretutorials/systemconfiguration/settingupsyslogserver/"
 description: "Describes setting up a remote syslog server in TrueNAS CORE."
 weight: 75
 tags:

--- a/content/CORE/CORETutorials/SystemConfiguration/SettingtheSystemDataset.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/SettingtheSystemDataset.md
@@ -1,5 +1,6 @@
 ---
 title: "Setting the System Dataset"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/settingthesystemdataset/"
 description: "Describes how to configure the system dataset on TrueNAS CORE."
 weight: 70
 aliases:

--- a/content/CORE/CORETutorials/SystemConfiguration/UsingConfigurationBackups.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/UsingConfigurationBackups.md
@@ -1,5 +1,6 @@
 ---
 title: "Using Configuration Backups"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/usingconfigurationbackups/"
 description: "Provides information concerning configuration backups on TrueNAS CORE."
 weight: 10
 aliases:

--- a/content/CORE/CORETutorials/SystemConfiguration/UsingTwoFactorAuthentication.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/UsingTwoFactorAuthentication.md
@@ -1,5 +1,6 @@
 ---
 title: "Using Two-Factor Authentication"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/usingtwofactorauthentication/"
 description: "Describes how to use two-factor authentication on TrueNAS CORE."
 weight: 180
 aliases:

--- a/content/CORE/CORETutorials/SystemConfiguration/ViewingEnclosures.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/ViewingEnclosures.md
@@ -1,5 +1,6 @@
 ---
 title: "Managing Enclosures"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/viewingenclosures/"
 description: "Provides information about hardware and expansion shelves on TrueNAS CORE."
 weight: 50
 aliases:

--- a/content/CORE/CORETutorials/SystemConfiguration/_index.md
+++ b/content/CORE/CORETutorials/SystemConfiguration/_index.md
@@ -1,5 +1,6 @@
 ---
 title: System Configuration
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/systemconfiguration/"
 description: "Tutorials about a wide variety of TrueNAS system management topics."
 geekdocCollapseSection: true
 weight: 20

--- a/content/CORE/CORETutorials/Tasks/CreatingCloudSyncTasks.md
+++ b/content/CORE/CORETutorials/Tasks/CreatingCloudSyncTasks.md
@@ -1,5 +1,6 @@
 ---
 title: "Creating Cloud Sync Tasks"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/creatingcloudsynctasks/"
 description: "Describes how to configure cloud storage backup tasks in TrueNAS CORE."
 weight: 90
 aliases:

--- a/content/CORE/CORETutorials/Tasks/CreatingCronJobs.md
+++ b/content/CORE/CORETutorials/Tasks/CreatingCronJobs.md
@@ -1,5 +1,6 @@
 ---
 title: "Creating Cron Jobs"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/creatingcronjobs/"
 description: "Describes how to create a cron job on TrueNAS CORE." 
 weight: 10
 aliases:

--- a/content/CORE/CORETutorials/Tasks/CreatingInitShutdownScripts.md
+++ b/content/CORE/CORETutorials/Tasks/CreatingInitShutdownScripts.md
@@ -1,5 +1,6 @@
 ---
 title: "Creating Init/Shutdown Scripts"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/creatinginitshutdownscripts/"
 description: "Explains how to create scheduled scripts on TrueNAS CORE."
 weight: 20
 aliases:

--- a/content/CORE/CORETutorials/Tasks/CreatingPeriodicSnapshotTasks.md
+++ b/content/CORE/CORETutorials/Tasks/CreatingPeriodicSnapshotTasks.md
@@ -1,5 +1,6 @@
 ---
 title: "Periodic Snapshot Tasks"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/creatingperiodicsnapshottasks/"
 description: "Describes how to create periodic snapshot tasks on TrueNAS CORE."
 weight: 50
 tags:

--- a/content/CORE/CORETutorials/Tasks/CreatingReplicationTasks/AdvancedReplication.md
+++ b/content/CORE/CORETutorials/Tasks/CreatingReplicationTasks/AdvancedReplication.md
@@ -1,5 +1,6 @@
 ---
 title: "Advanced Replication"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/creatingreplicationtasks/advancedreplication/"
 description: "Describes how to configure advanced replication tasks on TrueNAS CORE."
 weight: 30
 aliases:

--- a/content/CORE/CORETutorials/Tasks/CreatingReplicationTasks/LocalReplication.md
+++ b/content/CORE/CORETutorials/Tasks/CreatingReplicationTasks/LocalReplication.md
@@ -1,5 +1,6 @@
 ---
 title: "Local Replication"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/creatingreplicationtasks/localreplication/"
 description: "Describes how to create local replication tasks on TrueNAS CORE."
 weight: 10
 aliases:

--- a/content/CORE/CORETutorials/Tasks/CreatingReplicationTasks/RemoteReplication.md
+++ b/content/CORE/CORETutorials/Tasks/CreatingReplicationTasks/RemoteReplication.md
@@ -1,5 +1,6 @@
 ---
 title: "Remote Replication"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/creatingreplicationtasks/remotereplication/"
 description: "Describes how to create a remote replication task on TrueNAS CORE."
 weight: 20
 aliases:

--- a/content/CORE/CORETutorials/Tasks/CreatingReplicationTasks/TroubleshootingTips.md
+++ b/content/CORE/CORETutorials/Tasks/CreatingReplicationTasks/TroubleshootingTips.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshooting Tips"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/creatingreplicationtasks/troubleshootingtips/"
 description: "Provides troubleshooting tips for replication tasks on TrueNAS CORE."
 weight: 40
 aliases:

--- a/content/CORE/CORETutorials/Tasks/CreatingReplicationTasks/_index.md
+++ b/content/CORE/CORETutorials/Tasks/CreatingReplicationTasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Creating Replication Tasks"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/creatingreplicationtasks/"
 description: "TrueNAS CORE replication tutorials."
 geekdocCollapseSection: true
 weight: 60

--- a/content/CORE/CORETutorials/Tasks/CreatingRsyncTasks.md
+++ b/content/CORE/CORETutorials/Tasks/CreatingRsyncTasks.md
@@ -1,5 +1,6 @@
 ---
 title: "Creating Rsync Tasks"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/creatingrsynctasks/"
 description: "Provides information on how to create a remote sync (rsync) task on your TrueNAS."
 weight: 30
 aliases:

--- a/content/CORE/CORETutorials/Tasks/CreatingScrubTasks.md
+++ b/content/CORE/CORETutorials/Tasks/CreatingScrubTasks.md
@@ -1,5 +1,6 @@
 ---
 title: "Creating Scrub Tasks"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/creatingscrubtasks/"
 description: "Describes how to create scrub tasks on TrueNAS CORE."
 weight: 80
 aliases:

--- a/content/CORE/CORETutorials/Tasks/GoogleDriveSync.md
+++ b/content/CORE/CORETutorials/Tasks/GoogleDriveSync.md
@@ -1,5 +1,6 @@
 ---
 title: "Backing Up Google Drive to TrueNAS"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/googledrivesync/"
 description: "Describes how to back up Google Drive to TrueNAS CORE."
 weight: 100
 tags:

--- a/content/CORE/CORETutorials/Tasks/RunningSMARTTests.md
+++ b/content/CORE/CORETutorials/Tasks/RunningSMARTTests.md
@@ -1,5 +1,6 @@
 ---
 title: "Running S.M.A.R.T. Tests"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/runningsmarttests/"
 description: "Provides information on how to run Self-Monitoring, Analysis and Reporting Technology (S.M.A.R.T.) tests on your TrueNAS."
 weight: 40
 aliases:

--- a/content/CORE/CORETutorials/Tasks/UsingAdvancedScheduler.md
+++ b/content/CORE/CORETutorials/Tasks/UsingAdvancedScheduler.md
@@ -1,5 +1,6 @@
 ---
 title: "Using the Advanced Scheduler"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/usingadvancedscheduler/"
 description: "Describes how to use the Advanced Scheduler on TrueNAS CORE."
 weight: 95
 tags:

--- a/content/CORE/CORETutorials/Tasks/UsingResilverPriority.md
+++ b/content/CORE/CORETutorials/Tasks/UsingResilverPriority.md
@@ -1,5 +1,6 @@
 ---
 title: "Using Resilver Priority"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/usingresilverpriority/"
 description: "Describes how to configure resilver priority tasks on TrueNAS CORE."
 weight: 70
 tags:

--- a/content/CORE/CORETutorials/Tasks/_index.md
+++ b/content/CORE/CORETutorials/Tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/tasks/"
 description: "Tutorial articles about a wide variety of TrueNAS system tasks."
 geekdocCollapseSection: true
 weight: 70

--- a/content/CORE/CORETutorials/UpdatingTrueNAS/UpdatingENTERPRISE.md
+++ b/content/CORE/CORETutorials/UpdatingTrueNAS/UpdatingENTERPRISE.md
@@ -1,5 +1,6 @@
 ---
 title: "Updating CORE Enterprise"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/updatingtruenas/updatingenterprise/"
 description: "Describes how to update Enterprise-licensed TrueNAS CORE deployments."
 geekdocCollapseSection: true
 weight: 20

--- a/content/CORE/CORETutorials/UpdatingTrueNAS/_index.md
+++ b/content/CORE/CORETutorials/UpdatingTrueNAS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Updating CORE"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/updatingtruenas/updatingcore/"
 description: "Tutorials for updating or upgrading a TrueNAS CORE system."
 geekdocCollapseSection: true
 weight: 900

--- a/content/CORE/CORETutorials/UsingTaskManager.md
+++ b/content/CORE/CORETutorials/UsingTaskManager.md
@@ -1,5 +1,6 @@
 ---
 title: "Task Manager"
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/usingtaskmanager/"
 description: "Use the Task Manager screen to display a list of tasks performed by your TrueNAS and to view logs related to system tasks."
 weight: 14
 aliases: [/administration/taskmanager/]

--- a/content/CORE/CORETutorials/_index.md
+++ b/content/CORE/CORETutorials/_index.md
@@ -1,5 +1,6 @@
 ---
 title: CORE Tutorials
+redirect: "https://www.truenas.com/docs/core/13.0/coretutorials/"
 description: "Standalone tutorials. Tutorials are organized parallel to the CORE interface layout."
 geekdocCollapseSection: true
 weight: 40

--- a/content/CORE/CoreSecurityReports/SMB1Advisory.md
+++ b/content/CORE/CoreSecurityReports/SMB1Advisory.md
@@ -1,5 +1,6 @@
 ---
 title: "SMB1 Security Advisory"
+redirect: "https://www.truenas.com/docs/core/13.0/coresecurityreports/smb1advisory/"
 description: "Contains advisory information on the deprecated SMB1 file-sharing protocol."
 weight: 10
 ---

--- a/content/CORE/CoreSecurityReports/_index.md
+++ b/content/CORE/CoreSecurityReports/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "CORE Security Reports"
+redirect: "https://www.truenas.com/docs/core/13.0/coresecurityreports/"
 description: "CORE-specific security notices and links to the TrueNAS Security Hub."
 geekdocCollapseSection: true
 weight: 175

--- a/content/CORE/GettingStarted/Applications.md
+++ b/content/CORE/GettingStarted/Applications.md
@@ -1,5 +1,6 @@
 ---
 title: "Applications"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/applications/"
 description: "Describes how to install applications on TrueNAS CORE."
 weight: 90
 tags:

--- a/content/CORE/GettingStarted/COREGettingStartedPrint.md
+++ b/content/CORE/GettingStarted/COREGettingStartedPrint.md
@@ -1,5 +1,6 @@
 ---
 title: "⎙ Download or Print"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/printview/"
 description: "View the CORE Getting Started Guide as a single page suitable for download or print."
 weight: 1
 no_print: "true"

--- a/content/CORE/GettingStarted/COREHardwareGuide.md
+++ b/content/CORE/GettingStarted/COREHardwareGuide.md
@@ -1,5 +1,6 @@
 ---
 title: "CORE Hardware Guide"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/corehardwareguide/"
 description: "Describes the hardware specifications and system component recommendations for custom TrueNAS CORE deployment."
 weight: 20
 aliases:

--- a/content/CORE/GettingStarted/COREReleaseNotes.md
+++ b/content/CORE/GettingStarted/COREReleaseNotes.md
@@ -1,5 +1,6 @@
 ---
 title: Nightly Version Notes
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/corereleasenotes/"
 description: "Highlights and development notes for the latest TrueNAS CORE nightly builds."
 weight: 3
 aliases:

--- a/content/CORE/GettingStarted/ConsoleSetupMenu.md
+++ b/content/CORE/GettingStarted/ConsoleSetupMenu.md
@@ -1,5 +1,6 @@
 ---
 title: "Console Setup Menu"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/consolesetupmenu/"
 description: "Describes the Console Setup menu of TrueNAS CORE."
 weight: 40
 tags:

--- a/content/CORE/GettingStarted/DataBackups.md
+++ b/content/CORE/GettingStarted/DataBackups.md
@@ -1,5 +1,6 @@
 ---
 title: "Data Backups"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/databackups/"
 description: "Describes how to configure data backups on TrueNAS CORE."
 geekdocCollapseSection: true
 weight: 80

--- a/content/CORE/GettingStarted/Deprecations.md
+++ b/content/CORE/GettingStarted/Deprecations.md
@@ -1,5 +1,6 @@
 ---
 title: "Feature Deprecations"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/deprecations/"
 description: "Notes about CORE features that are deprecated and either receive no further updates or are scheduled for removal from TrueNAS."
 weight: 4
 related: false

--- a/content/CORE/GettingStarted/Install.md
+++ b/content/CORE/GettingStarted/Install.md
@@ -1,5 +1,6 @@
 ---
 title: "Install"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/install/"
 description: "Provides installation instructions for TrueNAS CORE."
 weight: 30
 tags:

--- a/content/CORE/GettingStarted/LoggingIn.md
+++ b/content/CORE/GettingStarted/LoggingIn.md
@@ -1,5 +1,6 @@
 ---
 title: "Logging In"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/loggingin/"
 description: "Describes how the logging in process works on TrueNAS CORE."
 weight: 50
 tags:

--- a/content/CORE/GettingStarted/SharingStorage.md
+++ b/content/CORE/GettingStarted/SharingStorage.md
@@ -1,5 +1,6 @@
 ---
 title: "Sharing Storage"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/sharingstorage/"
 description: "Describes sharing configurations on TrueNAS CORE."
 geekdocCollapseSection: true
 weight: 70

--- a/content/CORE/GettingStarted/StoringData.md
+++ b/content/CORE/GettingStarted/StoringData.md
@@ -1,5 +1,6 @@
 ---
 title: "Storage Configuration"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/storingdata/"
 description: "Describes how to configure storage on TrueNAS CORE."
 weight: 60
 tags:

--- a/content/CORE/GettingStarted/UserAgreements/COREEULA.md
+++ b/content/CORE/GettingStarted/UserAgreements/COREEULA.md
@@ -1,5 +1,6 @@
 ---
 title: "TrueNAS CORE EULA"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/useragreements/coreeula/"
 description: "End User License Agreement for TrueNAS CORE."
 weight: 1
 aliases:

--- a/content/CORE/GettingStarted/UserAgreements/DataCollectionStatement.md
+++ b/content/CORE/GettingStarted/UserAgreements/DataCollectionStatement.md
@@ -1,5 +1,6 @@
 ---
 title: "TrueNAS Data Collection Statement"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/useragreements/datacollectionstatement/"
 description: "TrueNAS CORE Data Collection Statement."
 weight: 5
 ---

--- a/content/CORE/GettingStarted/UserAgreements/EnterpriseEULA.md
+++ b/content/CORE/GettingStarted/UserAgreements/EnterpriseEULA.md
@@ -1,5 +1,6 @@
 ---
 title: "TrueNAS Enterprise EULA"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/useragreements/enterpriseeula/"
 description: "TrueNAS Enterprise End User License Agreement."
 weight: 2
 aliases:

--- a/content/CORE/GettingStarted/UserAgreements/SofDevLifecycle.md
+++ b/content/CORE/GettingStarted/UserAgreements/SofDevLifecycle.md
@@ -1,5 +1,6 @@
 ---
 title: "Software Development Life Cycle"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/useragreements/sofdevlifecycle/"
 description: "Description of the general process of development, release, and patching of TrueNAS CORE versions."
 weight: 4
 aliases:

--- a/content/CORE/GettingStarted/UserAgreements/_index.md
+++ b/content/CORE/GettingStarted/UserAgreements/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "User Agreements"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/useragreements/"
 description: "Different User agreement statements related to using TrueNAS."
 geekdocCollapseSection: true
 weight: 10

--- a/content/CORE/GettingStarted/_index.md
+++ b/content/CORE/GettingStarted/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+redirect: "https://www.truenas.com/docs/core/13.0/gettingstarted/"
 description: "This configuration guide provides step-by-step tutorials for installing and setting up TrueNAS CORE."
 geekdocCollapseSection: true
 weight: 10

--- a/content/CORE/UIReference/Accounts/Groups.md
+++ b/content/CORE/UIReference/Accounts/Groups.md
@@ -1,5 +1,6 @@
 ---
 title: "Groups"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/accounts/groups/"
 description: "Describes the fields on the Groups screen in TrueNAS CORE." 
 weight: 10
 tags:

--- a/content/CORE/UIReference/Accounts/Users.md
+++ b/content/CORE/UIReference/Accounts/Users.md
@@ -1,5 +1,6 @@
 ---
 title: "Users"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/accounts/users/"
 description: "Describes the fields on the Users screens in TrueNAS CORE."
 weight: 20
 tags:

--- a/content/CORE/UIReference/Accounts/_index.md
+++ b/content/CORE/UIReference/Accounts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Accounts"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/accounts/"
 description: "CORE UI User and Group screens documentation."
 geekdocCollapseSection: true
 weight: 50

--- a/content/CORE/UIReference/Dashboard/_index.md
+++ b/content/CORE/UIReference/Dashboard/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Dashboard
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/dashboard/"
 description: "CORE Dashboard reference."
 weight: 5
 geekdocCollapseSection: true

--- a/content/CORE/UIReference/DirectoryServices/ADScreen.md
+++ b/content/CORE/UIReference/DirectoryServices/ADScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "Active Directory Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/directoryservices/adscreen/"
 description: "Use the AD screen to configure Active Directory (AD) on TrueNAS CORE."
 weight: 10
 tags:

--- a/content/CORE/UIReference/DirectoryServices/IdmapScreen.md
+++ b/content/CORE/UIReference/DirectoryServices/IdmapScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "Idmap Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/directoryservices/idmapscreen/"
 description: "Use the Idmap screen to configure Identity Mapping (Idmap) on TrueNAS CORE."
 weight: 10
 tags:

--- a/content/CORE/UIReference/DirectoryServices/KerberosScreens.md
+++ b/content/CORE/UIReference/DirectoryServices/KerberosScreens.md
@@ -1,5 +1,6 @@
 ---
 title: "Kerberos Screens"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/directoryservices/kerberosscreens/"
 description: "Use the Kerberos screen to configure to configure Kerberos realms and keytabs on TrueNAS CORE."
 weight: 40
 tags:

--- a/content/CORE/UIReference/DirectoryServices/LDAPScreen.md
+++ b/content/CORE/UIReference/DirectoryServices/LDAPScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "LDAP Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/directoryservices/ldapscreen/"
 description: "Use the LDAP screen to configure Lightweight Directory Access Protocol (LDAP) server settings on TrueNAS CORE."
 weight: 20
 tags:

--- a/content/CORE/UIReference/DirectoryServices/NISScreen.md
+++ b/content/CORE/UIReference/DirectoryServices/NISScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "NIS Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/directoryservices/nisscreen/"
 description: "Use the NIS screen to configure Network Information System (NIS) on TrueNAS CORE."
 weight: 30
 tags:

--- a/content/CORE/UIReference/DirectoryServices/_index.md
+++ b/content/CORE/UIReference/DirectoryServices/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Directory Services"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/directoryservices/"
 description: "Reference documentation of the Directory Services screens."
 geekdocCollapseSection: true
 weight: 100

--- a/content/CORE/UIReference/JailsPluginsVMs/JailsScreens.md
+++ b/content/CORE/UIReference/JailsPluginsVMs/JailsScreens.md
@@ -1,5 +1,6 @@
 ---
 title: "Jails Screens"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/jailspluginsvms/jails/jailsscreens/"
 description: "Describes the fields in the Jails screen in TrueNAS CORE."
 weight: 10
 tags:

--- a/content/CORE/UIReference/JailsPluginsVMs/PluginsScreens.md
+++ b/content/CORE/UIReference/JailsPluginsVMs/PluginsScreens.md
@@ -1,5 +1,6 @@
 ---
 title: "Plugins Screens"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/jailspluginsvms/plugins/pluginsscreens/"
 description: "Describes how to install and maintain 3rd party applications on TrueNAS CORE."
 weight: 20
 tags:

--- a/content/CORE/UIReference/JailsPluginsVMs/VirtualMachines.md
+++ b/content/CORE/UIReference/JailsPluginsVMs/VirtualMachines.md
@@ -1,5 +1,6 @@
 ---
 title: "Virtual Machines"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/jailspluginsvms/virtualmachines/virtualmachines/"
 description: "Describes the fields in the Virtual Machines screen in TrueNAS CORE."
 weight: 10
 tags:

--- a/content/CORE/UIReference/JailsPluginsVMs/_index.md
+++ b/content/CORE/UIReference/JailsPluginsVMs/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Jails, Plugins and Virtual Machines"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/jailspluginsvms/"
 description: "Reference documentation for the Jails, Plugins, and Virtual Machines screens."
 geekdocCollapseSection: true
 weight: 130

--- a/content/CORE/UIReference/Network/GlobalConfigScreen.md
+++ b/content/CORE/UIReference/Network/GlobalConfigScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "Global Configuration Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/network/globalconfigscreen/"
 description: "Describes how to use the Global Configuration screen in TrueNAS CORE."
 weight: 20
 aliases: /core/network/globalconfig/

--- a/content/CORE/UIReference/Network/IPMIScreen.md
+++ b/content/CORE/UIReference/Network/IPMIScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "IPMI Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/network/ipmiscreen/"
 description: "Describes the fields on the IPMI screen in TrueNAS CORE."
 weight: 50
 tags:

--- a/content/CORE/UIReference/Network/InterfacesScreen.md
+++ b/content/CORE/UIReference/Network/InterfacesScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "Interfaces Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/network/interfacesscreen/"
 description: "Describes the fields in the Network Interface screen on TrueNAS CORE."
 weight: 10
 tags:

--- a/content/CORE/UIReference/Network/NetworkSummaryScreen.md
+++ b/content/CORE/UIReference/Network/NetworkSummaryScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "Network Summary Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/network/networksummaryscreen/"
 description: "Describes the fields in the Network Summary screen in TrueNAS CORE."
 weight: 10
 aliases: 

--- a/content/CORE/UIReference/Network/StaticRoutesScreen.md
+++ b/content/CORE/UIReference/Network/StaticRoutesScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "Static Routes Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/network/staticroutesscreen/"
 description: "Describes the Static Routes screen in TrueNAS CORE."
 weight: 40
 tags:

--- a/content/CORE/UIReference/Network/_index.md
+++ b/content/CORE/UIReference/Network/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Network"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/network/"
 description: "Reference documentation of the various Network menu screens."
 geekdocCollapseSection: true
 weight: 80

--- a/content/CORE/UIReference/ReportingGraphs.md
+++ b/content/CORE/UIReference/ReportingGraphs.md
@@ -1,5 +1,6 @@
 ---
 title: "Reporting"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/reportinggraphs/"
 description: "Contains information about the graphs displayed on the Reporting screen in TrueNAS CORE."
 weight: 135
 Aliases: /core/system/reporting/

--- a/content/CORE/UIReference/Services/AFPScreen.md
+++ b/content/CORE/UIReference/Services/AFPScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "AFP Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/afpscreen/"
 description: "Describes the AFP screen in TrueNAS CORE."
 weight: 10
 tags:

--- a/content/CORE/UIReference/Services/DynamicDNSScreen.md
+++ b/content/CORE/UIReference/Services/DynamicDNSScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "Dynamic DNS Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/dynamicdnsscreen/"
 description: "Describes the DDNS screen in TrueNAS CORE."
 weight: 20
 aliases: core/services/dynamicdns/

--- a/content/CORE/UIReference/Services/FTPScreen.md
+++ b/content/CORE/UIReference/Services/FTPScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "FTP Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/ftpscreen/"
 description: "Describes the FTP screen in TrueNAS CORE."
 weight: 30
 tags:

--- a/content/CORE/UIReference/Services/LLDPScreen.md
+++ b/content/CORE/UIReference/Services/LLDPScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "LLDP Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/lldpscreen/"
 description: "Describes the LLDP screen in TrueNAS CORE."
 weight: 50
 tags:

--- a/content/CORE/UIReference/Services/NFSScreen.md
+++ b/content/CORE/UIReference/Services/NFSScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "NFS Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/nfsscreen/"
 description: "Describes the NFS screen in TrueNAS CORE."
 weight: 60
 tags:

--- a/content/CORE/UIReference/Services/OpenVPNScreen.md
+++ b/content/CORE/UIReference/Services/OpenVPNScreen.md
@@ -1,5 +1,6 @@
 --- 
 title: "OpenVPN Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/openvpnscreen/"
 description: "Describes the OpenVPN screen in TrueNAS CORE."
 weight: 70
 tags:

--- a/content/CORE/UIReference/Services/S3Screen.md
+++ b/content/CORE/UIReference/Services/S3Screen.md
@@ -1,5 +1,6 @@
 ---
 title: "S3 Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/s3screen/"
 description: "Describes the S3 screen in TrueNAS CORE."
 weight: 100
 tags:

--- a/content/CORE/UIReference/Services/SMARTScreen.md
+++ b/content/CORE/UIReference/Services/SMARTScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "S.M.A.R.T. Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/smartscreen/"
 description: "Describes the S.M.A.R.T. screen in TrueNAS CORE."
 weight: 100
 tags:

--- a/content/CORE/UIReference/Services/SMBScreen.md
+++ b/content/CORE/UIReference/Services/SMBScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "SMB Service Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/smbscreen/"
 description: "Describes the SMB screen in TrueNAS CORE."
 weight: 110
 tags:

--- a/content/CORE/UIReference/Services/SNMPScreen.md
+++ b/content/CORE/UIReference/Services/SNMPScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "SNMP Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/snmpscreen/"
 description: "Describes the SNMP screen in TrueNAS CORE."
 weight: 120
 aliases: /core/services/snmp/

--- a/content/CORE/UIReference/Services/ServicesSSH.md
+++ b/content/CORE/UIReference/Services/ServicesSSH.md
@@ -1,5 +1,6 @@
 ---
 title: "SSH Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/servicesssh/"
 description: "Describes the SSH screen in TrueNAS CORE."
 weight: 130
 aliases:

--- a/content/CORE/UIReference/Services/TFTPScreen.md
+++ b/content/CORE/UIReference/Services/TFTPScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "TFTP Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/tftpscreen/"
 description: "Describes the TFTP screen in TrueNAS CORE."
 weight: 140
 tags:

--- a/content/CORE/UIReference/Services/UPSScreen.md
+++ b/content/CORE/UIReference/Services/UPSScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "UPS Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/upsscreen/"
 description: "Describes the UPS screen in TrueNAS CORE."
 weight: 150
 aliases:

--- a/content/CORE/UIReference/Services/WebDAVScreen.md
+++ b/content/CORE/UIReference/Services/WebDAVScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "WebDAV Services Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/webdavscreen/"
 description: "Describes the WebDAV screen in TrueNAS CORE."
 weight: 160
 tags:

--- a/content/CORE/UIReference/Services/_index.md
+++ b/content/CORE/UIReference/Services/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Services"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/services/"
 description: "Provides information on the Services screen and lists other services UI reference articles."
 geekdocCollapseSection: true
 weight: 120

--- a/content/CORE/UIReference/Sharing/AFPShareScreen.md
+++ b/content/CORE/UIReference/Sharing/AFPShareScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "AFP Share Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/sharing/afpsharescreen/"
 description: "Provides information about the AFP Share screen in TrueNAS CORE."
 weight: 10
 aliases:

--- a/content/CORE/UIReference/Sharing/NFSShareScreen.md
+++ b/content/CORE/UIReference/Sharing/NFSShareScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "NFS Share Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/sharing/nfssharescreen/"
 description: "Use the NFS share screen to configure Network File System (NFS) shares on your TrueNAS."
 weight: 30
 aliases:

--- a/content/CORE/UIReference/Sharing/SMBShareScreen.md
+++ b/content/CORE/UIReference/Sharing/SMBShareScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "SMB Share Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/sharing/smbsharescreen/"
 description: "Desctibes the SMB sharing screen in TrueNAS CORE"
 weight: 50
 aliases:

--- a/content/CORE/UIReference/Sharing/WebDAVShareScreen.md
+++ b/content/CORE/UIReference/Sharing/WebDAVShareScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "WebDAV Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/sharing/webdavsharescreen/"
 description: "Use the Sharing WebDAV screen to configure Web Distributed Authoring and Versioning (WebDAV) on your TrueNAS."
 weight: 40
 aliases:

--- a/content/CORE/UIReference/Sharing/_index.md
+++ b/content/CORE/UIReference/Sharing/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Sharing"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/sharing/"
 description: "Reference documentation for all screens within the Sharing menu option."
 geekdocCollapseSection: true
 weight: 110

--- a/content/CORE/UIReference/Sharing/iSCSI/FibreChannel.md
+++ b/content/CORE/UIReference/Sharing/iSCSI/FibreChannel.md
@@ -1,5 +1,6 @@
 ---
 title: "Fibre Channel"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/sharing/iscsi/fibrechannel/"
 description: "Provides information about using Fibre Channel with TrueNAS CORE."
 weight: 20
 alias: /core/sharing/iscsi/fibrechannel/

--- a/content/CORE/UIReference/Sharing/iSCSI/_index.md
+++ b/content/CORE/UIReference/Sharing/iSCSI/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Block Shares (iSCSI)"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/sharing/iscsi/"
 description: "Provides information about iSCSI terminology and configuration for TrueNAS CORE."
 geekdocCollapseSection: true
 weight: 20

--- a/content/CORE/UIReference/Sharing/iSCSI/iSCSIShare.md
+++ b/content/CORE/UIReference/Sharing/iSCSI/iSCSIShare.md
@@ -1,5 +1,6 @@
 ---
 title: "iSCSI Shares"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/sharing/iscsi/iscsishare/"
 description: "Describes how to configure iSCSI block share on TrueNAS CORE."
 weight: 10
 alias: /core/sharing/iscsi/iscsishare/

--- a/content/CORE/UIReference/Storage/DisksScreens.md
+++ b/content/CORE/UIReference/Storage/DisksScreens.md
@@ -1,5 +1,6 @@
 ---
 title: "Disks Screens"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/storage/pools/disksscreens/"
 description: "Describes the fields in the Disk Screens in TrueNAS CORE."
 weight: 40
 aliases:

--- a/content/CORE/UIReference/Storage/Pools/COREQuotaScreens.md
+++ b/content/CORE/UIReference/Storage/Pools/COREQuotaScreens.md
@@ -1,5 +1,6 @@
 ---
-title: "User and Group Quota Screens "
+title: "User and Group Quota Screens"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/storage/pools/corequotascreens/"
 description: "Describes CORE Dataset User and Group Quota screen settings and functions."
 weight: 18
 tags: 

--- a/content/CORE/UIReference/Storage/Pools/DatasetsScreen.md
+++ b/content/CORE/UIReference/Storage/Pools/DatasetsScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "Datasets Screens"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/storage/pools/datasetsscreen/"
 description: "Describes how to configure a dataset on TrueNAS CORE."
 weight: 17
 tags:

--- a/content/CORE/UIReference/Storage/Pools/ZvolsScreen.md
+++ b/content/CORE/UIReference/Storage/Pools/ZvolsScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "Zvols Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/storage/pools/zvolsscreen/"
 description: "Describes the fields in the Storage Pools Add Zvol screen in TrueNAS CORE."
 weight: 19
 tags:

--- a/content/CORE/UIReference/Storage/Pools/_index.md
+++ b/content/CORE/UIReference/Storage/Pools/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Pools"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/storage/pools/poolsscreens/"
 description: "Lists the screens related to Pools in TrueNAS CORE."
 geekdocCollapseSection: true
 weight: 10

--- a/content/CORE/UIReference/Storage/SnapshotsScreen.md
+++ b/content/CORE/UIReference/Storage/SnapshotsScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "Snapshots Screens"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/storage/snapshotsscreen/"
 description: "Describes the Snapshots screens on TrueNAS CORE."
 weight: 20
 tags:

--- a/content/CORE/UIReference/Storage/VMware-SnapshotsScreen.md
+++ b/content/CORE/UIReference/Storage/VMware-SnapshotsScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "VMware-Snapshots Screen"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/storage/pools/vmware-snapshotsscreen/"
 description: "Describes the fields in the VMware Snapshot screen on TrueNAS CORE."
 weight: 30
 tags:

--- a/content/CORE/UIReference/Storage/_index.md
+++ b/content/CORE/UIReference/Storage/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Storage"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/storage/"
 description: "Reference documentation for the various screens within the Storage menu option."
 geekdocCollapseSection: true
 weight: 90

--- a/content/CORE/UIReference/System/2FA.md
+++ b/content/CORE/UIReference/System/2FA.md
@@ -1,5 +1,6 @@
 ---
 title: "2FA (Two-Factor Authentication)"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/2fa/"
 description: "Describes the Two-Factor Authentication User Settings screen on TrueNAS CORE."
 weight: 190
 tags:

--- a/content/CORE/UIReference/System/ACMEDNS.md
+++ b/content/CORE/UIReference/System/ACMEDNS.md
@@ -1,5 +1,6 @@
 ---
 title: "ACME DNS"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/acmedns/"
 description: "Describes the fields in the Add ACME DNS Authenticators screen on TrueNAS CORE." 
 weight: 170
 tags:

--- a/content/CORE/UIReference/System/Advanced.md
+++ b/content/CORE/UIReference/System/Advanced.md
@@ -1,5 +1,6 @@
 ---
 title: "Advanced"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/advanced/"
 description: "Describes the System > Advanced screen on TrueNAS CORE."
 weight: 40
 tags:

--- a/content/CORE/UIReference/System/AlertServices.md
+++ b/content/CORE/UIReference/System/AlertServices.md
@@ -1,5 +1,6 @@
 ---
 title: "Alert Services"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/alertservices/"
 description: "Describes the fields on the Alert Services screen on TrueNAS CORE."
 weight: 80
 tags:

--- a/content/CORE/UIReference/System/AlertSettings.md
+++ b/content/CORE/UIReference/System/AlertSettings.md
@@ -1,5 +1,6 @@
 ---
 title: "Alert Settings"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/alertsettings/"
 description: "Describes the Alert Settings screen on TrueNAS CORE."
 weight: 90
 tags:

--- a/content/CORE/UIReference/System/BootScreen.md
+++ b/content/CORE/UIReference/System/BootScreen.md
@@ -1,5 +1,6 @@
 ---
 title: "Boot"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/bootscreen/"
 description: "Provides information about the Boot screen for the TrueNAS CORE."
 weight: 30
 aliases:

--- a/content/CORE/UIReference/System/CAs.md
+++ b/content/CORE/UIReference/System/CAs.md
@@ -1,5 +1,6 @@
 ---
 title: "CAs"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/cas/"
 description: "Describes the Certificate Authorities screen settings and functions."
 weight: 155
 tags:

--- a/content/CORE/UIReference/System/Certificates.md
+++ b/content/CORE/UIReference/System/Certificates.md
@@ -1,5 +1,6 @@
 ---
 title: "Certificates"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/certificates/"
 description: "Explains the fields located on the Certificates screen in TrueNAS CORE."
 weight: 160
 tags:

--- a/content/CORE/UIReference/System/CloudCredentials.md
+++ b/content/CORE/UIReference/System/CloudCredentials.md
@@ -1,5 +1,6 @@
 ---
 title: "Cloud Credentials"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/cloudcredentials/"
 description: "Describes the fields in the Cloud Credentials screen in TrueNAS CORE."
 weight: 100
 tags:

--- a/content/CORE/UIReference/System/Email.md
+++ b/content/CORE/UIReference/System/Email.md
@@ -1,5 +1,6 @@
 ---
 title: "Email"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/email/"
 description: "Describes the Email screen and settings on TrueNAS CORE."
 weight: 50
 tags:

--- a/content/CORE/UIReference/System/Failover.md
+++ b/content/CORE/UIReference/System/Failover.md
@@ -1,5 +1,6 @@
 ---
 title: "Failover (HA)"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/failover/"
 description: "Describes the fields in the Failover Configuration screen on TrueNAS CORE."
 weight: 178
 tags:

--- a/content/CORE/UIReference/System/General.md
+++ b/content/CORE/UIReference/System/General.md
@@ -1,5 +1,6 @@
 ---
 title: "General"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/general/"
 description: "Describes the fields for the general system settings for TrueNAS CORE."
 weight: 10
 aliases:

--- a/content/CORE/UIReference/System/KMIP.md
+++ b/content/CORE/UIReference/System/KMIP.md
@@ -1,5 +1,6 @@
 ---
 title: "KMIP"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/kmip/"
 description: "Describes the fields in the KMIP Key Status screen on TrueNAS CORE Enterprise."
 weight: 175
 aliases:

--- a/content/CORE/UIReference/System/NTPServers.md
+++ b/content/CORE/UIReference/System/NTPServers.md
@@ -1,5 +1,6 @@
 ---
 title: "NTP Servers"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/ntpservers/"
 description: "Describes the fields for the NTP Server Settings screen on TrueNAS CORE."
 weight: 20
 tags:

--- a/content/CORE/UIReference/System/Reporting.md
+++ b/content/CORE/UIReference/System/Reporting.md
@@ -1,5 +1,6 @@
 ---
 title: "Reporting"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/reporting/"
 description: "Contains information about the Reporting screen on TrueNAS CORE."
 weight: 70
 aliases: /core/administration/reporting/

--- a/content/CORE/UIReference/System/SSHConnections.md
+++ b/content/CORE/UIReference/System/SSHConnections.md
@@ -1,5 +1,6 @@
 ---
 title: "SSH Connections"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/sshconnections/"
 description: "Describes the SSH screen fields on TrueNAS CORE."
 weight: 110
 tags:

--- a/content/CORE/UIReference/System/SSHKeypairs.md
+++ b/content/CORE/UIReference/System/SSHKeypairs.md
@@ -1,5 +1,6 @@
 ---
 title: "SSH Keypairs"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/sshkeypairs/"
 description: "Describes the SSH Keypair screen on TrueNAS CORE."
 weight: 120
 aliases:

--- a/content/CORE/UIReference/System/Support.md
+++ b/content/CORE/UIReference/System/Support.md
@@ -1,5 +1,6 @@
 ---
 title: "Support"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/support/"
 description: "Describes the Support screen on TrueNAS CORE."
 weight: 180
 tags:

--- a/content/CORE/UIReference/System/SystemDataset.md
+++ b/content/CORE/UIReference/System/SystemDataset.md
@@ -1,5 +1,6 @@
 ---
 title: "System Dataset"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/systemdataset/"
 description: "Describes the System Dataset screen on TrueNAS CORE."
 weight: 60
 tags:

--- a/content/CORE/UIReference/System/Tunables.md
+++ b/content/CORE/UIReference/System/Tunables.md
@@ -1,5 +1,6 @@
 ---
 title: "Tunables"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/tunables/"
 description: "Describes the Tunable screen fields on TrueNAS CORE."
 weight: 140
 tags:

--- a/content/CORE/UIReference/System/Update.md
+++ b/content/CORE/UIReference/System/Update.md
@@ -1,5 +1,6 @@
 ---
 title: "Update"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/update/"
 description: "Describes the fields in the Update screen in TrueNAS CORE."
 geekdocCollapseSection: true
 weight: 150

--- a/content/CORE/UIReference/System/ViewEnclosure.md
+++ b/content/CORE/UIReference/System/ViewEnclosure.md
@@ -1,5 +1,6 @@
 ---
 title: "View Enclosure"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/viewenclosure/"
 description: "Provides information about the View Enclosure screen on TrueNAS CORE."
 weight: 45
 tags:

--- a/content/CORE/UIReference/System/_index.md
+++ b/content/CORE/UIReference/System/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "System"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/system/"
 description: "Reference documentation for the screens within the System menu option."
 geekdocCollapseSection: true
 weight: 60

--- a/content/CORE/UIReference/Tasks/AdvancedScheduler.md
+++ b/content/CORE/UIReference/Tasks/AdvancedScheduler.md
@@ -1,5 +1,6 @@
 ---
 title: "Advanced Scheduler"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/tasks/advancedscheduler/"
 description: "Describes the fields in the Advanced Scheduler in TrueNAS CORE."
 weight: 100
 tags:

--- a/content/CORE/UIReference/Tasks/CloudSyncTasks.md
+++ b/content/CORE/UIReference/Tasks/CloudSyncTasks.md
@@ -1,5 +1,6 @@
 ---
 title: "Cloud Sync Tasks"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/tasks/cloudsynctasks/"
 description: "Describes the Cloud Sync Tasks screen on TrueNAS CORE."
 weight: 90
 tags:

--- a/content/CORE/UIReference/Tasks/CronJobs.md
+++ b/content/CORE/UIReference/Tasks/CronJobs.md
@@ -1,5 +1,6 @@
 ---
 title: "Cron Jobs"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/tasks/cronjobs/"
 description: "Describes the fields on the Cron Jobs screen on TrueNAS CORE."
 weight: 10
 tags:

--- a/content/CORE/UIReference/Tasks/InitShutdownScripts.md
+++ b/content/CORE/UIReference/Tasks/InitShutdownScripts.md
@@ -1,5 +1,6 @@
 ---
 title: "Init/Shutdown Scripts"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/tasks/initshutdownscripts/"
 description: "Explains the fields on the Init/Shutdown Script screen on TrueNAS CORE."
 weight: 20
 tags:

--- a/content/CORE/UIReference/Tasks/PeriodicSnapshotTasks.md
+++ b/content/CORE/UIReference/Tasks/PeriodicSnapshotTasks.md
@@ -1,5 +1,6 @@
 ---
 title: "Periodic Snapshot Tasks"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/tasks/periodicsnapshottasks/"
 description: "Defines the fields in the Periodic Snapshot Tasks Screen on TrueNAS CORE."
 weight: 50
 tags:

--- a/content/CORE/UIReference/Tasks/ReplicationTasks.md
+++ b/content/CORE/UIReference/Tasks/ReplicationTasks.md
@@ -1,5 +1,6 @@
 ---
 title: "Replication Tasks"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/tasks/replicationtasks/"
 description: "Decribes the fields on the Replication Tasks screen for TrueNAS CORE."
 geekdocCollapseSection: true
 weight: 60

--- a/content/CORE/UIReference/Tasks/ResilverPriority.md
+++ b/content/CORE/UIReference/Tasks/ResilverPriority.md
@@ -1,5 +1,6 @@
 ---
 title: "Resilver Priority"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/tasks/resilverpriority/"
 description: "Describes the Resilver Priority screen on TrueNAS CORE." 
 weight: 70
 tags:

--- a/content/CORE/UIReference/Tasks/Rsync.md
+++ b/content/CORE/UIReference/Tasks/Rsync.md
@@ -1,5 +1,6 @@
 ---
 title: "Rsync Tasks"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/tasks/rsync/"
 description: "Provides information about the Rsync Tasks screen on TrueNAS CORE."
 weight: 30
 tags:

--- a/content/CORE/UIReference/Tasks/SMARTTests.md
+++ b/content/CORE/UIReference/Tasks/SMARTTests.md
@@ -1,5 +1,6 @@
 ---
 title: "S.M.A.R.T. Tests"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/tasks/smarttests/"
 description: "Describes the fields on the S.M.A.R.T. Test screen on TrueNAS CORE."
 weight: 40
 tags:

--- a/content/CORE/UIReference/Tasks/ScrubTasks.md
+++ b/content/CORE/UIReference/Tasks/ScrubTasks.md
@@ -1,5 +1,6 @@
 ---
 title: "Scrub Tasks"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/tasks/scrubtasks/"
 description: "Describes the fields on the Scrub Task screen on TrueNAS CORE."
 weight: 80
 tags:

--- a/content/CORE/UIReference/Tasks/_index.md
+++ b/content/CORE/UIReference/Tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/tasks/"
 description: "Reference documentation of screens within the Tasks menu option."
 geekdocCollapseSection: true
 weight: 70

--- a/content/CORE/UIReference/TopMenu/Alerts.md
+++ b/content/CORE/UIReference/TopMenu/Alerts.md
@@ -1,5 +1,6 @@
 ---
 title: "Alert Notifications"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/topmenu/alerts/"
 description: "Displays system alerts and provides options to dismiss or reopen dismissed alerts on your TrueNAS."
 weight: 20
 tags:

--- a/content/CORE/UIReference/TopMenu/TaskManager.md
+++ b/content/CORE/UIReference/TopMenu/TaskManager.md
@@ -1,5 +1,6 @@
 ---
 title: "Task Manager"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/topmenu/taskmanager/"
 description: "Displays a list of tasks performed by your TrueNAS."
 weight: 10
 tags:

--- a/content/CORE/UIReference/TopMenu/UIPreferences.md
+++ b/content/CORE/UIReference/TopMenu/UIPreferences.md
@@ -1,5 +1,6 @@
 ---
 title: "Interface Preferences"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/topmenu/uipreferences/"
 description: "Displays a list of general preferences for your TrueNAS."
 weight: 30
 aliases: /core/administration/uipreferences/

--- a/content/CORE/UIReference/TopMenu/_index.md
+++ b/content/CORE/UIReference/TopMenu/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Top Menu
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/topmenu/"
 description: "Reference documentation for the options panel that displays at the top of the TrueNAS UI."
 weight: 2
 geekdocCollapseSection: true

--- a/content/CORE/UIReference/UIReferencePrint.md
+++ b/content/CORE/UIReference/UIReferencePrint.md
@@ -1,5 +1,6 @@
 ---
 title: "⎙ Download or Print"
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/printview/"
 description: "View all CORE UI Reference content as a single page for download or print."
 weight: 1
 no_print: "true"

--- a/content/CORE/UIReference/_index.md
+++ b/content/CORE/UIReference/_index.md
@@ -1,5 +1,6 @@
 ---
 title: UI Reference Guide
+redirect: "https://www.truenas.com/docs/core/13.0/uireference/"
 description: "This book contains descriptions of the various screens and fields available in the TrueNAS User Interface."
 weight: 50
 geekdocCollapseSection: true

--- a/content/CORE/_index.md
+++ b/content/CORE/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "TrueNAS CORE"
+geekDocHidden: true
 geekdocCollapseSection: true
 weight: 10
 aliases:

--- a/content/CORE/_index.md
+++ b/content/CORE/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "TrueNAS CORE"
-geekDocHidden: true
+#redirect: "https://www.truenas.com/docs/core/13.0/"
+geekDocHidden: false
 geekdocCollapseSection: true
 weight: 10
 aliases:

--- a/content/CORE/_index.md
+++ b/content/CORE/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "TrueNAS CORE"
-#redirect: "https://www.truenas.com/docs/core/13.0/"
+redirect: "https://www.truenas.com/docs/core/13.0/"
 geekDocHidden: false
 geekdocCollapseSection: true
 weight: 10

--- a/content/SCALE/_index.md
+++ b/content/SCALE/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "TrueNAS SCALE"
+title: "TrueNAS 25.04 (Early)"
 geekdocCollapseSection: true
 weight: 20
 aliases:
@@ -29,9 +29,9 @@ h1 {display:none;}
 
 <div class="noprint">
 
-## 25.04 Featured Content
-
 To view or search through documentation for previous TrueNAS SCALE major versions, use the **Version** dropdown at the top of this page.
+
+## 25.04 Featured Content
 
   <div class="docs-sections">
     <p>

--- a/content/TrueCommand/_index.md
+++ b/content/TrueCommand/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "TrueCommand"
+geekDocHidden: true
 description: "Public documentation for TrueCommand, the TrueNAS fleet monitoring and managing application."
 geekdocCollapseSection: true
 weight: 30

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,6 +6,9 @@
 >
 <head>
     {{ partial "head/meta" . }}
+	{{ if .Params.redirect }}
+	<meta http-equiv="Refresh" content="0; url='{{ .Params.redirect }}'" />
+	{{ end }}
     <title>
       {{- if eq .Kind "home" -}}
         TrueNAS Documentation Hub
@@ -22,6 +25,7 @@
 </head>
 
 <body itemscope itemtype="https://schema.org/WebPage">
+ {{ if not .Params.redirect }}
     <!-- Define feature image for search results or linking -->
     <a href="#" style="display: none;" class="image featured">{{ with .Site.Params.featured_image }}<img src="{{ . }}"></img>{{end}}</a>
     <!-- Google Tag Manager (noscript) -->
@@ -67,7 +71,6 @@
                 {{ partial "toc-panel" . }}
             </aside>
         </main>
-
         {{ partial "site-footer" . }}
     </div>
     {{ partial "foot" . }}
@@ -77,6 +80,7 @@
     <script src="/js/figurenumber.js"></script>
     <!-- Scroll padding so anchor links are not hidden by the stickymenu -->
     <script src="/js/anchorpad.js"></script>
+ {{ end }}
 </body>
 </html>
 


### PR DESCRIPTION
This is for master branch content only to redirect the nightly dev content URLs that are anticipated to offline back to the evergreen 13.0 (or 13.3 in some specific cases) content URLs.

Still to do:
- TrueCommand nightly dev content redirects
- Rework website version selector to remove CORE > Nightly and TrueCommand > Nightly options.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
