### PR TITLE
PD-1499 / 25.04 / Pd 1499 create do not create root dataset share warning

### DIFF
--- a/content/SCALE/GettingStarted/Configure/SetUpSharing.md
+++ b/content/SCALE/GettingStarted/Configure/SetUpSharing.md
@@ -17,6 +17,8 @@ keywords:
 After setting up storage on your TrueNAS, it is time to begin sharing data!
 There are several sharing solutions available on SCALE, but in this article we discuss the options to create the share and dataset from the **Shares** screens.
 
+{{< include file="/static/includes/RootLevelDatasetShareWarning.md" >}}
+
 ## Sharing Data Methods
 TrueNAS SCALE provides three types of sharing methods:
 

--- a/content/SCALE/SCALETutorials/Shares/AFPMigration.md
+++ b/content/SCALE/SCALETutorials/Shares/AFPMigration.md
@@ -12,6 +12,8 @@ tags:
  - migrate
 ---
 
+{{< include file="/static/includes/RootLevelDatasetShareWarning.md" >}}
+
 Since the Apple Filing Protocol (AFP) for shares is deprecated and no longer receives updates, it is not in TrueNAS SCALE.
 
 However, users can sidegrade a TrueNAS CORE configuration into SCALE, so TrueNAS SCALE migrates previously-saved AFP configurations into SMB configurations.

--- a/content/SCALE/SCALETutorials/Shares/AddingNFSShares.md
+++ b/content/SCALE/SCALETutorials/Shares/AddingNFSShares.md
@@ -12,6 +12,8 @@ tags:
 ---
 
 
+{{< include file="/static/includes/RootLevelDatasetShareWarning.md" >}}
+
 ## About UNIX (NFS) Shares
 Creating a Network File System (NFS) share on TrueNAS makes a lot of data available for anyone with share access.
 Depending on the share configuration, it can restrict users to read or write privileges.

--- a/content/SCALE/SCALETutorials/Shares/MixedModeShares.md
+++ b/content/SCALE/SCALETutorials/Shares/MixedModeShares.md
@@ -8,6 +8,8 @@ tags:
 - nfs
 ---
 
+{{< include file="/static/includes/RootLevelDatasetShareWarning.md" >}}
+
 ## About Multiprotocol Shares
 A multiprotocol or mixed-mode NFS and SMB share supports both NFS and SMB protocols for sharing data.
 Multiprotocol shares allow clients to use either protocol to access the same data.

--- a/content/SCALE/SCALETutorials/Shares/SMB/AddSMBHomeShare.md
+++ b/content/SCALE/SCALETutorials/Shares/SMB/AddSMBHomeShare.md
@@ -7,6 +7,9 @@ tags:
 - smb
 ---
 
+
+{{< include file="/static/includes/RootLevelDatasetShareWarning.md" >}}
+
 {{< hint type=important title="Legacy Feature" >}}
 SMB Home Shares are a legacy feature for organizations looking to maintain existing SMB configurations.
 They are not recommended for new deployments.

--- a/content/SCALE/SCALETutorials/Shares/SMB/AddSMBShadowCopies.md
+++ b/content/SCALE/SCALETutorials/Shares/SMB/AddSMBShadowCopies.md
@@ -7,6 +7,9 @@ tags:
 - smb
 ---
 
+
+{{< include file="/static/includes/RootLevelDatasetShareWarning.md" >}}
+
 **Enable Shadow Copies** exports ZFS snapshots as [Shadow Copies](https://docs.microsoft.com/en-us/windows/win32/vss/shadow-copies-and-shadow-copy-sets) for Microsoft Volume Shadow Copy Service (VSS) clients.
 
 ## About SMB Shadow Copies

--- a/content/SCALE/SCALETutorials/Shares/SMB/ManageSMBShares.md
+++ b/content/SCALE/SCALETutorials/Shares/SMB/ManageSMBShares.md
@@ -9,6 +9,9 @@ tags:
 - acl
 ---
 
+
+{{< include file="/static/includes/RootLevelDatasetShareWarning.md" >}}
+
 To access SMB share management options, go to **Shares** screen with the **Windows (SMB) Shares** widget.
 The widget lists SMB shares configured on but is not the full list.
 Each share listed includes four icons that open other screens or dialogs that provide access to share settings.

--- a/content/SCALE/SCALETutorials/Shares/SMB/SMBMultichannel.md
+++ b/content/SCALE/SCALETutorials/Shares/SMB/SMBMultichannel.md
@@ -7,6 +7,9 @@ tags:
  - smb
 ---
 
+
+{{< include file="/static/includes/RootLevelDatasetShareWarning.md" >}}
+
 SMB multichannel allows servers to use multiple network connections simultaneously by combining the bandwidth of several network interface cards (NICs) for better performance.
 
 {{< hint type=important >}}

--- a/content/SCALE/SCALETutorials/Shares/SMB/SetUpBasicTimeMachineSMBShare.md
+++ b/content/SCALE/SCALETutorials/Shares/SMB/SetUpBasicTimeMachineSMBShare.md
@@ -9,6 +9,9 @@ tags:
 - shares
 ---
 
+
+{{< include file="/static/includes/RootLevelDatasetShareWarning.md" >}}
+
 SCALE uses predefined setting options to establish an SMB share that fits a predefined purpose, such as a basic time machine share.
 
 ## Setting Up a Basic Time Machine SMB Share

--- a/content/SCALE/SCALETutorials/Shares/SMB/_index.md
+++ b/content/SCALE/SCALETutorials/Shares/SMB/_index.md
@@ -12,6 +12,9 @@ tags:
 - shares
 ---
 
+
+{{< include file="/static/includes/RootLevelDatasetShareWarning.md" >}}
+
 ## About Windows (SMB) Shares
 
 SMB (also known as CIFS) is the native file-sharing system in Windows.

--- a/content/SCALE/SCALETutorials/Shares/_index.md
+++ b/content/SCALE/SCALETutorials/Shares/_index.md
@@ -18,6 +18,8 @@ TrueNAS SCALE allows users to create and configure Windows SMB shares, Unix (NFS
 When creating zvols for shares, avoid giving them names with capital letters or spaces since they can cause problems and failures with iSCSI and NFS shares.
 {{< /hint >}}
 
+{{< include file="/static/includes/RootLevelDatasetShareWarning.md" >}}
+
 <div class="noprint">
 
 ## Contents

--- a/static/includes/RootLevelDatasetShareWarning.md
+++ b/static/includes/RootLevelDatasetShareWarning.md
@@ -1,0 +1,7 @@
+&NewLine;
+
+{{< hint type=info title="Do Not Create Pool-Level Dataset Shares" >}}
+When creating a share, do not attempt to setup the root or pool-level dataset for the share.
+Instead, create a new dataset under the pool-level dataset for the share.
+Setting up a share using the root dataset leads to storage reconfiguration issues.
+{{< /hint >}}

--- a/static/includes/RootLevelDatasetShareWarning.md
+++ b/static/includes/RootLevelDatasetShareWarning.md
@@ -1,6 +1,6 @@
 &NewLine;
 
-{{< hint type=info title="Do Not Create Pool-Level Dataset Shares" >}}
+{{< hint type=tip title="Do Not Create Pool-Level Dataset Shares" >}}
 When creating a share, do not attempt to setup the root or pool-level dataset for the share.
 Instead, create a new dataset under the pool-level dataset for the share.
 Setting up a share using the root dataset leads to storage reconfiguration issues.

--- a/static/includes/RootLevelDatasetShareWarning.md
+++ b/static/includes/RootLevelDatasetShareWarning.md
@@ -3,5 +3,5 @@
 {{< hint type=tip title="Do Not Create Pool-Level Dataset Shares" >}}
 When creating a share, do not attempt to set up the root or pool-level dataset for the share.
 Instead, create a new dataset under the pool-level dataset for the share.
-Setting up a share using the root dataset leads to storage reconfiguration issues.
+Setting up a share using the root dataset leads to storage configuration issues.
 {{< /hint >}}

--- a/static/includes/RootLevelDatasetShareWarning.md
+++ b/static/includes/RootLevelDatasetShareWarning.md
@@ -1,6 +1,6 @@
 &NewLine;
 
-{{< hint type=tip title="Do Not Create Pool-Level Dataset Shares" >}}
+{{< hint type=important title="Do Not Create Pool-Level Dataset Shares" >}}
 When creating a share, do not attempt to set up the root or pool-level dataset for the share.
 Instead, create a new dataset under the pool-level dataset for the share.
 Setting up a share using the root dataset leads to storage configuration issues.

--- a/static/includes/RootLevelDatasetShareWarning.md
+++ b/static/includes/RootLevelDatasetShareWarning.md
@@ -1,7 +1,7 @@
 &NewLine;
 
 {{< hint type=tip title="Do Not Create Pool-Level Dataset Shares" >}}
-When creating a share, do not attempt to setup the root or pool-level dataset for the share.
+When creating a share, do not attempt to set up the root or pool-level dataset for the share.
 Instead, create a new dataset under the pool-level dataset for the share.
 Setting up a share using the root dataset leads to storage reconfiguration issues.
 {{< /hint >}}


### PR DESCRIPTION
This PR creates a snippet with a warning admonition about not sharing the root/pool-level dataset, and adds it to all getting started/SMB/NFS sharing articles.

This can be backported to 24.10 and 24.04.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
