### PR TITLE
Fix up aliases on 23.10 apps index

### DIFF
--- a/content/SCALETutorials/Apps/_index.md
+++ b/content/SCALETutorials/Apps/_index.md
@@ -4,33 +4,32 @@ description: "Expanding TrueNAS SCALE functionality with additional applications
 geekdocCollapseSection: true
 weight: 100
 aliases:
- - /scale/scaletutorials/apps/usingapps/
- - /scale/scaleuireference/apps/usingapps/
- - /scale/apps/usingapps/
- - /scale/scaletutorials/apps/usingcatalogs/
- - /scale/scaletutorials/apps/usingcustomapp/
- - /scale/scaletutorials/apps/appsadvancedsettings/
- - /scale/scaletutorials/apps/communityapps/
- - /scale/scaletutorials/apps/communityapps/chia/
- - /scale/scaletutorials/apps/communityapps/collabora/
- - /scale/scaletutorials/apps/communityapps/ddns-updater/
- - /scale/scaletutorials/apps/communityapps/addstorjnode/
- - /scale/scaletutorials/apps/communityapps/prometheusapp/
- - /scale/scaletutorials/apps/communityapps/installwgeasyapp/
- - /scale/scaletutorials/apps/communityapps/minioapp/
- - /scale/scaletutorials/apps/communityapps/minioapp/miniomanualupdate/
- - /scale/scaletutorials/apps/communityapps/minioapp/minioclustering/
- - /scale/scaletutorials/apps/communityapps/installnetdataapp/
- - /scale/scaletutorials/apps/communityapps/installnextcloudmedia/
- - /scale/scaletutorials/apps/communityapps/installpiholeapp/
- - /scale/scaletutorials/apps/communityapps/tftp-hpaapp/
- - /scale/scaletutorials/apps/communityapps/webdav/
- - /scale/scaletutorials/apps/communityapps/syncthingcharts/
- - /scale/scaletutorials/apps/enterpriseapps/
- - /scale/scaletutorials/apps/enterpriseapps/minio/
- - /scale/scaletutorials/apps/enterpriseapps/minio/configminioenterprisemnmd/
- - /scale/scaletutorials/apps/enterpriseapps/minio/configminioenterprisesnmd/
- - /scale/scaletutorials/apps/enterpriseapps/syncthing/
+ - /scaletutorials/apps/usingapps/
+ - /scaleuireference/apps/usingapps/
+ - /scaletutorials/apps/usingcatalogs/
+ - /scaletutorials/apps/usingcustomapp/
+ - /scaletutorials/apps/appsadvancedsettings/
+ - /scaletutorials/apps/communityapps/
+ - /scaletutorials/apps/communityapps/chia/
+ - /scaletutorials/apps/communityapps/collabora/
+ - /scaletutorials/apps/communityapps/ddns-updater/
+ - /scaletutorials/apps/communityapps/addstorjnode/
+ - /scaletutorials/apps/communityapps/prometheusapp/
+ - /scaletutorials/apps/communityapps/installwgeasyapp/
+ - /scaletutorials/apps/communityapps/minioapp/
+ - /scaletutorials/apps/communityapps/minioapp/miniomanualupdate/
+ - /scaletutorials/apps/communityapps/minioapp/minioclustering/
+ - /scaletutorials/apps/communityapps/installnetdataapp/
+ - /scaletutorials/apps/communityapps/installnextcloudmedia/
+ - /scaletutorials/apps/communityapps/installpiholeapp/
+ - /scaletutorials/apps/communityapps/tftp-hpaapp/
+ - /scaletutorials/apps/communityapps/webdav/
+ - /scaletutorials/apps/communityapps/syncthingcharts/
+ - /scaletutorials/apps/enterpriseapps/
+ - /scaletutorials/apps/enterpriseapps/minio/
+ - /scaletutorials/apps/enterpriseapps/minio/configminioenterprisemnmd/
+ - /scaletutorials/apps/enterpriseapps/minio/configminioenterprisesnmd/
+ - /scaletutorials/apps/enterpriseapps/syncthing/
 tags:
 - scaleapps
 - scaledocker


### PR DESCRIPTION
The aliases were added as "/scale/scaletutorials/..." but the way the 23.10 branch is build and deployed means the aliases were covering incorrect locations (truenas.com/docs/scale/23.10/scale/scaletutorials/...) instead of the desired locations (truenas.com/docs/scale/23.10/scaletutorials/...)



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
