### PR TITLE
PD-1802 / 25.04 / PD-1802 Add iSCSI info to MigratePrep.md

### DIFF
--- a/content/GettingStarted/Migrate/MigratePrep.md
+++ b/content/GettingStarted/Migrate/MigratePrep.md
@@ -26,7 +26,9 @@ For more information on using USB drives and devices in general, read the [Hardw
 If you must use a USB type device, verify you can access files on the device before you migrate.
 {{< /hint >}}
 {{< enterprise >}}
-Enterprise customers are encouraged to contact Support for assistance with the process of moving from a FreeBSD-based (13.3 or earlier) to a Linux-based (22.12 or newer) TrueNAS version, especially customers with HA systems.
+Enterprise customers are strongly encouraged to contact Support for assistance with the process of moving from a FreeBSD-based (13.3 or earlier) to a Linux-based (22.12 or newer) TrueNAS version, especially customers with HA systems with iSCSI shares. Enterprise customers should not attempt to migrate their HA systems with iSCSI on their own!
+Enterprise systems with iSCSI deployments require complex, special preparation and migration steps executed before and after migration to ensure data integrity.
+Please contact Support for assistance!
 {{< /enterprise >}}
 
 1. Upgrade your system to either the latest 13.0 or 13.3 release.
@@ -67,6 +69,12 @@ Enterprise customers are encouraged to contact Support for assistance with the p
    <input type="checkbox"> Credentials - Copy or write down the credentials for SSH connections and keypairs, and any configured cloud service backup providers if you do not have the credential settings saved in other files kept secured outside of TrueNAS.
 
    <input type="checkbox"> Data protection tasks - Write down or take screenshots of replication, periodic snapshot, cloud sync, or other task settings to reconfigure these after migrating.
+
+   Community users with iSCSI deployments can migrate their systems without assistance. Note, unlike FreeBSD systems, Linux Debian systems require at least one LUN set to zero.
+   iSCSI portals in Linux Debian-based systems are defined globally instead of per port.
+
+   Enterprise systems with iSCSI shares deployments have special requirements, preparation and migration steps to ensure data integrity and a smooth migration.
+   Other iSCSI differences only apply to Enterprise High Availability (HA) systems. Enterprise users **must** contact TrueNAS Customer Support for assistance with their migrations!
 
 5. Remove all SMB auxiliary parameter settings before migrating.
    In TrueNAS 23.10 (Cobia) or newer, the SMB **Auxiliary Parameters** option is not available in the UI.

--- a/content/GettingStarted/Migrate/MigratePrep.md
+++ b/content/GettingStarted/Migrate/MigratePrep.md
@@ -26,14 +26,14 @@ For more information on using USB drives and devices in general, read the [Hardw
 If you must use a USB type device, verify you can access files on the device before you migrate.
 {{< /hint >}}
 {{< enterprise >}}
-Enterprise customers are strongly encouraged to contact Support for assistance with the process of moving from a FreeBSD-based (13.3 or earlier) to a Linux-based (22.12 or newer) TrueNAS version, especially customers with HA systems with iSCSI shares. Enterprise customers should not attempt to migrate their HA systems with iSCSI on their own!
-Enterprise systems with iSCSI deployments require complex, special preparation and migration steps executed before and after migration to ensure data integrity.
+We strongly encourage Enterprise customers to contact Support for assistance moving from a FreeBSD-based (13.3 or earlier) to a Linux-based (22.12 or newer) TrueNAS version, especially customers with HA systems using iSCSI shares or fibre channel. Enterprise customers should not attempt to migrate their HA systems with iSCSI or fibre channel on their own!
+Enterprise systems with iSCSI and fibre channel deployments require complex, special preparation and migration steps executed before and after migration to ensure data integrity.
 Please contact Support for assistance!
 {{< /enterprise >}}
 
 1. Upgrade your system to either the latest 13.0 or 13.3 release.
-   TrueNAS Enterprise-licensed (or community systems that haven't switched to 13.3) systems on 12.0x or earlier should upgrade to the latest 13.0 release (e.g 13.0-U6.2 or newer) prior to migration.
-   Community users with 13.3 installed should update to the latest maintenance release of that version prior to migration.
+   TrueNAS Enterprise-licensed (or community systems that haven't switched to 13.3) systems on 12.0x or earlier should upgrade to the latest 13.0 release (e.g. 13.0-U6.2 or newer) before migration.
+   Community users with 13.3 installed should update to the latest maintenance release of that version before migration.
    Either major version can use the [iso upgrade](#migrating-using-an-iso-file-to-upgrade) method for migration.
 
 2. Migrate [GELI-encrypted pools](https://www.truenas.com/docs/core/13.0/coretutorials/storage/pools/storageencryption/#geli-pool-migrations) to a non-GELI-encrypted pool before upgrading from TrueNAS 12.0x or earlier releases!
@@ -50,7 +50,7 @@ Please contact Support for assistance!
 
    <input type="checkbox"> Deprecated services - Record the settings for [services deprecated in newer TrueNAS versions](#deprecated-services).
 
-   <input type="checkbox"> VMs - If you have virtual machines configured, write down or screenshot network, bootloader, and other setting information.
+   <input type="checkbox"> VMs - If you have virtual machines configured, write down or screenshot the network, bootloader, and other setting information.
 
    <input type="checkbox"> Plugins or jails - Plugins and jails do not migrate. Record settings for each plugin/jail and back up the data associated with each.
 
@@ -100,7 +100,7 @@ Please contact Support for assistance!
 8. Back up any critical data.
 
 9. Download your [system configuration file](https://www.truenas.com/docs/core/coretutorials/systemconfiguration/usingconfigurationbackups/) and a [debug file](https://www.truenas.com/docs/core/uireference/system/advanced/).
-   After updating to the latest publicly-available release of TrueNAS 13.0 (or 13.3 for community users) and making any changes to user accounts or any other settings, download these files and keep them in a safe place and where you can access them if you need to revert with a clean install using the TrueNAS 13.0 or 13.3 <file>iso</file> file.
+   After updating to the latest publicly available release of TrueNAS 13.0 (or 13.3 for community users) and making any changes to user accounts or any other settings, download these files and keep them in a safe place and where you can access them if you need to revert with a clean install using the TrueNAS 13.0 or 13.3 <file>iso</file> file.
 
 After completing the steps listed above that apply to your existing system, download the latest [TrueNAS 24.04 ISO file](https://www.truenas.com/download-tn-scale/) and save it to your computer.
 See [Software Releases](https://www.truenas.com/docs/softwarereleases/#upgrade-paths) for current recommended update paths to make sure you download and migrate to and from the correct TrueNAS versions.
@@ -165,10 +165,10 @@ Disable both the WebDAV share and service.
 Also disable the **Start Automatically** option to prevent the service from re-enabling after a system restart.
 
 Review any existing WebDAV service authentication settings.
-Take note of all IP addresses, port numbers, URLs and credentials (username and password).
+Take note of all IP addresses, port numbers, URLs, and credentials (username and password).
 
 Remove any existing WebDAV shares. Go to **Shares > WebDAV** and use **Edit** to view any existing configurations.
-Take note of the share name, path, and read only settings. Delete the WebDAV share configuration.
+Take note of the share name, path, and read-only settings. Delete the WebDAV share configuration.
 
 In Bluefin:
 To grant access to a specific user (and group) other than using the default admin user UID and GID, add a new non-root administrative user for the share(s).


### PR DESCRIPTION
This commit and PR adds only the iSCSI cautions and information to the 25.04 branch article, and the strong encouragement that Enterprise customers contact support for assistance.

This is the backport of the 25.10 content with what applies in 25.04

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
