### PR TITLE
PD-2253 / 26.04 / PD-2253 Update Delete NVMe Content

### DIFF
--- a/content/SCALE/SCALETutorials/Shares/NVMe-oF/Managing-NVMe-of-Subsystems.md
+++ b/content/SCALE/SCALETutorials/Shares/NVMe-oF/Managing-NVMe-of-Subsystems.md
@@ -50,17 +50,26 @@ TrueNAS copies the identification number to the clipboard.
 
 ### Deleting a Subsystem
 
+Before deleting a namespace subsystem, delete the port and any assoicated host. TrueNAS shows an error if the subsystem has an active port and host.
+
 While on the **NVMe-oF** screen, select the subsystem row in the table, then click **Delete** to the right of **Details for *name***.
 The **Delete Subsystem** dialog opens.
 
-Verify the name of the subsystem listed in the dialog to confirm you have the desired subsystem.
+1. [Delete the port](#deleting-a-port). This does not delete the port configuration from the system, it removes it from the namespace subsystem.
 
-Click **Delete** to delete the subsystem and namespace(s) associated with it.
+2. [Delete any assoicated host](#delete-host-dialog). This does not delete the host configuration from the system, it removes it from the namespace subsystem.
+
+3. Delete the subsystem.
+   
+   Verify the name of the subsystem listed in the dialog to confirm you have the desired subsystem.
+
+   Click **Delete** to delete the subsystem and namespace(s) associated with it.
+
 **Cancel** closes the dialog without deleting the subsystem.
 
-Select **Force** if the delete operation fails to start, and click **Delete**.
+Select **Force** if the delete operation shows an in use error, or to delete with a port or host still associated with the subsystem, then click **Delete** again.
 
-<!-- commenting out until edit function is added back to the Namespace widget
+<!-- comment out for now. The edit namespace is currently removed from the UI. It might be added back at a later date.
 ## Editing a Namespace
 
 While on the **NVMe-oF** screen, select the subsystem row in the table, then click the edit <span class="material-icons">edit</span> icon to the right of the zvol path to open the **Edit Namespace** screen.
@@ -82,6 +91,8 @@ The zvol can be exposed by either iSCSI or NVMe-oF, but not at the the same time
 If you delete a namespace you can make the zvol available through iSCSI again.
 Data is not lost when associating the existing zvol with an NVMe subsystem.
 
+Stop the NVMe service before you begin.
+
 With the **Zvol** tab on the **Edit Namespace** screen selected, browse to and select a different parent dataset, and then click **Create Zvol** if you want to use a new zvol.
 To select a different zvol, browse to and select that existing zvol.
 
@@ -102,8 +113,8 @@ Browse to and select the parent dataset or zvol location where the existing file
 
 {{< trueimage src="/images/SCALE/Shares/UseExistingFileInEditNamespace.png" alt="Using an Existing File" id="Using an Existing File" >}}
 
-Click **Save**.-->
-<!-- comment out until edit namespace is added back to the UI 
+Click **Save**.
+
 #### Changing to a New File
 RC.1 will add an enable checkbox to allow disabling the namespace, update screenshots and remove commented out text
 You can use this procedure to add files to the parent dataset for the namespace, from the **New File** tab on the **Add Namespace** or **Edit Namespace** screens.
@@ -126,13 +137,13 @@ Enter a size as a number with a measurement value, for example, *10 MB*, in **Fi
 
 Click **Save**.
 
-The new file shows on the **Namespaces** widget. -->
+The new file shows on the **Namespaces** widget. 
 
 ### Adding a Zvol Namespace
 
 To access the **Add Zvol** screen, click **Create Zvol** while on the **Zvol** tab of the **Edit Namespace** screen.
 
-{{< include file="/static/includes/Add-Zvol-To-NVMe-oF-Namespace.md" >}}
+{{< include file="/static/includes/Add-Zvol-To-NVMe-oF-Namespace.md" >}}-->
 
 ### Deleting a Zvol Namespace
 
@@ -206,7 +217,7 @@ Click **Save**.
 
 ### Removing a Port from the Subsystem
 
-You can change the port number assigned to the subsystem using the **Remove this port from the subsystem** ![SubsystemPortActionIcon](/images/SCALE/Shares/SubsystemPortActionIcon.png "Subsystem Port Action Icon") icon on the **Ports** widget.
+You can change the port number assigned to the subsystem using the ![RemoveFromSubsystem](/images/SCALE/Shares/RemoveFromSubsystem.png "Remove from Subsystem Icon") **Remove this port from the subsystem** icon on the **Ports** widget.
 
 After removing a port, the **Add** button lists any available port on the system, including the port removed from the subsystem, in the format *IP address:port*.
 

--- a/content/SCALE/SCALEUIReference/Shares/nvme-of-screens.md
+++ b/content/SCALE/SCALEUIReference/Shares/nvme-of-screens.md
@@ -46,7 +46,7 @@ The **Delete Subsystem** dialog confirms you want to delete the subsystem before
 
 {{< trueimage src="/images/SCALE/Shares/DeleteSubsystemDialog.png" alt="Delete Subsystem Dialog" id="Delete Subsystem Dialog" >}}
 
-**Force** forces the delete operation if it is in use.
+**Force** forces the delete operation if the subsystem has a port or host assicated with it.
 
 **Cancel** closes the dialog without deleting the subsystem.
 


### PR DESCRIPTION
This PR updates the Delete subsystem content in the UI ref and Manageing-NVMe-of-Subsystems.md tutorial.

This backports to 25.10

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
