### PR TITLE
PD-2206 / 25.04 / Pd 2206 update content around google photos use (by DjP-iX)

### DIFF
--- a/content/SCALETutorials/DataProtection/CloudSyncTasks/AddGooglePhotosCloudSyncTask.md
+++ b/content/SCALETutorials/DataProtection/CloudSyncTasks/AddGooglePhotosCloudSyncTask.md
@@ -11,11 +11,25 @@ keywords:
 - data backup and recovery
 ---
 
+{{< hint type=important title="Changes to Google Photos API (effective March 31, 2025)" >}}
+On March 31, 2025, Google changed the Google Photos API to allow external applications to access and manage only the media and albums they create.
+Cloud sync tasks continue to upload photos to albums created by the TrueNAS sync client, but reading from your full photo library or from shared albums does not work as expected.
+Some operations return permission errors.
+
+Tokens issued before March 31, 2025 do not provide full-library access under the new API rules.
+Generate new credentials if you need to continue uploading into albums created by the sync client.
+
+See the [Google API update notice](https://developers.google.com/photos/support/updates) for more details.
+
+Review existing Google Photos cloud sync tasks and configure them to use albums created by the TrueNAS source.
+A complete backup of a Google Photos library through the API is not possible.
+{{< /hint >}}
+
 Google Photos cloud sync tasks in TrueNAS use the [rclone](https://rclone.org/) backend for the [Google Photos API](https://developers.google.com/photos) to authenticate credentials and transfer data.
 
 Configuring a Google Photos cloud sync task is a multi-part procedure where you:
 
-1. [Plan your deployment](#before-you-begin) and selecting a local dataset.
+1. [Plan your deployment](#before-you-begin) and select a local dataset.
 2. [Generate Google API credentials](#creating-the-api-credentials) on the Google Cloud API dashboard.
 3. [Install rclone and generate a token](#configuring-rclone) on your remote client OS.
 4. [Add Google Photos cloud credentials](#adding-google-photos-cloud-credentials) on TrueNAS.
@@ -23,57 +37,70 @@ Configuring a Google Photos cloud sync task is a multi-part procedure where you:
 
 ## Before You Begin
 
-Review your storage and data protection requirements and consider your options before setting up a Google Photos cloud sync task.
-Refer to the rclone Google Photos backend documentation for more information on using rclone to sync Google Photos, including [standard options](https://rclone.org/googlephotos/#standard-options) and [limitations of the Google Photos API](https://rclone.org/googlephotos/#limitations), that might help you plan your deployment.
+Review your storage and data protection requirements before setting up a Google Photos cloud sync task.
+See the [rclone Google Photos backend documentation](https://rclone.org/googlephotos/) for details on [standard options](https://rclone.org/googlephotos/#standard-options) and [API limitations](https://rclone.org/googlephotos/#limitations) that can help you plan your deployment.
 
-Consider how you want to manage your media files on Google Photos and in your local dataset.
-Decide on the cloud sync task [direction and transfer mode](#choosing-a-sync-direction-and-mode), [remote folder](#choosing-a-target-folder) to target, and [new or existing local dataset](#selecting-the-dataset-and-organizing-files) to pull to or push from, that best fit your needs.
+Decide how you want to manage media files in Google Photos and your local dataset.
+Choose the cloud sync [direction and transfer mode](#choosing-a-sync-direction-and-mode), [target folder](#choosing-a-target-folder), and [local dataset](#selecting-the-dataset-and-organizing-files) (new or existing) that best fit your needs.
 
 ### Choosing a Sync Direction and Mode
 
-A Google Photos cloud sync task can either pull files from Google Photos to a local dataset on TrueNAS or push local files to Google Photos.
-Select the direction that best fits the way you intend to manage your media files.
+A Google Photos cloud sync task can either push local files to Google Photos or (limited) pull files from Google Photos to a local TrueNAS dataset.
+Select the direction that fits how you want to manage your media files.
 
-Choose to pull data from Google Photos if you prefer to manage media files via the Google Photos UI and use the local dataset as a backup target.
+Pull is restricted by the Google Photos API and only accesses albums created by the TrueNAS sync client.
+Pulling your full library or from shared albums is not possible.
 
-Choose to push data to Google Photos if you prefer to manage media files in the local dataset and use Google Photos as a cloud backup location.
+Push uploads local files into albums created by the TrueNAS sync client.
+Use push to manage media in your local dataset and back it up to Google Photos.
 
-Next, select the data transfer mode that best fits the way you want to manage file retention between the source and destination.
+Next, select the data transfer mode that fits how you want to manage file retention between the source and destination.
 There are three options:
 
-  * **SYNC** - Select to change files on the destination to match those on the source.
-    If a file does not exist on the source, it is also deleted from the destination.
-  * **COPY** - Select to duplicate each source file into the destination.
-    If files with the same names are present on the destination, they are overwritten.
-  * **MOVE** - Select to transfer files from the source to the destination and delete source files.
-    Copies files from the source to the destination and then deletes them from the source. Files with the same names on the destination are overwritten.
+* **SYNC** - Matches files on the destination to the source.
+  Deletes files from the destination if they do not exist on the source.
+  Only affects albums created by the sync client.
+* **COPY** - Duplicates each source file into the destination.
+  Overwrites files with the same name.
+  Only affects albums created by the sync client.
+* **MOVE** - Transfers files from the source to the destination and deletes them from the source.
+  Overwrites files with the same name.
+  Only affects albums created by the sync client.
 
 ### Choosing a Target Folder
 
-After choosing the direction and mode for your cloud sync task, choose the remote Google Photos folder that rclone targets to sync data.
-Because of the way rclone interacts with the Google Photos API, each target folder option has specific file management and structure requirements.
-This is due to the way rclone interacts with the Google Photos API.
-A cloud sync task cannot target the root level folder (<file>/</file>).
+After choosing the direction and mode for your cloud sync task, select the remote Google Photos folder that rclone targets.  
+Each folder option has specific file management and structure requirements due to API restrictions.  
+Cloud sync tasks cannot target the root folder (<file>/</file>).
 
 {{< truetable >}}
 | Folder | Recommended | Direction | Description |
 |-----------|-------------|-------------|-------------|
-| <file>/album</file> | Yes | Push or Pull | Use this option for push tasks or if you prefer to organize the Google Photos library by sorting media files into one or more discrete albums. All files must be in distinct albums or child directories of the local dataset. Media files uploaded to Google Photos but not assigned to an album are not pulled to a local dataset mirroring <file>/album</file>. Files uploaded to the base level of the local dataset instead of a child directory (an album) are not pushed to <file>/album</file>. |
-|  <file>/media/all</file> | Yes | Pull | Use this option if you prefer to use the Google Photos library as single directory, without organizing media files into discrete albums. The local dataset of a <file>/media/all</file> sync task contains all media files stored on the Google Photos account at the same level, with no further organization into subdirectories. Using <file>/media/all</file> allows you to upload new files to Google Photos, without needing to organize them into albums, and then pull them to TrueNAS. |
-| <file>/upload</file> | **No** | Push | Media files pushed from the local dataset to <file>/upload</file> are then uploaded to Google Photos and not sorted into an album. Because <file>/upload</file> is a temporary storage location, it can not accurately synchronize from one task to the next. Pushing to this folder does not preserve metadata and can result in duplicated files, poor performance, file name instability. |
+| <file>/album</file> | Yes | Push or Pull | Use this folder for push tasks or to organize media into albums. Only albums created by the TrueNAS cloud sync client are accessible. Pull returns only items in these albums; push uploads work as expected. All local files must be in child directories (albums) under the dataset. |
+| <file>/media/all</file> | **No** | Pull | API restrictions prevent reading your full Google Photos library. Only items in app-created albums are accessible. Do not use this option for full-library sync. |
+| <file>/upload</file> | **No** | Push | Temporary upload location. Files pushed here are not sorted into albums, metadata can be lost, and repeated sync tasks can produce duplicates or unstable filenames. Use only for temporary transfers. |
 {{< /truetable >}}
 
 ### Selecting the Dataset and Organizing Files
 
-Select TrueNAS local dataset or create a new one to use as the source or destination.
+Select a TrueNAS local dataset or create a new one to use as the source or destination.
 
 {{< expand "Creating a Dataset" "v" >}}
 {{< include file="/static/includes/CreateDatasetSCALE.md" >}}
 {{< /expand >}}
 
-Configure file management structure inside the local dataset (for push tasks) or albums in the Google Photos (for pull tasks) as required by your direction, mode, and target selections (see above).
+For push tasks, organize files in the local dataset so they map to albums created by the TrueNAS cloud sync client.  
+For pull tasks, the Google Photos API only provides access to items in albums created by the sync client.
+Full-library pulls or shared albums are not accessible.
+Configure your dataset accordingly based on your chosen direction, mode, and target folder.
 
 ## Creating the API Credentials
+
+{{< hint type=warning title="Important: API Credentials and Tokens" >}}
+Tokens generated before March 31, 2025 do not provide full access to your Google Photos library under the new API rules.  
+When creating credentials, ensure that your OAuth client and token are intended for use with albums created by the TrueNAS cloud sync client.
+Only these app-created albums can be accessed for push or pull tasks.
+{{< /hint >}}
 
 On the [Google API dashboard](https://console.cloud.google.com/apis/dashboard), click the dropdown menu to the right of the Google Cloud logo and select your project.
 
@@ -89,6 +116,8 @@ After you select your project, click **Enabled APIs & Services** on the left men
 {{< trueimage src="/images/SCALE/DataProtection/GooglePhotosAPIEnableAPIsandServices.png" alt="Enable APIs and Services" id="Enable APIs and Services" >}}
 
 Enter **photos library api** in the search bar, then select **Photos Library API** and click **ENABLE**.
+This enables the API for your project
+Access remains limited to albums created by the TrueNAS cloud sync client.
 
 {{< trueimage src="/images/SCALE/DataProtection/GooglePhotosAPIClickEnable.png" alt="Enable Photos Library API" id="Enable Photos Library API" >}}
 
@@ -106,7 +135,7 @@ Enter an email address in **Developer contact information**, then click **SAVE A
 
 {{< trueimage src="/images/SCALE/DataProtection/GooglePhotosAPIDeveloperContactInformation.png" alt="Enter Developer Contact Information" id="Enter Developer Contact Information" >}}
 
-Continue to the **Test users** section and click **+ ADD USERS**, enter your email address, then click **ADD**.
+Continue to the **Test users** section and click **+ ADD USERS**, enter the email addresses of users who run cloud sync tasks, then click **ADD**.
 
 {{< trueimage src="/images/SCALE/DataProtection/GooglePhotosAPIAddTestingUser.png" alt="Add Test User" id="Add Test User" >}}
 
@@ -116,7 +145,7 @@ On the **OAuth consent screen**, click **PUBLISH APP** under **Testing** and pus
 
 {{< expand "Can I leave the app in testing mode?" "v" >}}
 You can leave the app in testing mode, but testing app credentials expire after seven days.
-Cloud sync tasks fail when credentials expire.
+Cloud sync tasks fail when testing mode credentials expire.
 {{< /expand >}}
 
 ### Create Credentials
@@ -146,6 +175,9 @@ Enter a name for the new remote, then enter the number from the list correspondi
 
 Enter the client id and secret you saved when you created the Google Photos API credentials, then enter `false` or press <kbd>Enter</kbd> to allow the Google Photos backend to request full access.
 
+**Note:** After March 31, 2025, full-library access is no longer possible under the Google Photos API.
+Even if rclone requests full access, it only sees albums created by the TrueNAS cloud sync client.
+
 {{< trueimage src="/images/SCALE/DataProtection/GooglePhotosAPIrcloneConfig2.png" alt="Configure rclone Client ID and Secret" id="Configure rclone Client ID and Secret" >}}
 
 Do not edit the advanced config.
@@ -155,6 +187,7 @@ A browser window opens to authorize rclone access.
 Click **Allow**.
 
 In the command line, enter `y` to confirm rclone uploads media items with full resolution and complete the configuration.
+Only albums created by the TrueNAS cloud sync client are accessible.
 
 Copy and save the type, client_id, client_secret, and token, then enter `y` to save the new remote.
 
@@ -172,6 +205,9 @@ Paste the Google Photos API client ID and client secret in the **OAuth Client ID
 
 Paste your rclone token into the **Token** field.
 
+**Note:** Due to API restrictions, these credentials only provide access to albums created by the TrueNAS cloud sync client
+Full-library or shared-album access is not possible.
+
 Click **Verify Credential** to ensure the credentials are valid, then click **Save**.
 
 ## Creating the Cloud Sync Task
@@ -188,7 +224,8 @@ Go to **Data Protection > Cloud Sync Tasks** and click **Add**. The **Cloud Sync
    Select the Google Photos location to back up data to or from in **Folder**.
    Browse to and select the **album** folder or enter **/album**.
 
-   {{< trueimage src="/images/SCALE/DataProtection/CloudSyncTaskWizardWhatandWhenScreen.png" alt="Cloud Sync Task Wizard What and When" id="Cloud Sync Task Wizard - What and When" >}}
+   **Note:** Pull tasks only access albums created by the TrueNAS cloud sync client.
+   Full-library pulls or shared albums are not accessible.
 
 3. Select the local dataset in **Directory/Files**.
    This is the dataset sent to Google Photos for push tasks or the write destination for pull tasks.
@@ -197,7 +234,7 @@ Go to **Data Protection > Cloud Sync Tasks** and click **Add**. The **Cloud Sync
    Push tasks containing media files saved to the local dataset root level fail with the error: **Failed to sync: can't upload files here**.  
 
    Save files to child directories, not to the root level of the TrueNAS dataset.
-   Directories under the local dataset correspond to albums in the Google Photos library.
+   Directories under the local dataset correspond to albums created by the TrueNAS cloud sync client in Google Photos.
    {{< /hint >}}
 
 4. Enter a **Description** for the cloud sync task.
@@ -217,35 +254,40 @@ Click <i class="fa fa-play" aria-hidden="true" title="Run Job"></i> **Run Job** 
 ### Troubleshooting
 
 If a Google Photos cloud sync task fails, go to **Data Protection** and click the **FAILED** status in **State** on the **Cloud Sync Tasks** widget.
-Review the logged error message(s).
+Review the logged error messages.
 Common error messages for failed Google Photos tasks include:
 
 {{< expand "Failed to copy: can't upload files here" "v" >}}
-Problem: A push task is trying to upload files to the root level <file>/</file> folder or the <file>/media/all</file> folder.
+Problem: A push task attempts to upload files to the root level <file>/</file> folder or the <file>/upload</file> folder.
 
-Solution: Reconfigure the push task to target the <file>/album</file> folder (and organize your files into one or more subfolders/albums) or change the direction of the task to pull from Google Photos and target the <file>/media/all</file> folder.
+Solution: Reconfigure the push task to target the <file>/album</file> folder and organize your files into child directories (albums).
+Directories under the local dataset correspond to albums the TrueNAS cloud sync client creates in Google Photos.
+Only albums the sync client creates are accessible to cloud sync tasks.
 {{< /expand >}}
 
 {{< expand "Pulling from the root directory is not allowed. Please, select a specific directory" "v" >}}
-Problem: A pull or push task is targeting the root level <file>/</file> folder.
+Problem: A pull or push task targets the root level <file>/</file> folder.
 
-Solution: Review [Before You Begin](#before-you-begin) above and change the target folder to <file>/album</file> or <file>/media/all</file>.
-Ensure the selected folder does not conflict with the direction of the task.
+Solution: Change the target folder to <file>/album</file>.
+Pull tasks transfer only media that exist in albums created by the TrueNAS cloud sync client.
+Full-library pulls and shared albums are not accessible via the API.
+Do not rely on <file>/media/all</file> for a full export.
 {{< /expand >}}
 
 {{< expand "Failed to copy: directory not found" "v" >}}
-Problem: A pull task is targeting the <file>/upload</file> folder.
+Problem: A pull task targets the <file>/upload</file> folder.
 
-Solution: The <file>/upload</file> folder functions as a temporary queue for rclone to upload files to Google Photos.
+Solution: The <file>/upload</file> folder functions as a temporary upload queue.
 rclone cannot pull from <file>/upload</file>.
-Review [Before You Begin](#before-you-begin) above and change the target folder to <file>/album</file> or <file>/media/all</file>.
-Organize your Google Photos library or local dataset as needed for the selected target.
+Change the target folder to <file>/album</file> and organize files accordingly.
+Remember that only albums created by the TrueNAS cloud sync client are accessible for pull tasks.
 {{< /expand >}}
 
-After reviewing available logs, click <i class="material-icons" aria-hidden="true" title="Edit">edit</i> **Edit** on the task and review the configuration.
-Compare configured options to the requirements in [Before You Begin](#before-you-begin) above and correct any issues.
+If a pull task runs but some or all files never appear in the local dataset, those files are not in albums created by the TrueNAS cloud sync client and the API does not expose them to the sync client.
+To get originals from Google Photos you can:
 
-If a pull task is successful but some or all files are missing from the local dataset, review your library organization in Google Photos.
-Pull tasks configured with <file>/album</file> as the target folder only transfer files organized into albums.
-Files uploaded to Google Photos but not added to an album are not transferred.
-Using the Google Photos UI, create one or more albums and add all files to an album then click <i class="fa fa-play" aria-hidden="true" title="Run Job"></i> **Run Job** to re-run the cloud sync task.
+* Export your account via [Google Takeout](https://takeout.google.com/settings/takeout/custom/photos) (download the archive and import the files into TrueNAS).
+* Download desired photos directly from [Google Photos](photos.google.com) and copy them into your TrueNAS dataset.
+
+If you want the sync client to manage media going forward, create and sync albums via TrueNAS.
+Those albums then remain accessible to the TrueNAS cloud sync client.


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 94b3c8541822848d60ad487b1f966c1b5a780857
    git cherry-pick -x 6d5deb0f272d99d3ebd1d31ae0fee7b8db92b5f9
    git cherry-pick -x 6629c80b6bf822dc59119e8f5aa6ae5b27c2b188
    git cherry-pick -x 3f1931db15d4e31a800835f20073ca14045f3d78
    git cherry-pick -x f50ae97d9bf526644569baaf2be1336e1cc2e0ce
    git cherry-pick -x 6ae00236977b1c06621f662a704f14c8f7b84747
    git cherry-pick -x 06dc0f14c6b9968412aa941b8bbbfb514b6611e8

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 815dfda78e018b99e53b8ab9347f39b0e3b62149



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.


Original PR: https://github.com/truenas/documentation/pull/4168
Jira URL: https://ixsystems.atlassian.net/browse/PD-2206