### PR TITLE
DOCS-2055 / None / Docs 2055 update support card content

### DIFF
--- a/content/SCALE/SystemSettings/General/GeneralSettings.md
+++ b/content/SCALE/SystemSettings/General/GeneralSettings.md
@@ -30,7 +30,7 @@ The TrueNAS **General Settings** provide options to configure support, file a ti
 
 ## Configuring Support
 
-The **Support** widget shows information about the TrueNAS version and system hardware.
+The **Support** card shows information about the TrueNAS version and system hardware.
 Links to the open-source TrueNAS documentation, community forums, and official Enterprise licensing are provided.
 
 **Add License** opens a screen where you can paste a copy of your TrueNAS Enterprise license ([details]({{< ref "AddLicenseProactiveSupport" >}})).
@@ -42,8 +42,9 @@ After adding a license, the option changes to **Update License**.
 These options allow you to report a system bug or to send TrueNAS feedback on the UI and rate a screen. Feedback goes to the TrueNAS development team.
 An icon shows on new UI feature screens where TrueNAS is asking you to send feedback, and it allow you to capture a screenshot of that screen.
 
-**Proactive Support** shows for Enterprise-licensed systems.
-It opens the **Proactive Support** window, where you enter configuration settings to set up proactive support for an Enterprise system.
+Enterprise-licensed systems display a contextual banner based on the system's support tier and contract status.
+Silver/Gold tier systems with proactive support not yet configured show a **Set up Proactive Support** banner with an **Enable** button.
+When proactive support is already active, a **Manage** button appears in the license info list to update contact settings.
 For information on configuring proactive support, see [Adding a License and Proactive Support]({{< ref "AddLicenseProactiveSupport" >}}).
 
 ## Sending Feedback
@@ -52,7 +53,7 @@ For information on configuring proactive support, see [Adding a License and Proa
 
 ## Configuring GUI Options
 
-The **GUI** widget allows users to configure the TrueNAS web interface address. Click **Settings** on the widget to open the **GUI Settings** configuration screen.
+The **GUI** card allows users to configure the TrueNAS web interface address. Click **Settings** on the widget to open the **GUI Settings** configuration screen.
 
 {{< trueimage src="/images/SCALE/SystemSettings/SystemGeneralGuiSettings.png" alt="GUI Settings Screen" id="GUI Settings Screen" >}}
 
@@ -100,7 +101,7 @@ To show real-time console messages at the bottom of the browser window, select *
 
 Localizing the TrueNAS system consists of changing the UI language and the keyboard layout to support the selected language, and setting the time zone to match where the TrueNAS server is located. To set date and time formats, go to the top toolbar [**Settings > Preferences**]({{< ref "/Scale/TopToolbar/Settings/_index.md" >}}) screen.
 
-To change the Web UI on-screen language and set the keyboard to work with the selected language, click **Settings** on the **Localization** widget to open the **Localization Settings** configuration screen.
+To change the Web UI on-screen language and set the keyboard to work with the selected language, click **Settings** on the **Localization** card to open the **Localization Settings** configuration screen.
 
 {{< trueimage src="/images/SCALE/SystemSettings/SystemGeneralLocalizationSettings.png" alt="Localization Settings Screen" id="Localization Settings Screen" >}}
 
@@ -114,7 +115,7 @@ Click **Save**.
 
 ## Setting Up System Email
 
-The **Email** widget displays information about current system mail settings.
+The **Email** card displays information about current system mail settings.
 When configured, an automatic script sends a nightly email to the administrator account containing important information, such as the health of the disks.
 
 To configure the system email send method, click **Settings** to open the **Email Options** screen.

--- a/content/SCALE/SystemSettings/General/GeneralSettings.md
+++ b/content/SCALE/SystemSettings/General/GeneralSettings.md
@@ -42,7 +42,7 @@ After adding a license, the option changes to **Update License**.
 These options allow you to report a system bug or to send TrueNAS feedback on the UI and rate a screen. Feedback goes to the TrueNAS development team.
 An icon shows on new UI feature screens where TrueNAS is asking you to send feedback, and it allow you to capture a screenshot of that screen.
 
-Enterprise-licensed systems display a contextual banner based on the system's support tier and contract status.
+Enterprise-licensed systems display a contextual banner based on the system support tier and contract status.
 Silver/Gold tier systems with proactive support not yet configured show a **Set up Proactive Support** banner with an **Enable** button.
 When proactive support is already active, a **Manage** button appears in the license info list to update contact settings.
 For information on configuring proactive support, see [Adding a License and Proactive Support]({{< ref "AddLicenseProactiveSupport" >}}).
@@ -99,7 +99,7 @@ To show real-time console messages at the bottom of the browser window, select *
 
 ## Localizing the TrueNAS System
 
-Localizing the TrueNAS system consists of changing the UI language and the keyboard layout to support the selected language, and setting the time zone to match where the TrueNAS server is located. To set date and time formats, go to the top toolbar [**Settings > Preferences**]({{< ref "/Scale/TopToolbar/Settings/_index.md" >}}) screen.
+Localizing the TrueNAS system consists of changing the UI language and the keyboard layout to support the selected language and setting the time zone to match where the TrueNAS server is located. To set date and time formats, go to the top toolbar [**Settings > Preferences**]({{< ref "/Scale/TopToolbar/Settings/_index.md" >}}) screen.
 
 To change the Web UI on-screen language and set the keyboard to work with the selected language, click **Settings** on the **Localization** card to open the **Localization Settings** configuration screen.
 
@@ -115,7 +115,7 @@ Click **Save**.
 
 ## Setting Up System Email
 
-The **Email** card displays information about current system mail settings.
+The **Email** card displays information about the current system mail settings.
 When configured, an automatic script sends a nightly email to the administrator account containing important information, such as the health of the disks.
 
 To configure the system email send method, click **Settings** to open the **Email Options** screen.

--- a/content/SCALE/SystemSettings/General/GeneralSettingsScreens.md
+++ b/content/SCALE/SystemSettings/General/GeneralSettingsScreens.md
@@ -29,28 +29,43 @@ The **General Settings** screen has four cards that show current general system 
 Community systems show the same cards, but are not eligible for Enterprise support options or licenses.
 Enterprise systems show an image of the system model.
 
-## Support Cards
+## Support Card
 
-The **Support** card for Community Edition TrueNAS shows the version, model number of the CPU detected, system memory detected, a system serial number if configured, and links to the [Documentation Hub](https://www.truenas.com/docs/), [TrueNAS Forums](https://forums.truenas.com/), and offers [TrueNAS Licensing](https://www.ixsystems.com/support/) information.
+The **Support** card shows system information and provides access to support resources and actions.
+All systems show three buttons in the card header:
+
+* **File Ticket** opens a [feedback/report issue window](#send-feedback-window) where users can provide feedback or report an issue and save/attach a system debug file.
+* **Save Debug** starts downloading a system debug file to the local machine.
+* **Add License** (or **Update License** after a license is applied) opens the **[License](#license-screen)** screen. Requires Full Admin role.
+
+### Community Edition Support Card
+
+The **Support** card for TrueNAS Community Edition shows a banner with a link to the TrueNAS forums for community support, followed by system information including the OS version, system product, CPU model (if detected), memory, and system serial number (if configured).
 
 {{< trueimage src="/images/SCALE/SystemSettings/GeneralSettingsSupportCard.png" alt="Support Card" id="Support Card" >}}
 
-**File Ticket** opens a [feedback/report issue window](#send-feedback-window) where users can provide feedback on the screen or report an issue and save/attach a system debug file.
-
-**Save Debug** starts downloading a system debug file to the local machine.
+A links row at the bottom of the card provides quick access to **Documentation**, **Forums**, and **Licensing** information.
 
 {{< enterprise>}}
-The **Support** card on the **General Settings** screen for Enterprise customers shows system licenses applied to the system, the system model, serial, license numbers not shown for Community Edition of TrueNAS, and any additional hardware associated with the system.
+### Enterprise Support Card
+
+The **Support** card on the **General Settings** screen for Enterprise systems displays license details including contract type, expiration date, model, system serial, licensed serials, features, and any additional hardware.
+Licensed systems with recognized hardware display a product image at the top of the card.
 
 {{< trueimage src="/images/SCALE/SystemSettings/GeneralSettingsSupportCardEnterprise.png" alt="Support Card - Enterprise" id="Support Card - Enterprise" >}}
 
-The **This is a production system** toggle, which shows only on TrueNAS Enterprise systems, opens the [**Update Production Status**](#update-production-status-dialog) dialog.
+The **This is a production system** toggle, which shows only on TrueNAS Enterprise systems, appears alongside the **Model** field in the license info list.
+Enabling it opens the [**Update Production Status**](#update-production-status-dialog) dialog.
 
-**Add License** opens the **[License](#license-screen)** screen.
-After adding a license, **Update License** replaces the **Add License** button.
+### Support Banners
 
-**Get Support** dropdown shows two options: **File Ticket** and **Proactive Support** when the system is an Enterprise-licensed system.
-Non-Enterprise licensed systems only show the [**File Ticket**](#) option.
+The **Support** card displays a contextual banner depending on the system's license tier and support configuration:
+
+* **Contract expiring soon** — Shows when an active support contract expires within 14 days. Displays the number of days remaining and the expiration date, with a **Contact Us** link to renew.
+* **Set up Proactive Support** — Shows for Silver/Gold tier systems where proactive support is available but not yet enabled. Click **Enable** to open the [Proactive Support](#proactive-support-screen) configuration screen.
+* **Need help? Looking for support?** (Bronze tier) — Shows for systems where proactive support is not included. Provides an **Explore your options** link to review available support plans.
+
+When proactive support is active, the license info list includes a **Proactive Support: Enabled** row with a **Manage** button to update contact configuration.
 {{< /enterprise >}}
 
 ### Update Production Status Dialog
@@ -122,7 +137,7 @@ It allows pasting a copy of your license into the form and saving it.
 Silver/Gold coverage customers can enable proactive support.
 This feature automatically emails TrueNAS when certain conditions occur in a TrueNAS system.
 
-**Proactive Support** opens a window where you configure proactive support.
+Click **Enable** in the **Set up Proactive Support** banner, or **Manage** in the proactive support row (when already enabled), to open the proactive support configuration screen.
 
 {{< trueimage src="/images/SCALE/SystemSettings/ProactiveSupportForm.png" alt="Proactive Support Form" id="Proactive Support Form" >}}
 

--- a/content/SCALE/SystemSettings/General/GeneralSettingsScreens.md
+++ b/content/SCALE/SystemSettings/General/GeneralSettingsScreens.md
@@ -91,7 +91,7 @@ The **Rate this page** is the default selection after clicking the option to rat
 
 **Message** is a text entry field for a longer description of what steps were taken and the result. The field provides examples of what to enter. This content populates the Jira ticket description field after clicking **Login To Jira To Submit**.
 
-**Attach debug**, which is selected by default, downloads and attaches a system debug to the Private Attachment Area TrueNaS provides to secure user confidential data that is part of the debug file.
+**Attach debug**, which is selected by default, downloads and attaches a system debug to the Private Attachment Area TrueNAS provides to secure user confidential data that is part of the debug file.
 
 **Take screenshot of the current page**, selected by default, takes a screenshot of the current screen.
 
@@ -107,7 +107,7 @@ Select the **Rate this page** to show options to submit review feedback on a UI 
 
 Stars set a rating using one (lowest) to five (best) stars.
 
-**Message** is a text entry field for comments about the screen you are rating. Include what you like, don't like, works well, or does not work well, and your exerience with the screen.
+**Message** is a text entry field for comments about the screen you are rating. Include what you like, don't like, works well, or does not work well, and your experience with the screen.
 
 **Take screenshot of the current page**, selected by default, takes a screenshot of the current screen.
 


### PR DESCRIPTION
This PR piggybacks off the changes made in https://github.com/truenas/documentation/pull/4513 to cover additional changes in the Support Card for 26, including the different support banner options and conditional behaviors.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
