### PR TITLE
Add cli warning

### DIFF
--- a/static/includes/IncusExperimental.md
+++ b/static/includes/IncusExperimental.md
@@ -4,3 +4,6 @@
 Functionality could change significantly between releases, and instances might not upgrade reliably.
 Use this feature for testing purposes only&mdash;do not rely on it for production workloads.
 Long-term stability is planned for future TrueNAS Community Edition releases.
+
+Make all configuration changes using the TrueNAS UI.
+Operations using the command line are not supported and might not persist on upgrade.

--- a/static/includes/InstanceWarning.md
+++ b/static/includes/InstanceWarning.md
@@ -2,7 +2,4 @@
 
 {{< hint type=warning title="Experimental Feature" >}}
 {{< include file="/static/includes/IncusExperimental.md" >}}
-
-Make all configuration changes using the TrueNAS UI.
-Operations using the command line are not supported.
 {{< /hint >}}


### PR DESCRIPTION
Reorganizes the warning about UI-only Incus support so it appears in the release notes

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
