### PR TITLE
Docs: advise keeping UIDs/GIDs below 65,536 for container mappings

### DIFF
--- a/content/SCALE/SCALETutorials/Containers/_index.md
+++ b/content/SCALE/SCALETutorials/Containers/_index.md
@@ -197,6 +197,11 @@ Assigning dataset permissions to a host user is not enough to grant container pe
 Incorrect or missing mappings can cause permission errors when containers access host paths.
 {{< /hint >}}
 
+{{< hint type=note >}}
+Do not use UIDs or GIDs above **65,535**. While they may appear to work initially, container ID mappings can fail after a **TrueNAS upgrade**.  
+Always keep mapped IDs **below 65,536** to ensure reliable upgrades.
+{{< /hint >}}
+
 #### Granting Root Access to Host Paths
 
 To safely allow container root processes to access host datasets, TrueNAS provides a built-in unprivileged root user for containers **truenas_container_unpriv_root**.


### PR DESCRIPTION
TrueNAS currently allows host UIDs/GIDs greater than 65,535 to be mapped, and containers may appear to work initially. However, after a TrueNAS upgrade these mappings can fail, causing containers to disappear or fail to start. Documentation updated to state that all mapped IDs must remain below 65,536 to ensure upgrade reliability.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
