### PR TITLE
PD-1853 / 13.0 / PD-1853 Fix Command in line 23 of NPIV.md Snippet

### DIFF
--- a/static/includes/NPIV.md
+++ b/static/includes/NPIV.md
@@ -20,7 +20,7 @@ Refer to your switch documentation for details on how to configure zoning of vir
 To create virtual ports on the TrueNAS system, go to **System > Tunables** and click **ADD**.
 Enter these options:
 
-* **Variable** - Enter <code>input hint.isp.<i>X</i>.vports</code>, where *X* is the number of the physical interface.
+* **Variable** - Enter <code>hint.isp.<i>X</i>.vports</code>, where *X* is the number of the physical interface.
 * **Value** - Enter the number of virtual ports to create. 
   The maximum number of target ports is 125 SCSI target ports, including all physical Fibre Channel ports, all virtual ports, and all configured combinations of iSCSI portals and targets.
 * **Type** - Select **loader**. Reboot each node in HA.


### PR DESCRIPTION
The command in line 23 does not set up the virtual port. Removing the word "input" from the command fixes this command. Change tested and verified.

Backport this change to 13.3

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
