### PR TITLE
PD-1996 / 24.10 / PD-1996 Update yaml files for 24.10

### DIFF
--- a/data/properties/scale-downloads.yaml
+++ b/data/properties/scale-downloads.yaml
@@ -115,6 +115,12 @@ majorVersions:
     majorVersion: "24.10 (Electric Eel)"
     releaseName: "Electric Eel"
     releases:
+      - name: "24.10.2.3"
+        link: "https://download.truenas.com/TrueNAS-SCALE-ElectricEel/24.10.2.3/"
+        date: "2025-07-14"
+      - name: "24.10.2.2"
+        link: "https://download.truenas.com/TrueNAS-SCALE-ElectricEel/24.10.2.2/"
+        date: "2025-05-13"
       - name: "24.10.2.1"
         link: "https://download.truenas.com/TrueNAS-SCALE-ElectricEel/24.10.2.1/"
         date: "2025-04-03"

--- a/data/properties/scale-releases.yaml
+++ b/data/properties/scale-releases.yaml
@@ -26,11 +26,26 @@ majorVersions:
     name: "TrueNAS SCALE 25.04 - Fangtooth"
     releaseName: "Fangtooth"
     releases:
-      - name: "25.04 Nightlies"
-        type: "Experimental"
-        link: "https://www.truenas.com/docs/scale/25.04/gettingstarted/scalereleasenotes/"
-        releaseDate: "2024-08-13"
+      - name: "25.04.2"
+        type: "Current"
+        link: "https://www.truenas.com/docs/scale/25.04/gettingstarted/scalereleasenotes/#25042"
+        releaseDate: "2025-07-31"
         latest: true
+      - name: "25.04.1"
+        type: "Early"
+        link: ""
+        releaseDate: "2025-05-27"
+        latest: fasle
+      - name: "25.04.0"
+        type: "Early"
+        link: ""
+        releaseDate: "2025-04-15"
+        latest: false
+      - name: "25.04-RC.1"
+        type: "Early"
+        link: ""
+        releaseDate: "2025-03-11"
+        latest: false
       - name: "25.04-BETA.1"
         type: "Early"
         link: ""
@@ -45,4 +60,9 @@ majorVersions:
         type: "Stable"
         link: ""
         releaseDate: "2025-04-15"
+        latest: false
+      - name: "25.04 Nightlies"
+        type: "Experimental"
+        link: "https://www.truenas.com/docs/scale/25.04/gettingstarted/scalereleasenotes/"
+        releaseDate: "2024-08-13"
         latest: false

--- a/static/includes/SCALEUpgradePaths.md
+++ b/static/includes/SCALEUpgradePaths.md
@@ -75,7 +75,7 @@ Visit the <a href="https://www.truenas.com/software-status/" target="_blank">Tru
             F["23.10.2 (Cobia)"] -->|update| G
             G["24.04.2.5 (Dragonfish)"] -->|update| H
             H["24.10.2.3 (Electric Eel)"] -->|update| I
-            I["25.04.0 (Fangtooth)"]
+            I["25.04.2 (Fangtooth)"]
           {{< /mermaid >}}
         </div>
       </div>


### PR DESCRIPTION
This PR Updates the 24.10 and 25.04 releases in /data/properties/downloads.yaml and /data/properties/release.yaml files, and it updates the mermaid in the SCALEUpgradePahts.md snippet.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
