### PR TITLE
PD-2131 / 13.3 / Pd 2131 no indication to add user to ftp group (by DjP-iX)

### DIFF
--- a/content/CORETutorials/Services/ConfiguringFTP.md
+++ b/content/CORETutorials/Services/ConfiguringFTP.md
@@ -72,5 +72,3 @@ The default directory is the same as the user <file>/home</file> directory.
 After connecting, you can create directories and upload or download files.
 
 ![FilezillaFTPConnect](/images/CORE/FilezillaFTPConnect.png "Filezilla FTP Connection")
-
-{{< taglist tag="coreftp" limit="10" >}}

--- a/content/CORETutorials/Services/ConfiguringFTP.md
+++ b/content/CORETutorials/Services/ConfiguringFTP.md
@@ -6,15 +6,18 @@ tags:
 - ftp
 ---
 
+The [File Transfer Protocol (FTP)](https://tools.ietf.org/html/rfc959) is a simple option for data transfers.
+SSH provides secure transfer methods for critical objects like configuration files, while TFTP provides simple file transfer methods for non-critical files.
+
 ## FTP Connections
 
-FTP connections cannot share connections with other accounts, such as SMB connections. FTP connections need a new dataset and local user account.
+FTP connections cannot share connections with other accounts, such as SMB connections. FTP requires a new dataset and local user account.
 
 Go to **Storage > Pools** to add a new dataset.
 
 ![StoragePoolsAddDataset2](/images/CORE/Storage/StoragePoolsAddDataset2.png "Adding a New Dataset")
 
-See [Creating Datasets]({{< ref "/CORETutorials/Storage/Pools/Datasets" >}}) for information on how to create the dataset. After this step is completed, the new dataset appears nested beneath the pool.
+See [Creating Datasets]({{< ref "/CORETutorials/Storage/Pools/Datasets" >}}) for information on creating the dataset. After you create the dataset, it appears nested beneath the pool.
 
 ![StorageAllPoolsDataset](/images/CORE/Storage/StorageAllPoolsDataset.png "New Dataset Listed")
 
@@ -23,10 +26,20 @@ Next, go to **Accounts > Users > Add** to create a local user on the TrueNAS.
 ![AddUserNamedCORE](/images/CORE/Accounts/AddUserNamedCORE.png "Adding a New User Account")
 
 Assign a user name and password. Link the new dataset for the FTP share as the home directory of the user.
-Link the new dataset for the FTP share on a per user basis, or create a global account for FTP. Example: OurOrgFTPacnt, etc.
+Link the new dataset for the FTP share on a per-user basis, or create a global account for FTP (example: OurOrgFTPacnt).
+
+{{< hint type=note >}}
+By default, only members of the **ftp** group can authenticate via FTP.
+Add your newly created user to the **ftp** group, or change this behavior in the FTP service configuration:
+
+- Enable **Allow Local User Login** to allow any local user to authenticate
+- Enable **Allow Anonymous Login** to allow anonymous connections without authentication
+
+Dataset permissions are configured separately and control what files authenticated users can access.
+{{< /hint >}}
 
 Return to **Storage > Pools**, find the new dataset, and click <i class="material-icons" aria-hidden="true" title="Options">more_vert</i>**> Edit Permissions**.
-In the **Owner** fields, select the new user account as the **User** and **Group** from the dropdown list. 
+In the **Owner** fields, select the new user account as the **User** and **Group** from the dropdown list.
 Be sure to select **Apply User** and **Apply Group** before saving.
 
 ![StoragePoolsEditPermissionsCORE](/images/CORE/Storage/StoragePoolsEditPermissionsCORE.png "Basic Permissions Editor")
@@ -37,15 +50,15 @@ To configure FTP, go to the **Services** page, find the **FTP** entry, and click
 
 ![FTPServicesGeneralCORE](/images/CORE/Services/FTPServicesGeneralCORE.png "Services FTP Options")
 
-Configure the options according to your environment and security considerations. See [FTP Screen]({{< ref "FTPScreen" >}})
+Configure the options according to your environment and security considerations. See [FTP Screen]({{< ref "/UIReference/Services/FTPScreen" >}}).
 
 ### Advanced Options
 
-Enable **chroot** to help confine FTP sessions to a local user home directory and allow **Local User Login**.
+Enable **chroot** to confine FTP sessions to a local user home directory and allow **Local User Login**.
 
 {{< hint type=important >}}
 Unless necessary, do not allow anonymous or root access. For better security, enable TLS when possible.
-This is effectively [FTPS](https://tools.ietf.org/html/rfc4217). 
+This creates [FTPS](https://tools.ietf.org/html/rfc4217).
 Enable TLS when FTP involves a WAN.  
 {{< /hint >}}
 
@@ -59,3 +72,5 @@ The default directory is the same as the user <file>/home</file> directory.
 After connecting, you can create directories and upload or download files.
 
 ![FilezillaFTPConnect](/images/CORE/FilezillaFTPConnect.png "Filezilla FTP Connection")
+
+{{< taglist tag="coreftp" limit="10" >}}

--- a/content/CORETutorials/Services/ConfiguringFTP.md
+++ b/content/CORETutorials/Services/ConfiguringFTP.md
@@ -11,7 +11,7 @@ SSH provides secure transfer methods for critical objects like configuration fil
 
 ## FTP Connections
 
-FTP connections cannot share connections with other accounts, such as SMB connections. FTP requires a new dataset and local user account.
+FTP connections cannot share connections with other accounts, such as SMB connections. FTP requires a new dataset and a local user account.
 
 Go to **Storage > Pools** to add a new dataset.
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 6f744be75558166975b7afff9f8f4105a2bde479
    git cherry-pick -x 4db5f6b8322f6210f3f42cd1d0d5bd74ca876357

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x fbcd5a797888c980f990f21ea32bb05d6b173fc0


Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.


Original PR: https://github.com/truenas/documentation/pull/4013
Jira URL: https://ixsystems.atlassian.net/browse/PD-2131