### PR TITLE
Add two additional auth methods that are disabled in STIG mode

### DIFF
--- a/content/SCALE/SCALETutorials/SystemSettings/Advanced/_index.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Advanced/_index.md
@@ -122,7 +122,7 @@ When STIG (and FIPS) are enabled:
 * TrueNAS cannot issue API keys and existing API keys cannot be used for authentication. Only the user credential with two-factor authentication method is accepted.
 * SSH log-ins require a cryptographic algorithm.
 * SMB authentication for local TrueNAS accounts is disabled.
-* NTLM authentication passthrough to a Domain Controller is disabled.
+* NTLM authentication passthrough to a domain controller is disabled.
 * Usage stats are not reported and the **Usage Collection** option is disabled.
 * One-time passwords (OTP) configured for administrative users have a single use and expire after 24 hours.
   After logging in with the OTP, the system prompts the user to immediately change the password and set up two-factor authentication.

--- a/content/SCALE/SCALETutorials/SystemSettings/Advanced/_index.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Advanced/_index.md
@@ -121,6 +121,8 @@ When STIG (and FIPS) are enabled:
 
 * TrueNAS cannot issue API keys and existing API keys cannot be used for authentication. Only the user credential with two-factor authentication method is accepted.
 * SSH log-ins require a cryptographic algorithm.
+* SMB authentication for local TrueNAS accounts is disabled.
+* NTLM authentication passthrough to a Domain Controller is disabled.
 * Usage stats are not reported and the **Usage Collection** option is disabled.
 * One-time passwords (OTP) configured for administrative users have a single use and expire after 24 hours.
   After logging in with the OTP, the system prompts the user to immediately change the password and set up two-factor authentication.


### PR DESCRIPTION
Discussed with Andrew W and found two additional auth methods to consider before enabling STIG/FIPS.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
