### PR TITLE
24.04.2.5 Release updates

### DIFF
--- a/content/GettingStarted/SCALEReleaseNotes.md
+++ b/content/GettingStarted/SCALEReleaseNotes.md
@@ -121,6 +121,21 @@ The items listed here represent new feature flags implemented since the previous
 
 For more details on feature flags, see [OpenZFS Feature Flags](https://openzfs.github.io/openzfs-docs/Basic%20Concepts/Feature%20Flags.html) and [OpenZFS zpool-feature.7](https://openzfs.github.io/openzfs-docs/man/7/zpool-features.7.html).
 
+## 24.04.2.5 Changelog
+
+**November 8, 2024**
+
+iXsystems is pleased to release TrueNAS 24.10.0.2!
+This is a release to address another high-impact issue discovered with SMB memory management.
+
+* Fix Management of SMB AIO read buffers ([NAS-132365](https://ixsystems.atlassian.net/browse/NAS-132365)).
+
+Users with 24.04.2.4 installed and SMB shares in use are encouraged to upgrade to this release immediately.
+
+### 24.04.2.5 Known Issues
+
+Please see the 24.04.2 changelog below and use the Jira filter links to see the full changelog and known issues related to the 24.04.2 > 24.04.2.5 releases.
+
 ## 24.04.2.4 Changelog
 
 **November 7, 2024**
@@ -136,7 +151,7 @@ Notable Changes:
 
 ### 24.04.2.4 Known Issues
 
-Please see the 24.10.0 changelog below and use the Jira filter links to see the full changelog and known issues related to the 24.10.0 and 24.10.0.1 releases.
+Please see the 24.04.2 changelog below and use the Jira filter links to see the full changelog and known issues related to the 24.04.2 > 24.04.2.4 releases.
 
 ## 24.04.2.3 Changelog
 

--- a/content/GettingStarted/SCALEReleaseNotes.md
+++ b/content/GettingStarted/SCALEReleaseNotes.md
@@ -151,6 +151,9 @@ Notable Changes:
 
 ### 24.04.2.4 Known Issues
 
+* Users have reported an issue with SMB memory management under heavy SMB loads.
+  A fix for this issue is in the 24.04.2.5 release version.
+
 Please see the 24.04.2 changelog below and use the Jira filter links to see the full changelog and known issues related to the 24.04.2 > 24.04.2.4 releases.
 
 ## 24.04.2.3 Changelog

--- a/data/properties/scale-downloads.yaml
+++ b/data/properties/scale-downloads.yaml
@@ -74,6 +74,9 @@ majorVersions:
     majorVersion: "Unstable Builds"
     majorLink: ""
     releases:
+      - name: "24.04.2.5"
+        link: "https://download.truenas.com/TrueNAS-SCALE-Dragonfish/24.04.2.5/"
+        date: "2024-11-08"
       - name: "24.04.2.4"
         link: "https://download.truenas.com/TrueNAS-SCALE-Dragonfish/24.04.2.4/"
         date: "2024-11-07"

--- a/data/properties/scale-releases.yaml
+++ b/data/properties/scale-releases.yaml
@@ -8,19 +8,19 @@ majorVersions:
     name: "TrueNAS SCALE 24.04 - Dragonfish"
     releaseName: "Dragonfish"
     releases:
-      - name: "24.04.2.4"
+      - name: "24.04.2.5"
         type: "Maintenance"
         link: "https://www.truenas.com/docs/scale/24.04/gettingstarted/scalereleasenotes/#240424-changelog"
-        releaseDate: "2024-11-07"
+        releaseDate: "2024-11-08"
         latest: true
   - lifecycle: "Current"
     name: "TrueNAS SCALE 24.10 - Electric Eel"
     releaseName: "Electric Eel"
     releases:
-      - name: "24.10.0.1"
+      - name: "24.10.0.2"
         type: "Maintenance"
-        link: "https://www.truenas.com/docs/scale/24.10/gettingstarted/scalereleasenotes/#241001-changelog"
-        releaseDate: "2024-11-07"
+        link: "https://www.truenas.com/docs/scale/24.10/gettingstarted/scalereleasenotes/#241002-changelog"
+        releaseDate: "2024-11-08"
         latest: true
       - name: "24.10.1"
         type: "Maintenance"

--- a/data/properties/scale-releases.yaml
+++ b/data/properties/scale-releases.yaml
@@ -10,7 +10,7 @@ majorVersions:
     releases:
       - name: "24.04.2.5"
         type: "Maintenance"
-        link: "https://www.truenas.com/docs/scale/24.04/gettingstarted/scalereleasenotes/#240424-changelog"
+        link: "https://www.truenas.com/docs/scale/24.04/gettingstarted/scalereleasenotes/#240425-changelog"
         releaseDate: "2024-11-08"
         latest: true
   - lifecycle: "Current"

--- a/static/includes/SCALEUpgradePaths.md
+++ b/static/includes/SCALEUpgradePaths.md
@@ -17,8 +17,8 @@
             B["CORE 13.0-U6.2<br><br>CORE 13.3-RELEASE"] -->|ISO install| E
             C["22.12.4.2 (Bluefin)"] -->|update| D
             D["23.10.2 (Cobia)"] -->|update| E
-            E["24.04.2.4 (Dragonfish)"] -->|update| H
-            H["24.10.0.1 (Electric Eel)"]
+            E["24.04.2.5 (Dragonfish)"] -->|update| H
+            H["24.10.0.2 (Electric Eel)"]
           {{< /mermaid >}}
         </div>
       </div>
@@ -32,8 +32,8 @@
             A["CORE 13.0-U6.2"] -->|ISO install| D
             B["Current 23.10 (Cobia) release"] -->|update| C
             C["23.10.2 (Cobia)"] -->|update| D
-            D["24.04.2.4 (Dragonfish)"]  -->|"(anticipated)"| E
-            E["24.10.0.1 (Electric Eel)"]
+            D["24.04.2.5 (Dragonfish)"]  -->|"(anticipated)"| E
+            E["24.10.0.2 (Electric Eel)"]
           {{< /mermaid >}}
         </div>
       </div>


### PR DESCRIPTION
Add release notes and other schedule & upgrade path updates for 24.0.4.2.5 and 24.10.0.2 releases



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
