### PR TITLE
PD-1421: Add references to api.truenas.com and clarify access methods a bit

### DIFF
--- a/content/SCALE/API/_index.md
+++ b/content/SCALE/API/_index.md
@@ -14,15 +14,21 @@ related: false
 
 ## API Documentation
 
-You can access TrueNAS API documentation in the web interface by clicking <i class="material-icons" aria-hidden="true" title="laptop" style="vertical-align: top;">laptop</i> **My API Keys** on the top right toolbar <i class="material-icons" aria-hidden="true">account_circle</i> user settings dropdown menu to open the **User API Keys** screen.
-Click **API Docs** on the **User API Keys** or **User** screen to access the TrueNAS API documentation built into the system.
-A new browser window opens, showing the API documentation Table of Contents.
-
-![SCALEapidocs](/images/SCALE/Dashboard/APIKeysScreen.png "API Docs location")
-
-Alternatively, append **/api/docs/** to your TrueNAS host name or IP address in a browser to access the API documentation.
-
 {{< include file="/static/includes/APIDocs.md" >}}
+
+### Viewing API Documenation
+
+There are several ways to view TrueNAS API documentation:
+
+* In the web interface, click <i class="material-icons" aria-hidden="true" title="laptop" style="vertical-align: top;">laptop</i> **My API Keys** on the top right toolbar <i class="material-icons" aria-hidden="true">account_circle</i> user settings dropdown menu to open the **User API Keys** screen.
+   Click **API Docs** on the **User API Keys** or **User** screen to access the TrueNAS API documentation built into the system.
+   A new browser window opens, showing the API documentation Table of Contents.
+
+   ![SCALEapidocs](/images/SCALE/Dashboard/APIKeysScreen.png "API Docs location")
+
+* Append **/api/docs/** to your TrueNAS host name or IP address in a browser to access the API documentation.
+
+* Go to the [API Docs website](https://api.truenas.com) and use the dropdown to view documentation for a specific TrueNAS (and API) version.
 
 ## API Access
 

--- a/content/SCALE/SCALETutorials/TopToolbar/ManagingAPIKeys.md
+++ b/content/SCALE/SCALETutorials/TopToolbar/ManagingAPIKeys.md
@@ -9,7 +9,7 @@ tags:
 - apikeys
 ---
 
-TrueNAS 25.04 and later uses a versioned JSON-RPC 2.0 over WebSocket API with support for user-linked API access keys ([API Reference]({{< ref "/scale/api" >}})).
+TrueNAS 25.04 and later uses a versioned [JSON-RPC 2.0 over WebSocket API](https://api.truenas.com) with support for user-linked API access keys ([API Reference]({{< ref "/scale/api" >}})).
 
 User-linked API keys allow administrators to configure per-user access to the TrueNAS API.
 Keys are revocable and can be configured to expire on a preset date.
@@ -20,7 +20,7 @@ The **User API Keys** screen shows a table listing API keys added to the system,
 
 {{< trueimage src="/images/SCALE/Dashboard/APIKeysScreen.png" alt="API Keys Screen" id="API Keys Screen" >}}
 
-Click **API Docs** to view [API Documentation](#api-documentation).
+Click **API Docs** to view [API Documentation](#api-documentation) embedded within the system.
 
 {{<include file="/static/includes/addcolumnorganizer.md">}}
 
@@ -92,7 +92,7 @@ TrueNAS opens a **Delete API Key** dialog.
 
 Select **Confirm**, then click **Delete**.
 
-## API Documentation
+## Embedded API Documentation
 
 Click **API Docs** on the **User** or **User API Keys** screen to access the TrueNAS API documentation built into the system.
 A new browser window opens, showing the API documentation Table of Contents.


### PR DESCRIPTION
api/_index.md:
 - Reorder content to place the includes snippet that the beginning of the API Documentation section. This is informational/introductory content that explains the relevance of the API docs and is better served at the beginning of the section.
 - Make the API access options a subheader and bullet list to better differentiate between the individual access methods
 - Add a link to the api.truenas.com online location

ManagingAPIKeys.md
 - Add one link to the api.truenas.com location and clarify the remaining instructions are for accessing embedded documentation.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
