### PR TITLE
PD-2052 / 25.04 / add notice about auxiliary params to various areas

### DIFF
--- a/content/SCALETutorials/SystemSettings/Services/SSHServiceSCALE.md
+++ b/content/SCALETutorials/SystemSettings/Services/SSHServiceSCALE.md
@@ -40,6 +40,8 @@ Configure the options as needed to match your network environment.
 
 These **Auxiliary Parameters** can be useful when troubleshooting SSH connectivity issues:
 
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 * Increase the `ClientAliveInterval` if SSH connections tend to drop.
 * Increase the `MaxStartups` value (**10** is default) when you need more concurrent SSH connections.
 

--- a/content/SCALETutorials/SystemSettings/Services/UPSServicesSCALE.md
+++ b/content/SCALETutorials/SystemSettings/Services/UPSServicesSCALE.md
@@ -26,6 +26,8 @@ See [UPS Service Screen]({{< ref "UPSServicesScreenSCALE" >}}) for details on th
 
 Some UPS models are unresponsive with the default polling frequency (default is two seconds).
 TrueNAS displays the issue in logs as a recurring error like **libusb_get_interrupt: Unknown error**.
+
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
 If you get an error, decrease the polling frequency by adding an entry to **Auxiliary Parameters (ups.conf)**: `pollinterval = 10`.
 
 {{< expand "How do I find a device name?" "v" >}}

--- a/content/SCALEUIReference/Credentials/DirectoryServices/LDAP.md
+++ b/content/SCALEUIReference/Credentials/DirectoryServices/LDAP.md
@@ -51,6 +51,8 @@ The settings on the **Advanced Options** screen include the **[Basic Options](#l
 
 ![LDAPAdvancedOptionsSettings](/images/SCALE/Credentials/LDAPAdvancedOptionsSettings.png "LDAP Screen Advanced Options")
 
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 {{< truetable >}}
 | Setting | Description |  
 |---------|-------------|  

--- a/content/SCALEUIReference/DataProtection/ReplicationScreensSCALE.md
+++ b/content/SCALEUIReference/DataProtection/ReplicationScreensSCALE.md
@@ -208,13 +208,17 @@ The **Replication Schedule** options set when to run the task based on the sched
 |---------|-------------|
 | **Run On a Schedule** | Displays the **Schedule** option where you select a preset time or select **Custom** to use the advanced scheduler. |
 | **Run Once** | Runs the replication task after you click **Start Replication**. Displays the **Make Destination Dataset Read-only?** option. Removes the **Schedule** option. |
-| **Schedule** | Displays after selecting the **Run On a Schedule** radio button. Select a preset time or can select **Custom** to use the advanced scheduler. |
+| **Schedule** | Displays after selecting the **Run On a Schedule** radio button. Select a preset time or select **Custom** to use the advanced scheduler. |
 | **Make Destination Dataset Read-only?** | Displays after selecting the **Run Once** radio button. Select to change the destination dataset to be read-only. To continue using the default or existing dataset read permissions, leave this checkbox cleared. |
 {{< /truetable >}}
 {{< /expand >}}
 
 #### Destination Snapshot Lifetime Options
-The **Destination Snapshot Lifetime** setting determines how long the replicated snapshot is retained on the destination server. 
+The **Destination Snapshot Lifetime** setting determines how long the replicated snapshot is retained on the destination server.  
+
+{{< hint type=note (title="Snapshot Preservation") >}}
+TrueNAS always preserves the latest snapshot to permit later resumption of replication. If a dataset or zvol is deleted on the source, you must manually delete the replicated dataset or zvol and the most recent snapshot on the destination.
+{{< /hint >}} 
 
 {{< trueimage src="/images/SCALE/DataProtection/AddReplicationTaskWhenRunOnceCustomLifetime.png" alt="Add Replication Task When Custom Lifetime" id="Add Replication Task When Custom Lifetime" >}}
 

--- a/content/SCALEUIReference/DataProtection/RsyncTasksScreensSCALE.md
+++ b/content/SCALEUIReference/DataProtection/RsyncTasksScreensSCALE.md
@@ -98,6 +98,9 @@ The **More Options** specify other settings related to when and how the rsync oc
 {{< /expand >}}
 
 {{< expand "More Options Settings" "v" >}}
+
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|

--- a/content/SCALEUIReference/Shares/SMBSharesScreens.md
+++ b/content/SCALEUIReference/Shares/SMBSharesScreens.md
@@ -134,6 +134,8 @@ The **Other Options** settings include improving Apple software compatibility, Z
 
 {{< trueimage src="/images/SCALE/Shares/AddSMBAdvancedOtherSettings.png" alt="SMB Advanced Options Other" id="SMB Advanced Options Other" >}}
 
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|

--- a/content/SCALEUIReference/SystemSettings/Services/FTPServiceScreenSCALE.md
+++ b/content/SCALEUIReference/SystemSettings/Services/FTPServiceScreenSCALE.md
@@ -83,6 +83,8 @@ Enable TLS when possible (especially when exposing FTP to a WAN). TLS effectivel
 
 {{< trueimage src="/images/SCALE/SystemSettings/FTPAdvancedSettingsOtherOptions.png" alt="FTP Advanced Settings Other Options" id="FTP Advanced Settings Other Options" >}}
 
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 {{< truetable >}}
 | Settings | Description |
 |----------|-------------|

--- a/content/SCALEUIReference/SystemSettings/Services/SNMPServiceScreenSCALE.md
+++ b/content/SCALEUIReference/SystemSettings/Services/SNMPServiceScreenSCALE.md
@@ -42,6 +42,8 @@ Click the <i class="material-icons" aria-hidden="true" title="Configure">edit</i
 
 ### Other Options
 
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|

--- a/content/SCALEUIReference/SystemSettings/Services/SSHServiceScreenSCALE.md
+++ b/content/SCALEUIReference/SystemSettings/Services/SSHServiceScreenSCALE.md
@@ -41,6 +41,8 @@ The **Basic Settings** options display by default when you edit the SSH service.
 
 {{< trueimage src="/images/SCALE/SystemSettings/SSHServicesAdvancedSettings.png" alt="SSH Advanced Settings Options" id="SSH Advanced Settings Options" >}}
 
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|

--- a/content/SCALEUIReference/SystemSettings/Services/UPSServicesScreenSCALE.md
+++ b/content/SCALEUIReference/SystemSettings/Services/UPSServicesScreenSCALE.md
@@ -62,6 +62,8 @@ Click <i class="material-icons" aria-hidden="true" title="Configure">edit</i> to
 
 {{< trueimage src="/images/SCALE/SystemSettings/UPSServiceSettingsOtherOptions.png" alt="UPS Service Other Options" id="UPS Service Other Options" >}}
 
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|

--- a/static/includes/auxiliary-parameters-caution.md
+++ b/static/includes/auxiliary-parameters-caution.md
@@ -1,0 +1,5 @@
+&NewLine;
+{{< hint type=warning title="Auxiliary Parameters" >}}
+Auxiliary parameters are an unsupported configuration.
+Parameters entered here are not validated and can cause undefined system behavior, including data corruption or data loss.
+{{< /hint >}}


### PR DESCRIPTION
This is a general note that is applied to these user custom input fields:
- SSH (service)
- UPS (service)
- LDAP (creds)
- rsync (task)
- ftp (service)
- snmp (service)
- SMB (share)

Port to 25.10 docs is needed



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
