### PR TITLE
Update 25.04-BETA.1 anticipated release day

### DIFF
--- a/data/properties/scale-releases.yaml
+++ b/data/properties/scale-releases.yaml
@@ -39,7 +39,7 @@ majorVersions:
       - name: "25.04-BETA.1"
         type: "Early"
         link: ""
-        releaseDate: "2025-02-11"
+        releaseDate: "2025-02-13"
         latest: false
       - name: "25.04-RC.1"
         type: "Early"


### PR DESCRIPTION
adjusted to Feb 13 after review.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
