### PR TITLE
PD-2052 / 25.10 / add notice about auxiliary params to various areas (by Mrt134)

### DIFF
--- a/content/SCALE/SCALETutorials/SystemSettings/Services/SSHServiceSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Services/SSHServiceSCALE.md
@@ -41,6 +41,8 @@ Configure the options as needed to match your network environment.
 
 These **Auxiliary Parameters** can be useful when troubleshooting SSH connectivity issues:
 
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 * Increase the `ClientAliveInterval` if SSH connections tend to drop.
 * Increase the `MaxStartups` value (**10** is default) when you need more concurrent SSH connections.
 

--- a/content/SCALE/SCALETutorials/SystemSettings/Services/UPSServicesSCALE.md
+++ b/content/SCALE/SCALETutorials/SystemSettings/Services/UPSServicesSCALE.md
@@ -27,6 +27,8 @@ See [UPS Service Screen]({{< ref "UPSServicesScreenSCALE" >}}) for details on th
 
 Some UPS models are unresponsive with the default polling frequency (default is two seconds).
 TrueNAS displays the issue in logs as a recurring error like **libusb_get_interrupt: Unknown error**.
+
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
 If you get an error, decrease the polling frequency by adding an entry to **Auxiliary Parameters (ups.conf)**: `pollinterval = 10`.
 
 {{< expand "How do I find a device name?" "v" >}}

--- a/content/SCALE/SCALEUIReference/Credentials/DirectoryServices/LDAP.md
+++ b/content/SCALE/SCALEUIReference/Credentials/DirectoryServices/LDAP.md
@@ -57,6 +57,8 @@ The settings on the **Advanced Options** screen include the **[Basic Options](#l
 
 ![LDAPAdvancedOptionsSettings](/images/SCALE/Credentials/LDAPAdvancedOptionsSettings.png "LDAP Screen Advanced Options")
 
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 {{< truetable >}}
 | Setting | Description |  
 |---------|-------------|  

--- a/content/SCALE/SCALEUIReference/DataProtection/RsyncTasksScreensSCALE.md
+++ b/content/SCALE/SCALEUIReference/DataProtection/RsyncTasksScreensSCALE.md
@@ -100,6 +100,9 @@ The **More Options** specify other settings related to when and how the rsync oc
 {{< /expand >}}
 
 {{< expand "More Options Settings" "v" >}}
+
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|

--- a/content/SCALE/SCALEUIReference/Shares/SMBSharesScreens.md
+++ b/content/SCALE/SCALEUIReference/Shares/SMBSharesScreens.md
@@ -152,6 +152,8 @@ The **Other Options** settings include improving Apple software compatibility, Z
 
 {{< trueimage src="/images/SCALE/Shares/AddSMBAdvancedOtherSettings.png" alt="SMB Advanced Options Other" id="SMB Advanced Options Other" >}}
 
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|

--- a/content/SCALE/SCALEUIReference/SystemSettings/Services/FTPServiceScreenSCALE.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/Services/FTPServiceScreenSCALE.md
@@ -85,6 +85,8 @@ Enable TLS when possible (especially when exposing FTP to a WAN). TLS effectivel
 
 {{< trueimage src="/images/SCALE/SystemSettings/FTPAdvancedSettingsOtherOptions.png" alt="FTP Advanced Settings Other Options" id="FTP Advanced Settings Other Options" >}}
 
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 {{< truetable >}}
 | Settings | Description |
 |----------|-------------|

--- a/content/SCALE/SCALEUIReference/SystemSettings/Services/SNMPServiceScreenSCALE.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/Services/SNMPServiceScreenSCALE.md
@@ -44,6 +44,8 @@ Click the <i class="material-icons" aria-hidden="true" title="Configure">edit</i
 
 ### Other Options
 
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|

--- a/content/SCALE/SCALEUIReference/SystemSettings/Services/SSHServiceScreenSCALE.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/Services/SSHServiceScreenSCALE.md
@@ -43,6 +43,8 @@ The **Basic Settings** options display by default when you edit the SSH service.
 
 {{< trueimage src="/images/SCALE/SystemSettings/SSHServicesAdvancedSettings.png" alt="SSH Advanced Settings Options" id="SSH Advanced Settings Options" >}}
 
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|

--- a/content/SCALE/SCALEUIReference/SystemSettings/Services/UPSServicesScreenSCALE.md
+++ b/content/SCALE/SCALEUIReference/SystemSettings/Services/UPSServicesScreenSCALE.md
@@ -64,6 +64,8 @@ Click <i class="material-icons" aria-hidden="true" title="Configure">edit</i> to
 
 {{< trueimage src="/images/SCALE/SystemSettings/UPSServiceSettingsOtherOptions.png" alt="UPS Service Other Options" id="UPS Service Other Options" >}}
 
+{{< include file="/static/includes/auxiliary-parameters-caution.md" >}}
+
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|

--- a/static/includes/auxiliary-parameters-caution.md
+++ b/static/includes/auxiliary-parameters-caution.md
@@ -1,0 +1,5 @@
+&NewLine;
+{{< hint type=warning title="Auxiliary Parameters" >}}
+Auxiliary parameters are an unsupported configuration.
+Parameters entered here are not validated and can cause undefined system behavior, including data corruption or data loss.
+{{< /hint >}}


### PR DESCRIPTION
This is a general note that is applied to these user custom input fields:
- SSH (service)
- UPS (service)
- LDAP (creds)
- rsync (task)
- ftp (service)
- snmp (service)
- SMB (share)

Port to 25.10 docs is needed



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.


Original PR: https://github.com/truenas/documentation/pull/3888
Jira URL: https://ixsystems.atlassian.net/browse/PD-2052