### PR TITLE
PD-1994 / 25.10 / PD-1994-Update-App-IP-Support-Lists (by DjP-iX)

### DIFF
--- a/static/includes/AppsHostIP.md
+++ b/static/includes/AppsHostIP.md
@@ -7,31 +7,79 @@ It includes port bind mode options to publish the port for external access or ex
 A small but growing list of applications currently support this functionality in TrueNAS 24.10 or later.
 
 {{< expand "Applications that currently support host IP port binding" "v" >}}
-The following applications currently support host IP port binding.
+All applications added to the TrueNAS Apps catalog after December 24, 2024 support host IP port binding. As of May 9, 2025, these applications include:
 {{< columns >}}
-* calibre-web  
-* esphome  
-* handbrake-web  
-* homearr  
-* invoiceninja  
-* it-tools  
-* jelu  
-* lyrion-music-server  
-* minecraft-bedrock  
+* ArchiSteamFarm  
+* Arti  
+* Authelia  
+* Authentik  
+* Bitcoind  
+* Calibre Web  
+* Change Detection  
+* Channels DVR  
+* Cockpit WS  
+* Code Server  
+* Codegate  
+* Concourse  
+* ConvertX
+* Crafty 4  
+* Dozzle
 
 <--->
 
-* romm  
-* satisfactory-server  
-* steam-headless  
-* terreria  
-* tianji  
-* umami  
-* urbackup  
-* zigbee2mqtt  
-* emby  
+* Duplicati  
+* Electrs  
+* Emby  
+* ESPHome  
+* Flood  
+* Forgejo  
+* Gitea Act Runner  
+* Glances  
+* Handbrake Web  
+* Heimdall  
+* Homearr
+* Homebox  
+* I2P  
+* InfluxDB  
+* Invoice Ninja  
+
+<--->
+
+* IT Tools  
+* IX Remote Assist  
+* Jackett  
+* JDownloader2  
+* Jelu  
+* Karakeep  
+* Kasm Workspaces  
+* Lyrion Music Server  
+* Minecraft Bedrock
+* Open Speed Test  
+* Outline  
+* Playwright  
+* Romm  
+* Satisfactory Server  
+* Scrypted  
+
+<--->
+
+* Spottarr  
+* Steam Headless  
+* Stirling PDF  
+* Terreria  
+* Tianji  
+* TrueNAS WebUI  
+* TVHeadend  
+* Umami  
+* Unmanic  
+* UrBackup  
+* Versity Gateway  
+* Warracker  
+* Windmill  
+* Wyze Bridge  
+* Zigbee2MQTT  
 {{< /columns >}}
-All future applications, as well as those added to the TrueNAS Apps catalog after December 24, 2024, support this feature.
+All applications added after this date also support this feature.
 {{< /expand >}}
 
 However, applications that were in the TrueNAS Apps catalog before implementation of this feature require OS-level changes to enable support.
@@ -41,132 +89,146 @@ The updated versions of these applications do not function on TrueNAS versions e
 {{< expand "Applications that do not currently support host IP port binding" "v" >}}
 
 {{< columns >}}
-* actual-budget  
-* adguard-home  
-* audiobookshelf  
-* autobrr  
-* bazarr  
-* briefkasten  
-* calibre  
-* castopod  
-* chia  
-* clamav  
-* dashy  
-* ddns-updater  
-* deluge  
-* distribution  
-* dockge  
-* drawio  
-* eclipse-mosquitto  
-* filebrowser  
-* filestash  
-* firefly-iii  
-* flame  
-* flaresolverr  
-* freshrss  
-* frigate  
-* fscrawler  
-* gaseous-server  
-* gitea  
-* grafana  
-* handbrake  
+* Actual Budget  
+* Adguard Home  
+* Asigra DS System  
+* Audiobookshelf  
+* Autobrr  
+* Bazarr  
+* Briefkasten  
+* Calibre  
+* Castopod  
+* Chia  
+* ClamAV  
+* Collabora  
+* Dashy  
+* DDNS Updater  
+* Deluge  
+* Diskoverdata  
+* Distribution  
+* Dockge  
+* Drawio  
+* Eclipse Mosquitto  
+* Elastic Search  
+* Emby  
+* Filebrowser  
+* Filestash  
+* Firefly III  
+* Flame  
+* Flaresolverr  
+* FreshRSS  
+* Frigate  
+* FSCrawler  
+* Gaseous Server  
+* Gitea
+
+<--->
   
-<--->  
+* Grafana  
+* Handbrake  
+* Home Assistant  
+* Homepage  
+* Homer  
+* Immich  
+* Invidious  
+* IPFS  
+* IX App (Custom App)  
+* Jellyfin  
+* Jellyseerr  
+* Jenkins  
+* Joplin  
+* Kapowarr  
+* Kavita  
+* Komga  
+* Lidarr  
+* Linkding  
+* Listmonk  
+* Logseq  
+* Mealie  
+* Metube  
+* Minecraft  
+* Minecraft Bedrock  
+* MineOS  
+* Minio  
+* Mumble  
+* N8N  
+* Navidrome  
+* NetbootXYZ  
+* Netdata  
+* Nextcloud  
 
-* homepage  
-* homer  
-* immich  
-* invidious  
-* ipfs  
-* jellyfin  
-* jellyseerr  
-* jenkins  
-* joplin  
-* kapowarr  
-* kavita  
-* komga  
-* lidarr  
-* linkding  
-* listmonk  
-* logseq  
-* mealie  
-* metube  
-* minecraft  
-* mineos  
-* mumble  
-* n8n  
-* navidrome  
-* netbootxyz  
-* nginx-proxy-manager  
-* node-red  
-* odoo  
-* ollama  
-* omada-controller
+<--->
 
-<--->  
+* Nginx Proxy Manager  
+* Node RED  
+* Odoo  
+* Ollama  
+* Omada Controller  
+* Open Speed Test  
+* Open WebUI  
+* Organizr  
+* Outline  
+* Overseerr  
+* Palworld  
+* Paperless NGX  
+* Passbolt  
+* Penpot  
+* PGAdmin  
+* Photoprism  
+* PiGallery2  
+* PiHole  
+* Piwigo  
+* Planka  
+* Plex  
+* Portainer  
+* Postgres  
+* Prometheus  
+* Prowlarr  
+* Qbittorrent  
+* Radarr  
+* Readarr  
+* Redis  
+* Romm  
+* Roundcube  
+* Rsyncd  
 
-* open-webui  
-* organizr  
-* overseerr  
-* palworld  
-* paperless-ngx  
-* passbolt  
-* penpot  
-* pgadmin  
-* pigallery2  
-* piwigo  
-* planka  
-* portainer  
-* postgres  
-* prowlarr  
-* qbittorrent  
-* radarr  
-* readarr  
-* redis  
-* roundcube  
-* rsyncd  
-* rust-desk  
-* sabnzbd  
-* scrutiny  
-* searxng  
-* sftpgo  
-* sonarr  
-* tautulli  
-* tdarr  
-* terraria
+<--->
 
-<--->  
-
-* tftpd-hpa  
-* tiny-media-manager  
-* transmission  
-* twofactor-auth  
-* unifi-controller  
-* uptime-kuma  
-* vaultwarden  
-* vikunja  
-* webdav  
-* whoogle  
-* wordpress  
-* asigra-ds-system  
-* syncthing  
-* collabora  
-* diskoverdata  
-* elastic-search  
-* emby  
-* home-assistant  
-* ix-app (Custom App)
-* minio  
-* netdata  
-* nextcloud  
-* photoprism  
-* pihole  
-* plex  
-* prometheus  
-* storj  
-* wg-easy
+* Rust Desk  
+* Satisfactory Server  
+* Sabnzbd  
+* Scrutiny  
+* SearxNG  
+* Scrypted  
+* SFTPGo  
+* Sonarr  
+* Storj  
+* Syncthing  
+* Tautulli  
+* TDarr  
+* Terraria  
+* TFTPD HPA  
+* Tiny Media Manager  
+* Transmission  
+* TrueNAS WebUI  
+* Twofactor Auth  
+* Unifi Controller  
+* Umami  
+* Uptime Kuma  
+* UrBackup  
+* Vaultwarden  
+* Versitygw  
+* Vikunja  
+* Warracker  
+* WebDAV  
+* WG Easy  
+* Whoogle  
+* Windmill  
+* Wordpress  
+* Wyze Bridge  
+* Zigbee2MQTT  
 {{< /columns >}}
-
+These applications update to support host IP port binding on June 1, 2025.
 {{< /expand >}}
 
 As a result, June 1 is also the cutoff date for two related app behaviors:


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x c8f30614980143d8b9e9e283a06014ef26e7de55
    git cherry-pick -x 0dbda2a7d248086d8521d7d79dce8757b0820709
    git cherry-pick -x 3230ea330cbc848f0e5398481fe90308b7da85cb
    git cherry-pick -x 642d1a3e7031e737f3be4782139f5dd244e330a3

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 851fb26628e9227dbb88986313d1f74cc5d44ecf

Started this as a release notes update, but this update isn't release specific and I think better to release sooner than waiting for 25.04.1

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.


Original PR: https://github.com/truenas/documentation/pull/3809
Jira URL: https://ixsystems.atlassian.net/browse/PD-1994