### PR TITLE
PD-1517 Add List of Disruptive Actions

### DIFF
--- a/content/SCALE/GettingStarted/Configure/UIConfigurationSCALE.md
+++ b/content/SCALE/GettingStarted/Configure/UIConfigurationSCALE.md
@@ -20,6 +20,7 @@ iXsystems TrueNAS Enterprise customers should contact iXsystems Support after th
 {{< expand "Contacting Support" "v" >}}
 {{< include file="/static/includes/iXsystemsSupportContact.md" >}}
 {{< /expand >}}
+{{< include file="/static/includes/DisruptiveActionslist.md" >}}
 {{< /enterprise >}}
 
 TrueNAS SCALE users should follow the instructions provided below to complete the initial setup and configuration of their systems.

--- a/content/SCALE/SCALETutorials/Network/_index.md
+++ b/content/SCALE/SCALETutorials/Network/_index.md
@@ -12,6 +12,16 @@ related: false
 The **Network** menu option has several screens that enable configuring network interfaces and general system-level network settings.
 The tutorials in this section guide with the various screens and configuration forms contained within this menu item.
 
+{{< enterprise >}}
+iXsystems TrueNAS Enterprise customers should contact iXsystems Support to receive additional guidance on system configuration.
+
+{{< expand "Contacting Support" "v" >}}
+{{< include file="/static/includes/iXsystemsSupportContact.md" >}}
+{{< /expand >}}
+
+{{< include file="/static/includes/DisruptiveActionslist.md" >}}
+{{< /enterprise >}}
+
 <div class="noprint">
 
 ## Contents

--- a/content/SCALE/SCALETutorials/Shares/_index.md
+++ b/content/SCALE/SCALETutorials/Shares/_index.md
@@ -18,6 +18,16 @@ TrueNAS SCALE allows users to create and configure Windows SMB shares, Unix (NFS
 When creating zvols for shares, avoid giving them names with capital letters or spaces since they can cause problems and failures with iSCSI and NFS shares.
 {{< /hint >}}
 
+{{< enterprise >}}
+iXsystems TrueNAS Enterprise customers should contact iXsystems Support to receive additional guidance on system configuration.
+
+{{< expand "Contacting Support" "v" >}}
+{{< include file="/static/includes/iXsystemsSupportContact.md" >}}
+{{< /expand >}}
+
+{{< include file="/static/includes/DisruptiveActionslist.md" >}}
+{{< /enterprise >}}
+
 <div class="noprint">
 
 ## Contents

--- a/content/SCALE/SCALETutorials/Shares/iSCSI/_index.md
+++ b/content/SCALE/SCALETutorials/Shares/iSCSI/_index.md
@@ -7,6 +7,18 @@ aliases:
 related: false
 ---
 
+
+
+{{< enterprise >}}
+iXsystems TrueNAS Enterprise customers should contact iXsystems Support to receive additional guidance on system configuration.
+
+{{< expand "Contacting Support" "v" >}}
+{{< include file="/static/includes/iXsystemsSupportContact.md" >}}
+{{< /expand >}}
+
+{{< include file="/static/includes/DisruptiveActionslist.md" >}}
+{{< /enterprise >}}
+
 ## About the Block (iSCSI) Sharing Protocol
 
 {{< include file="/static/includes/iSCSIRef.md" >}}

--- a/content/SCALE/SCALETutorials/SystemSettings/Services/_index.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Services/_index.md
@@ -13,6 +13,17 @@ keywords:
 - software storage solutions
 ---
 
+
+{{< enterprise >}}
+iXsystems TrueNAS Enterprise customers should contact iXsystems Support to receive additional guidance on system configuration.
+
+{{< expand "Contacting Support" "v" >}}
+{{< include file="/static/includes/iXsystemsSupportContact.md" >}}
+{{< /expand >}}
+
+{{< include file="/static/includes/DisruptiveActionslist.md" >}}
+{{< /enterprise >}}
+
 **System > Services** displays each system component that runs continuously in the background. These typically control data-sharing or other external access to the system. Individual services have configuration screens and activation toggles, and you can set them to run automatically.
 
 Documented services related to data sharing or automated tasks are in their respective [Shares]({{< relref "/SCALE/SCALEUIReference/Shares/_index.md" >}}) and [Tasks]({{< relref "/SCALE/SCALEUIReference/DataProtection/_index.md" >}}) articles.

--- a/static/includes/DisruptiveActionsList.md
+++ b/static/includes/DisruptiveActionsList.md
@@ -1,0 +1,27 @@
+&NewLine;
+
+Configuring features and functions can result in disruption to services and access to users or system connecting to TrueNAS through sharing or network services.
+When adding new or changing existing functions and services, plan maintenance windows to minimize disruptions based on the type and area of change.
+
+{{< expand "Actions that Cause Disruptions" "v" >}}
+The following administrator actions  result in disruptions to services and client connections.
+Durtation of the disruptions depends on system and service configurations, number of users accessing shares and services, network interfaces, and configuration methods (directory service provisioned verses manually configured).
+{{< truetable >}}
+| Service | Function | Action Description |
+|---------|----------|-------------|
+| Network |  | Changing any network setting such as adding or modifying an interface, making a general network change, etc., disrupts network services. An improperly configured network interface can result in lost access to the web UI if changing the primary interface address. Improperly configured general network settings such as DNS name servers, default gateway, host name, or domain name can result in broken network connectivity. |
+| Directory Services |  | Changing Active Directory or LDAP services can result in issues with user access, domain access, etc. TrueNAS alerts users when changes cause breakage in affected areas. |
+| SMB service | `smb.update` | Updating all SMB clients disrupts access. Before making changes, the service must be stopped and then restarted when complete. Stopping the service disrupts clients relying on the service. |
+| NFS service | `nfs.update` | Updating all NFS clients disrupts access. Before making changes, the service must be stopped and then restarted when complete. Stopping the service disrupts clients relying on the service. |
+| SMB shares | `sharing.smb.update`<br>`sharing.smb.delete` | Changing `guest` parameter or toggling `home` on or off in all clients disrupts access, otherwise clients connected to a particular share are disrupted. Before making changes, the service must be stopped and then restarted when complete. Stopping the service disrupts clients relying on the service. |
+| NFS shares | `sharing.nfs.update`<br>`sharing.nfs.delete` | Updates to clients connected to export, and deleting clients connected to export are disrupted. Before making changes, the service must be stopped and then restarted when complete. Stopping the service disrupts clients relying on the service. |
+| iSCSI | `iscsi.global.update` | All iSCSI clients (e.g. ALUA toggle, basename changes, etc.) that likely require client-side modifications are disrupted. For example, if ALUA is enabled, we serve targets on different IPs than when it is not enabled. Clients have to be reconfigured. Before making changes, the service must be stopped and then restarted when complete. Stopping the service disrupts clients relying on the service. |
+| iSCSI configurations |  | Changes to previously used iSCSI configurations are disrupted. Making changes to the iSCSI configuration requires stopping and restarting the iSCSI service. Before making changes, the service must be stopped and then restarted when complete. Stopping the service disrupts clients relying on the service. |
+| iSCSI portal | `iscsi.portal.update`<br>`iscsi.portal.delete` | Updating existing targets to use the portal, or deleting targets using the portal disrupts access. Before making changes, the service must be stopped and then restarted when complete. Stopping the service disrupts clients relying on the service. |
+| iSCSI initiator | `iscsi.initiator.update`<br>`iscsi.initiator.delete` | Updates to targets configured to use the initiator, or deleting targets using the initiator disrupt access. Before making changes, the service must be stopped and then restarted when complete. Stopping the service disrupts clients relying on the service.. |
+| iSCSI auth | `iscsi.auth.update`<br>`iscsi.auth.delete` | Updating targets configured to use configured authentication (cannot call `iscsi.auth.delete` while used) disrupts access. Updates might require client configuration. Before making changes, the service must be stopped and then restarted when complete. Stopping the service disrupts clients relying on the service. |
+| iSCSI auth | `iscsi.discoveryauth.create`<br>`iscsi.discoveryauth.update`<br>`iscsi.discoveryauth.delete` | Changes to all targets disrupt access. Before making changes, the service must be stopped and then restarted when complete. Stopping the service disrupts clients relying on the service. |
+| iSCSI other APIs | `iscsi.target.update` | Changes only impact the target modified. Before making changes, the service must be stopped and then restarted when complete. Stopping the service disrupts clients relying on the service. |
+| All services | Starts and restarts | Starting, stopping, and restarting any service disrupts clients relying on the service. Before making changes, the service must be stopped and then restarted when complete. Stopping the service disrupts clients relying on the service. |
+{{< /truetable >}}
+{{< /expand >}}


### PR DESCRIPTION
This PR creates a snippet with a list of disruptive administrator actions and adds it to the /gettingstarted/confiig/UIConfigurationSCALE>md, 
SCALEtutorials/network/_index.md, 
SCALEtutorials/shares/_index.md and /shares/iscsi/_index.md 
SCALEtutorials/systemsettings/services/_index.md
files.

Backport to 24.10


Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
