### PR TITLE
PD-1792 / 24.10 / find and fix outdated references to password login toggles in the SSH Service screen (24.10)

### DIFF
--- a/content/SCALETutorials/SystemSettings/Advanced/ManageGlobal2FASCALE.md
+++ b/content/SCALETutorials/SystemSettings/Advanced/ManageGlobal2FASCALE.md
@@ -25,7 +25,7 @@ You can use other authenticator applications, but you must confirm the settings 
 
 {{< hint type=important >}}
 Two-factor authentication is time-based and requires a correct system time setting.
-Ensure Network Time Protocol (NTP) is functional before enabling two-factor authentication is strongly recommended!
+We strongly recommend ensuring Network Time Protocol (NTP) is functional before enabling two-factor authentication!
 {{< /hint >}}
 
 {{< expand "What is 2FA and why should I enable it?" "v" >}}
@@ -66,7 +66,7 @@ Before you begin, download Google Authenticator to your mobile device.
    TrueNAS takes you to the **Two-Factor Authentication** screen to finish 2FA setup.
 
    You can also access the two-factor authentication settings for the currently logged-in user from the **Settings** option on the top toolbar.
-   Click on the **Settings** icon, then select **Two-Factor Authentication** to open the **User Two-Factor Authentication Actions** screen.
+   Click the **Settings** icon, then select **Two-Factor Authentication** to open the **User Two-Factor Authentication Actions** screen.
 
    {{< trueimage src="/images/SCALE/SystemSettings/UserTwoFactorAuthenticationActionsScreen.png" alt="User Two-Factor Authentication Actions Screen" id="User Two-Factor Authentication Actions Screen" >}}
 
@@ -97,7 +97,7 @@ To change the system-generated **Secret**, click on the **Settings** icon on the
 Click **Renew 2FA Secret**.
 
 ## Using 2FA to Log in to TrueNAS
-Enabling 2FA changes the log in process for both the TrueNAS web interface and SSH logins.
+Enabling 2FA changes the login process for both the TrueNAS web interface and SSH logins.
 
 ### Logging In Using the Web Interface
 The login screen adds another field for the randomized authenticator code. If this field is not immediately visible, try refreshing the browser.
@@ -106,7 +106,7 @@ Enter the code from the mobile device (without the space) in the login window an
 
 {{< trueimage src="/images/SCALE/Login/2faSigninSplashScreen.png" alt="2FA Signin Splash Screen" id="2FA Splash Screen" >}}
 
-If you wait too long, a new number code displays in Google Authenticator, so you can retry.
+If you wait too long, a new number code displays in Google Authenticator so you can retry.
 
 ### Logging In Using SSH
 1. Confirm that you set **Enable Two-Factor Auth for SSH** in **System > Advanced > Global Two Factor Authentication**.

--- a/content/SCALETutorials/SystemSettings/Advanced/ManageGlobal2FASCALE.md
+++ b/content/SCALETutorials/SystemSettings/Advanced/ManageGlobal2FASCALE.md
@@ -111,12 +111,10 @@ If you wait too long, a new number code displays in Google Authenticator, so you
 ### Logging In Using SSH
 1. Confirm that you set **Enable Two-Factor Auth for SSH** in **System > Advanced > Global Two Factor Authentication**.
 
-2. Go to **System > Services** and edit the **SSH** service.
+2. Go to **Credentials > Users** and edit the desired user account. Set **SSH password login enabled**, then click **Save**.
 
-   a. Set **Log in as Admin with Password**, then click **Save**.
+3. Go to **System Settings > Services** and click the **SSH** toggle. Wait for the service status to show that it is running.
 
-   b. Click the **SSH** toggle and wait for the service status to show that it is running.
+4. Open the Google Authentication app on your mobile device.
 
-3. Open the Google Authentication app on your mobile device.
-
-4. Open a terminal (such as Windows Shell) and SSH into the system using either the host name or IP address, the administrator account user name and password, and the 2FA code.
+5. Open a terminal (such as Windows Shell) and SSH into the system using either the host name or IP address, the administrator account user name and password, and the 2FA code.

--- a/static/includes/BasicReplicationProcess.md
+++ b/static/includes/BasicReplicationProcess.md
@@ -7,7 +7,7 @@ Ensure the account configuration has **SSH password login enabled** set.
 
 Remote replication requires setting up an [SSH connection]({{< relref "AddSSHConnectionKeyPair.md" >}}) in TrueNAS before creating a remote replication task.
 
-Verify the SSH service settings to ensure **Allow Password Authentication** selected to enable these capabilities.
+Verify the SSH service settings and ensure **Allow Password Authentication** is selected to enable these capabilities.
 Incorrect SSH service settings can impact the admin user ability to establish an SSH session during replication and require you to obtain and paste a public SSH key into the admin user settings.
 
 Replication tasks typically require a configured and active [periodic snapshot task]({{< relref "PeriodicSnapshotTasksSCALE.md" >}}).

--- a/static/includes/BasicReplicationProcess.md
+++ b/static/includes/BasicReplicationProcess.md
@@ -2,12 +2,12 @@
 
 ### Prerequisites
 Before setting up a replication task, you must configure an [admin user]({{< relref "ManageLocalUsersSCALE.md" >}}) with the **Home Directory** set to something other than **/var/empty**.
-
-**Allow all sudo commands with no password** must be selected to enable SSH+NETCAT remote replication.
+Ensure the account configuration has **SSH password login enabled** set.
+**Allow all sudo commands with no password** must also be enabled to enable SSH+NETCAT remote replication.
 
 Remote replication requires setting up an [SSH connection]({{< relref "AddSSHConnectionKeyPair.md" >}}) in TrueNAS before creating a remote replication task.
 
-Verify the SSH service settings to ensure you have **Root with Password**, **Log in as Admin with Password**, and **Allow Password Authentication** selected to enable these capabilities.
+Verify the SSH service settings to ensure **Allow Password Authentication** selected to enable these capabilities.
 Incorrect SSH service settings can impact the admin user ability to establish an SSH session during replication and require you to obtain and paste a public SSH key into the admin user settings.
 
 Replication tasks typically require a configured and active [periodic snapshot task]({{< relref "PeriodicSnapshotTasksSCALE.md" >}}).


### PR DESCRIPTION
Update to reflect where this option now exists in the Credentials > Users add/edit form.
Will review 25.04 and master branches too.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
