### PR TITLE
DOCS-2589 / 25.04 / DOCS-2589-add-info-on-systems-ability-to-use-bash-instead-of-the-defa… (by linzi-ix)

### DIFF
--- a/content/SCALETutorials/SystemSettings/Advanced/ManageInitShutdownSCALE.md
+++ b/content/SCALETutorials/SystemSettings/Advanced/ManageInitShutdownSCALE.md
@@ -29,7 +29,7 @@ Click **Add** to open the **Add Init/Shutdown Script** configuration screen.
 
 Enter a description and then select **Command** or **Script** from the **Type** dropdown list. Selecting **Script** displays additional options.
 
-Enter the command string in **Command**, or if using a script, enter or use the browse to the path in **Script**. The script runs using [dash(1)](https://manpages.debian.org/testing/dash/sh.1.en.html "dash(1) Page").
+Enter the command string in **Command**, or if using a script, enter or use the browse to the path in **Script**. The script must have the execute bit set. By default scripts run using [dash(1)](https://manpages.debian.org/testing/dash/sh.1.en.html "dash(1) Page"), but you can run a script under a different interpreter by including a shebang line (for example, `#!/bin/bash`) as the first line of the script.
 
 Select the option from the **When** dropdown list for the time this command or script runs.
 

--- a/content/SCALEUIReference/SystemSettings/AdvancedSettingsScreen.md
+++ b/content/SCALEUIReference/SystemSettings/AdvancedSettingsScreen.md
@@ -162,7 +162,7 @@ Any script listed is a link that opens the **[Edit Init/Shutdown Script](#add-or
 | **Description** | Comments about this script. |
 | **Type** | Select *Command* for an executable or *Script* for an executable script. |
 | **Command** | Enter the command with any options. |
-| **Script** | Select the script. The script runs using [dash(1)](https://manpages.debian.org/testing/dash/sh.1.en.html "dash(1) Page"). |
+| **Script** | Select the script. Scripts run using [dash(1)](https://manpages.debian.org/testing/dash/sh.1.en.html "dash(1) Page") by default, or under the interpreter named in the shebang line of the script (for example, `#!/bin/bash`). |
 | **When** | Select when the command or script runs from the dropdown list. Options are **Pre Init** for early in the boot process, after mounting file systems and starting networking. **Post Init** runs at the end of the boot process before Linux services start. **Shutdown** runs during the system power-off process. |
 | **Enabled** | Select to enable this script. When left cleared, it disables the script without deleting it. |
 | **Timeout** | Automatically stop the script or command after the specified number of seconds. |


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x e4168e559b46585ebaaed303636dae7d6cd1f59c

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 3ed6f2467b22eb873a64733007f7178d5cd0658b


Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.


Original PR: https://github.com/truenas/documentation/pull/4626
Jira URL: https://ixsystemsinc.atlassian.net/browse/DOCS-2589