### PR TITLE
Add 25.10-beta.1 proposed release date

### DIFF
--- a/data/properties/scale-releases.yaml
+++ b/data/properties/scale-releases.yaml
@@ -40,6 +40,6 @@ majorVersions:
       - name: "25.10-BETA.1"
         type: "Early"
         link: ""
-        releaseDate: ""
+        releaseDate: "2025-08-28"
         latest: false
 


### PR DESCRIPTION
Can backport to 25.04 branch as needed.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
