### PR TITLE
PD-1914 / 24.10 / PD-1914 Manual Backport of Session Timeout Correction

### DIFF
--- a/content/SCALEUIReference/SystemSettings/AdvancedSettingsScreen.md
+++ b/content/SCALEUIReference/SystemSettings/AdvancedSettingsScreen.md
@@ -239,7 +239,8 @@ Enter the value in seconds.
 {{< hint type=tip >}}
 The default lifetime setting is 300 seconds or five minutes.
 
-The maximum is 2147482 seconds or 24 days, 20 hours, 31 minutes, and 22 seconds.
+The maximum is 2147482 seconds or converting it to hours/minutes/seconds, 596 hours, 31 minutes, and 22 seconds.
+If converting it to days/hours/minutes/second, 24 days, 20 hours, 31 minutes, and 22 seconds.
 {{< /hint >}}
 
 The **Login Banner** field allows specifying a text message the system shows before the TrueNAS login splash screen displays.


### PR DESCRIPTION
This PR is a manual backport of the correction to the session timeout  maximum seconds, showing it converted to hours/minutes/seconds and days/hours/minutes/seconds.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
