### PR TITLE
Brighten dark mode text a little to improve readability (master branch; backports needed)

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -2031,10 +2031,12 @@ pre.gdoc-mermaid.mermaid.mermaid_sizing {
 }
 :root[color-theme='dark'] {
   --enterprise-title: rgb(52, 58, 64); /* Define --enterprise-title for the dark theme */
+  --body-font-color: #f0f3f5;
 }
 @media (prefers-color-scheme: dark) {
   :root {
     --enterprise-title: rgb(52, 58, 64); /* Define --enterprise-title for devices preferring dark mode */
+	--body-font-color: #f0f3f5;
   }
 }
 @media (prefers-color-scheme: light) {


### PR DESCRIPTION
Had a request come in to brighten the off-white text a little more in dark mode so there would be a starker contrast. Made the adjustment for the variable --body-font-color only in dark mode and automatic dark mode selectors. Please review and send feedback. If this change is good to merge, then we'll backport to the other active branches too.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
