### PR TITLE
Fix link to Goldeneye release

### DIFF
--- a/content/SCALE/GettingStarted/SCALEReleaseNotes.md
+++ b/content/SCALE/GettingStarted/SCALEReleaseNotes.md
@@ -37,7 +37,7 @@ jump_to_buttons:
 {{< hint type="tip" title="26.04 Nightly Development Documentation" >}}
 This page tracks the latest development roadmap and notes for the future TrueNAS major version 26.04 (Halfmoon).
 
-See the stable [25.04 (Fangtooth)](https://www.truenas.com/docs/scale/25.04/gettingstarted/scalereleasenotes/) or pre-release [25.10 (Goldeye)](https://www.truenas.com/docs/scale/25.04/gettingstarted/scalereleasenotes/) release notes for information relating to those versions.
+See the stable [25.04 (Fangtooth)](https://www.truenas.com/docs/scale/25.04/gettingstarted/scalereleasenotes/) or pre-release [25.10 (Goldeye)](https://www.truenas.com/docs/scale/25.10/gettingstarted/scalereleasenotes/) release notes for information relating to those versions.
 {{< /hint >}}
 
 ## Notable Changes and Known Issues


### PR DESCRIPTION
Edited URL for Goldeneye release (which was improperly linking to Fangtooth)