### PR TITLE
add apps market snippet and remove 25.04 support timeline from 25.10 UI reference

### DIFF
--- a/content/SCALE/SCALEUIReference/Apps/_index.md
+++ b/content/SCALE/SCALEUIReference/Apps/_index.md
@@ -16,7 +16,7 @@ tags:
 related: false
 ---
 
-{{< include file="/static/includes/AppsSupportTimeline.md" >}}
+{{< include file="/static/includes/apps/AppsMarket.md" >}}
 
 {{< include file="/static/includes/ProposeArticleChange.md" >}}
 


### PR DESCRIPTION

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
