### PR TITLE
Add small groupings to TrueNAS version selector (13.3 cleanup)

### DIFF
--- a/layouts/partials/docs-nav.html
+++ b/layouts/partials/docs-nav.html
@@ -212,20 +212,34 @@
     
       if (product === 'TrueNAS') {
         versionDropdown.innerHTML = `
-		  <small>Next</small>
-		  <hr style="background-color: white; width: 90%; border: none; height: 1px;">
-          <div class="truenas-dropdown-item" onclick="selectVersion('scale-nightly')" id="scale-nightly">25.10</div>
-		  <div class="truenas-dropdown-item" onclick="selectVersion('25.04')" id="2504">25.04</div>
-		  <small>Current</small>
-		  <hr style="background-color: white; width: 90%; border: none; height: 1px;">
-          <div class="truenas-dropdown-item" onclick="selectVersion('24.10')" id="2410">24.10</div>
-		  <small>Previous</small>
-		  <hr style="background-color: white; width: 90%; border: none; height: 1px;">
-          <div class="truenas-dropdown-item" onclick="selectVersion('24.04')" id="2404">24.04</div>
-          <div class="truenas-dropdown-item" onclick="selectVersion('13.3')" id="13.3">13.3</div>
-          <div class="truenas-dropdown-item" onclick="selectVersion('13.0')" id="13">13.0</div>
-		  <hr style="background-color: white; width: 90%; border: none; height: 1px;">
-          <div class="truenas-dropdown-item" onclick="selectVersion('Archive')" id="Archive">Archive</div>
+          <div class="truenas-version-group">
+            <div class="version-header">
+              <small class="version-label">Next</small>
+              <hr class="version-line">
+            </div>
+            <div class="truenas-dropdown-item" onclick="selectVersion('scale-nightly')" id="scale-nightly">25.10</div>
+            <div class="truenas-dropdown-item" onclick="selectVersion('25.04')" id="2504">25.04</div>
+          </div>
+          <div class="truenas-version-group">
+            <div class="version-header">
+              <small class="version-label">Current</small>
+              <hr class="version-line">
+            </div>
+            <div class="truenas-dropdown-item" onclick="selectVersion('24.10')" id="2410">24.10</div>
+          </div>
+          <div class="truenas-version-group">
+            <div class="version-header">
+              <small class="version-label">Previous</small>
+              <hr class="version-line">
+            </div>
+            <div class="truenas-dropdown-item" onclick="selectVersion('24.04')" id="2404">24.04</div>
+            <div class="truenas-dropdown-item" onclick="selectVersion('13.3')" id="13.3">13.3</div>
+            <div class="truenas-dropdown-item" onclick="selectVersion('13.0')" id="13">13.0</div>
+          </div>
+          <div class="truenas-version-group">
+            <hr class="no-version-line">
+            <div class="truenas-dropdown-item" onclick="selectVersion('Archive')" id="Archive">Archive</div>
+          </div>
         `;
       } else if (product === 'TrueCommand') {
         versionDropdown.innerHTML = `

--- a/static/custom.css
+++ b/static/custom.css
@@ -2383,3 +2383,57 @@ pre.gdoc-mermaid.mermaid.mermaid_sizing {
     text-align: center;
 }
 /* End style for Logo and Icon*/
+
+/* Styling for Community Edition and Enterprise logos */
+.edition-logo {
+    height: 24px !important;
+    vertical-align: middle !important;
+  }
+
+  .no-highlight-table table {
+    background: transparent !important; /* Prevents colored highlights */
+    border-collapse: collapse;
+    width: 100%;
+  }
+  
+  .no-highlight-table th, .no-highlight-table td {
+    border: 1px solid #ddd; /* Light border for readability */
+    padding: 8px;
+    text-align: left;
+  }
+  
+  .no-highlight-table tr:nth-child(even) {
+    background: transparent !important; /* Removes alternating row colors */
+  }
+  
+/* Styling for Version Selector Sections */
+
+.version-header {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: 5px;
+  }
+  
+  .version-label {
+    flex-shrink: 0;
+    font-size: 0.9em;
+    color: white;
+    line-height: 1;
+  }
+  
+  .version-line {
+    flex-grow: 1;
+    height: 1px;
+    border-top: 1px solid white;
+    margin-left: 5px;
+  }
+
+  .no-version-line {
+    flex-grow: 1;
+    height: 1px;
+    border-top: 1px solid white;
+    margin: 0 5px;
+  }
+
+/* End Styling for Version Selector Sections */


### PR DESCRIPTION
* PD-1825: add small groupings to TrueNAS version selector (backports needed)

Add a small horizontal rule element and text descriptor.

* additional styling

* adjust line height and add archive div

---------



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
