### PR TITLE
DOCS-2504 / 26 / DOCS-2504-25-10-3-follow-up-26

### DIFF
--- a/data/properties/scale-releases.yaml
+++ b/data/properties/scale-releases.yaml
@@ -27,10 +27,10 @@ majorVersions:
     name: "TrueNAS 25.10 - Goldeye"
     releaseName: "Goldeye"
     releases:
-      - name: "25.10.2.1"
+      - name: "25.10.3"
         type: "Maintenance"
-        link: "https://www.truenas.com/docs/scale/25.10/gettingstarted/versionnotes/#25.10.2.1"
-        releaseDate: "2026-02-25"
+        link: "https://www.truenas.com/docs/scale/25.10/gettingstarted/versionnotes/#25.10.3"
+        releaseDate: "2026-04-14"
         latest: true
   - lifecycle: "26"
     name: "TrueNAS 26"

--- a/static/includes/SCALEUpgradePaths.md
+++ b/static/includes/SCALEUpgradePaths.md
@@ -30,7 +30,7 @@ See the <a href="https://www.truenas.com/docs/softwarestatus/#which-truenas-vers
               G["24.04.2.5 (Dragonfish)"] -->|update| H
               H["24.10.2.4 (Electric Eel)"] -->|update| I
               I["25.04.2.6 (Fangtooth)"] -->|update| J
-              J["25.10.2.1 (Goldeye)"] -->|"anticipated"| K
+              J["25.10.3 (Goldeye)"] -->|"anticipated"| K
               K["TrueNAS 26.0"]
             {{< /mermaid >}}
           </div>
@@ -60,7 +60,7 @@ See the <a href="https://www.truenas.com/docs/softwarestatus/#which-truenas-vers
               E["24.04.2.5 (Dragonfish)"]  -->|update| F
               F["24.10.2.4 (Electric Eel)"] -->|update| G
               G["25.04.2.6 (Fangtooth)"] -->|update| H
-              H["25.10.2.1 (Goldeye)"] -->|"anticipated"| I
+              H["25.10.3 (Goldeye)"] -->|"anticipated"| I
               I["TrueNAS 26.0"]
             {{< /mermaid >}}
           </div>


### PR DESCRIPTION
Update 25.10 latest release to 25.10.3 in scale-releases.yaml and UpgradePaths



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
