### PR TITLE
NAS-136264: update rsync option description: validate remote path

### DIFF
--- a/content/SCALE/SCALETutorials/DataProtection/RsyncTasksSCALE.md
+++ b/content/SCALE/SCALETutorials/DataProtection/RsyncTasksSCALE.md
@@ -97,7 +97,7 @@ You can use the SSS connection created in [Setting Up an SSH Connection](#settin
 7. Enter the full path to the dataset on the remote server to either pull from or push to in **Remote Path**.
    Maximum path length is 255 characters.
 
-   If the remote path location does not exist, select **Validate Remote Path** to create and define it in **Remote Path**.
+   To confirm the remote server is reachable and the path exists, you can set **Validate Remote Path**.
 
 8. Set the schedule for when to run this task, and any other options you want to use.
 


### PR DESCRIPTION
Fix validate remote path option behavior



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
