### PR TITLE
PD-1914 / 25.10 / PD-1914 Correct Time Conversion in Session Settings

### DIFF
--- a/content/SCALE/SCALEUIReference/SystemSettings/AdvancedSettingsScreen.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/AdvancedSettingsScreen.md
@@ -263,7 +263,8 @@ Enter the value in seconds.
 {{< hint type=tip >}}
 The default lifetime setting is 300 seconds or five minutes.
 
-The maximum is 2147482 seconds or 24 days, 20 hours, 31 minutes, and 22 seconds.
+The maximum is 2147482 seconds or converting it to hours/minutes/seconds, 596 hours, 31 minutes, and 22 seconds.
+If converting it to days/hours/minutes/second, 24 days, 20 hours, 31 minutes, and 22 seconds.
 {{< /hint >}}
 
 The **Login Banner** field allows specifying a text message that the system shows before the TrueNAS login splash screen displays.


### PR DESCRIPTION
This commit corrects the time conversion for the maximum number of seconds. Added clarification to what the max seconds converts to if hours/minutes/seconds and if days/hours/minutes/seconds.

This can backport to 25.04. Manually backporting to 24.10 because not all the information in the /SCALEUIReference/SystemSettings/Advanced/_index.md is the same as in 25.10 and 25.40 branches


Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
