### PR TITLE
Small updates to software releases page

### DIFF
--- a/content/TrueNASUpgrades/_index.md
+++ b/content/TrueNASUpgrades/_index.md
@@ -18,7 +18,7 @@ aliases:
 
 <--->
 
-{{< tabbox name=core-downloads defaultTab=3 >}}
+{{< tabbox name=core-downloads defaultTab=2 >}}
 
 {{< /columns >}}
 


### PR DESCRIPTION
- Change default CORE tab - make 13.0 releases the default view



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
