### PR TITLE
(24.10) Add extra note about get_name fix

### DIFF
--- a/content/GettingStarted/SCALEReleaseNotes.md
+++ b/content/GettingStarted/SCALEReleaseNotes.md
@@ -162,6 +162,7 @@ Remove midclt call from 24.10.1 known issues if [NAS-132914](https://ixsystems.a
 iXsystems is pleased to release TrueNAS 24.10.1!
 This is a maintenance release and includes refinement and fixes for issues discovered after the 24.10.0 and 24.10.0.X releases.
 
+* Fix issue with zpl_get_name ([NAS-132930](https://ixsystems.atlassian.net/browse/NAS-132930)). This can improve performance in some specific NFS workloads (see the upstream [OpenZFS pull request](https://github.com/openzfs/zfs/pull/16833/files)).
 * Rework Dashboard CPU widgets to show metrics per physical core ([NAS-131839](https://ixsystems.atlassian.net/browse/NAS-131839)).
 * Prevent incorrect translation of LDAP Base DN to kerberos realm ([NAS-132192](https://ixsystems.atlassian.net/browse/NAS-132192)).
 * Increase the maximum permitted Samba (SMB) ACL size from 64 to 1024 entries ([NAS-132344](https://ixsystems.atlassian.net/browse/NAS-132344)).


### PR DESCRIPTION
This has a performance implication for some edge case NFS uses, so adding to release notes list.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
