### PR TITLE
PD-2173-fixed-hover

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -2688,8 +2688,8 @@ pre.gdoc-mermaid.mermaid.mermaid_sizing {
     font-weight: bold !important;
 }
 
-/* Hover effect for the button span */
-.gdoc-nav section:last-child .gdoc-nav__list li:nth-child(2) span.flex:hover {
+/* Hover effect moved to li to avoid nested hover conflicts */
+.gdoc-nav section:last-child .gdoc-nav__list li:nth-child(2):hover span.flex {
     background-color: #5da639 !important;
     border-color: #5da639 !important;
     color: white !important;


### PR DESCRIPTION
The changes in https://github.com/truenas/documentation/pull/4101 led to an odd double hover effect once deployed to the live site:

<img width="285" height="96" alt="image" src="https://github.com/user-attachments/assets/6cdbb998-e11e-4c5a-824f-1232e66da2e2" />

This wasn't happening in local builds. 

Hopefully this tweak should prevent it.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
