### PR TITLE
(25.10) Add blurb to upgrade notes about metric system startup time

### DIFF
--- a/content/GettingStarted/SCALEReleaseNotes.md
+++ b/content/GettingStarted/SCALEReleaseNotes.md
@@ -251,6 +251,8 @@ initializeChangelogTableForTabs('25.10');
   The SMB recycle bin feature is no longer available for new shares due to security and usability concerns.
   For file recovery and versioning, use ZFS snapshots, which provide more reliable and predictable data protection.
   See [Legacy Share Settings](https://www.truenas.com/docs/scale/25.10/scaleuireference/shares/smbsharesscreens/#legacy-share-settings) for more information.
+  
+* Pool usage, disk temperature, and related metrics can have a short delay of no more than 10 minutes before displaying. This is typically seen when TrueNAS boots or in situations where the reporting system restarts.
 
   </div>
 


### PR DESCRIPTION
This is behavior in 25.10 that is downstream from the reporting system backend (netdata) and is anticipated to be the way 25.10 (at minimum) generally behaves).

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
