### PR TITLE
PD-1859 / 25.10 / Pd 1859 zfscapacitycalculator doesnt show with dark mode

### DIFF
--- a/layouts/shortcodes/capacity_calculator.html
+++ b/layouts/shortcodes/capacity_calculator.html
@@ -133,7 +133,7 @@
     </tr>
 
     <tr>
-        <td><label id="disk_afr_label" for="disk_afr">Disk AFR (%):</label></td>
+        <td><label for="disk_afr">Disk AFR (%):</label></td>
         <td><input class="monitor" type="text" id="disk_afr" name="disk_afr" value="5" disabled></td>
         
         <td> </td>
@@ -143,15 +143,15 @@
     </tr>
 
     <tr>
-        <td><label id="allow_resilver_label" for="allow_resilver">Assume Resilver:</label></td>
+        <td><label for="allow_resilver">Assume Resilver:</label></td>
         <td><input class="monitor" type="checkbox" id="allow_resilver" name="allow_resilver" disabled checked></td>
         
-        <td id="res_label"><label id="reservation" for="reservation">Reservation (%):</label></td>
+        <td id="res_label"><label for="reservation">Reservation (%):</label></td>
         <td id="res_input"><input class="monitor" type="text" id="reservation" name="reservation" value="20" disabled></td>
     </tr>
 
     <tr>
-        <td  style="vertical-align: top;"><label id="resilver_time_label" for="resilver_time" >Resilver Time (hrs):</label></td>
+        <td  style="vertical-align: top;"><label for="resilver_time" >Resilver Time (hrs):</label></td>
         <td style="vertical-align: top;"><input class="monitor" type="text" id="resilver_time" name="resilver_time" value="48" disabled></td>
         
         <td id="reset_button" style="vertical-align: top;"><button type="button" id="reset_button">Reset</button></td>

--- a/static/custom.css
+++ b/static/custom.css
@@ -1592,8 +1592,15 @@ a.section-box:hover {
 }
 /* Adjust input elements for calculator */
 .monitor {
-    color: var(--body-font-color); /* Adjust text color as needed */
-  } 
+    color: var(--body-font-color);
+    background-color: var(--body-background);
+  }
+input[type='radio']  {
+    accent-color: #0095d5;
+}
+input[type='checkbox']  {
+    accent-color: #0095d5;
+}
 /* End Adjust input elements for calculator */
 
 /* Style for tables with class "inputs" */


### PR DESCRIPTION
Quick styling changes to make calculator work better with the docs hub light/dark mode selector and some small improvements

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
