### PR TITLE
PD-1805 / 24.10 / Update credentials > Samba Authentication field name (24.10 branch)

### DIFF
--- a/content/GettingStarted/Configure/SetUpSharing.md
+++ b/content/GettingStarted/Configure/SetUpSharing.md
@@ -38,7 +38,7 @@ See [Using Administration Logins]({{< relref "AdminRoles.md" >}}) for more infor
 To add non-SMB share users or edit users, go to **Credentials > Users** to add or edit the user(s).
 Click **Add** to create a new or as many new user accounts as you need.
 
-Enter the values in each required field, verify **Samba Authentication** is selected for SMB share users, then click **Save**.
+Enter the values in each required field, verify **SMB User** is selected for SMB share users, then click **Save**.
 For more information on the fields and adding users, see [Creating User Accounts]({{< relref "ManageLocalUsersScale.md" >}}).
 
 By default, all new users are members of a built-in group called **builtin_users**.

--- a/content/SCALETutorials/Credentials/ManageLocalGroups.md
+++ b/content/SCALETutorials/Credentials/ManageLocalGroups.md
@@ -40,7 +40,7 @@ You can only use the dollar sign ($) as the last character in a group name.
 
 {{< include file="/static/includes/AdminSudo.md" >}}
 
-To allow Samba permissions and authentication to use this group, select **Samba Authentication**.
+To allow Samba permissions and authentication to use this group, select **SMB Group**.
 
 To allow more than one group to have the same group ID (not recommended), select **Allow Duplicate GIDs**.
 Use only if absolutely necessary, as duplicate GIDs can lead to unexpected behavior.

--- a/content/SCALETutorials/Shares/SMB/_index.md
+++ b/content/SCALETutorials/Shares/SMB/_index.md
@@ -77,7 +77,7 @@ To add users or edit users, go to **Credentials > Users** to add or edit the SMB
 Click **Add** to create a new or as many new user accounts as needed.
 If joined to Active Directory, Active Directory can create the TrueNAS accounts.
 
-Enter the values in each required field, verify **Samba Authentication** is selected, then click **Save**.
+Enter the values in each required field, verify **SMB User** is selected, then click **Save**.
 For more information on the fields and adding users, see [Creating User Accounts]({{< relref "ManageLocalUsersScale.md" >}}).
 
 By default, all new users are members of a built-in group called **builtin_users**.

--- a/content/SCALEUIReference/Credentials/LocalGroupsScreens.md
+++ b/content/SCALEUIReference/Credentials/LocalGroupsScreens.md
@@ -45,7 +45,7 @@ Click **Add** to open the **Add Group** configuration screen.
 | **Allow all sudo commands** | Select to give group members permission to use all [sudo](https://www.sudo.ws/) commands. Using sudo prompts the user for their account password. |
 | **Allowed sudo commands with no password** | Use to list specific [sudo](https://www.sudo.ws/) commands allowed for group members with no password required. Enter each command as an absolute path to the ELF (Executable and Linkable Format) executable file, for example */usr/bin/nano*. <file>/usr/bin/</file> is the default location for commands. <br> Grants limited root-like permissions for group members when using these commands. Exercise caution when allowing sudo commands without password prompts. It is recommended to limit this privilege to trusted users and specific commands to minimize security risks. |
 | **Allow all sudo commands with no password** | Not recommended. Select to give group members the ability to use all [sudo](https://www.sudo.ws/) commands with no password required. |
-| **Samba Authentication** | Select to allow this group to authenticate to and access data shares with [SMB]({{< relref "/SCALETutorials/Shares/_index.md" >}}) samba shares. |
+| **SMB Group** | Select to allow this group to authenticate to and access data shares with [SMB]({{< relref "/SCALETutorials/Shares/_index.md" >}}) samba shares. |
 | **Allow Duplicate GIDs** | Not recommended. Select to allow more than one group to have the same group ID. Use only if absolutely necessary, as duplicate GIDs can lead to unexpected behavior. |
 {{< /truetable >}}
 


### PR DESCRIPTION
After reviewing a 24.10 environment, I confirmed that the field was renamed to SMB User for User Credentials and SMB Group for Group Credentials. Did a bulk search for the obsolete term and updated each instance that I found.

Local build testing found no issues.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
