### PR TITLE
DOCS-2603 / 25.10 / Docs 2603 fix csv path resolution in release notes scripts (by DjP-iX)

### DIFF
--- a/scripts/release_notes/CHANGELOG.md
+++ b/scripts/release_notes/CHANGELOG.md
@@ -136,6 +136,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `release_notes.py` — Default CSV path now resolves to `documentation/static/data/{version}-changelog.csv` (previously `public/data/`). `public/data/` is a Hugo build artifact and is gitignored, so the prior default required either a Hugo build between dropping the CSV and running `prep`, or dropping the CSV into the build dir where it could be blown away on the next clean build. `static/data/` is the source-controlled location the team actually uses.
+- `README.md`, `QUICKSTART.md` — Updated CSV path references from `public/data/` to `static/data/`.
+- `test_release_notes.py` — Updated expected path to match new default. Fixed two pre-existing assertions that compared a `25.10.3` slug against `25_10_2_2`; the intent was clearly `25.10.2.2 -> 25_10_2_2` and `25.10.3 -> 25_10_3`.
+
 ### Planned Features
 
 **Version 1.1.0 (Q2 2026):**

--- a/scripts/release_notes/QUICKSTART.md
+++ b/scripts/release_notes/QUICKSTART.md
@@ -47,8 +47,8 @@ $env:GITHUB_TOKEN = "ghp_xxxxxxxxxxxx"
 
 ### Before You Start: Two Conventions to Know
 
-> **CSV naming:** Save your Jira export as `{version}-changelog.csv` in `documentation/public/data/`.
-> Example: `public/data/25.10.3-changelog.csv`
+> **CSV naming:** Save your Jira export as `{version}-changelog.csv` in `documentation/static/data/`.
+> Example: `static/data/25.10.3-changelog.csv`
 > The `prep` command looks for this file automatically.
 
 > **VersionNotes.md placeholder:** The new version tab must contain exactly this placeholder:
@@ -64,7 +64,7 @@ $env:GITHUB_TOKEN = "ghp_xxxxxxxxxxxx"
 
 1. Open your Jira filter for the release
 2. Click **Export** → **Export CSV (all fields)**
-3. Save as `documentation/public/data/25.10.X-changelog.csv`
+3. Save as `documentation/static/data/25.10.X-changelog.csv`
 
 ### Step 2: Run prep (5 minutes)
 
@@ -163,7 +163,7 @@ jump_to_buttons:
 
 ### "CSV file not found"
 
-The `prep` command looks for `public/data/{version}-changelog.csv`.
+The `prep` command looks for `static/data/{version}-changelog.csv`.
 Save your Jira export there, named exactly `{version}-changelog.csv`.
 
 ### "notable-changes.md not found"

--- a/scripts/release_notes/README.md
+++ b/scripts/release_notes/README.md
@@ -22,7 +22,7 @@ This automation reduces the process from ~2 hours to ~15 minutes.
 ```
 ┌──────────────────────────────────────────────┐
 │ 1. Export CSV from Jira Filter               │
-│    Save as public/data/{version}-changelog.csv│
+│    Save as static/data/{version}-changelog.csv│
 │    (Manual step - ~2 minutes)                │
 └────────────────┬─────────────────────────────┘
                  │
@@ -110,8 +110,8 @@ chmod +x update_version_notes.py
 ### Prerequisites: Two Conventions
 
 **CSV naming convention:**
-Save your Jira export to `documentation/public/data/` named `{version}-changelog.csv`.
-Example: `public/data/25.10.3-changelog.csv`
+Save your Jira export to `documentation/static/data/` named `{version}-changelog.csv`.
+Example: `static/data/25.10.3-changelog.csv`
 The `prep` command finds it automatically.
 
 **VersionNotes.md placeholder:**
@@ -127,7 +127,7 @@ See [Adding a New Version Tab](#adding-a-new-version-tab).
 
 1. Navigate to the Jira filter for your release
 2. Click **Export** → **Export CSV (all fields)**
-3. Save as `documentation/public/data/{version}-changelog.csv`
+3. Save as `documentation/static/data/{version}-changelog.csv`
 
 ### Step 2: Run prep
 

--- a/scripts/release_notes/release_notes.py
+++ b/scripts/release_notes/release_notes.py
@@ -25,7 +25,7 @@ def version_to_slug(version: str) -> str:
     """Convert version string to underscore-separated slug.
 
     Examples:
-        25.10.3 -> 25_10_2_2
+        25.10.2.2 -> 25_10_2_2
         25.10.3   -> 25_10_3
     """
     return version.replace(".", "_")
@@ -34,9 +34,9 @@ def version_to_slug(version: str) -> str:
 def default_csv_path(version: str) -> Path:
     """Return the expected CSV path for a given version.
 
-    Convention: documentation/public/data/{version}-changelog.csv
+    Convention: documentation/static/data/{version}-changelog.csv
     """
-    return (SCRIPTS_DIR / ".." / ".." / "public" / "data" / f"{version}-changelog.csv").resolve()
+    return (SCRIPTS_DIR / ".." / ".." / "static" / "data" / f"{version}-changelog.csv").resolve()
 
 
 def output_dir(version: str) -> Path:

--- a/scripts/release_notes/test_release_notes.py
+++ b/scripts/release_notes/test_release_notes.py
@@ -10,17 +10,17 @@ sys.path.insert(0, str(Path(__file__).parent))
 from release_notes import version_to_slug, default_csv_path, output_dir
 
 def test_version_to_slug():
-    assert version_to_slug("25.10.3") == "25_10_2_2"
+    assert version_to_slug("25.10.2.2") == "25_10_2_2"
     assert version_to_slug("25.10.3") == "25_10_3"
 
 def test_default_csv_path():
     script_dir = Path(__file__).parent
-    expected = script_dir / ".." / ".." / "public" / "data" / "25.10.3-changelog.csv"
+    expected = script_dir / ".." / ".." / "static" / "data" / "25.10.3-changelog.csv"
     assert default_csv_path("25.10.3") == expected.resolve()
 
 def test_output_dir():
     script_dir = Path(__file__).parent
-    expected = script_dir / "output" / "25_10_2_2"
+    expected = script_dir / "output" / "25_10_3"
     assert output_dir("25.10.3") == expected
 
 if __name__ == "__main__":


### PR DESCRIPTION
- `release_notes.py` — Default CSV path now resolves to `documentation/static/data/{version}-changelog.csv` (previously `public/data/`). `public/data/` is a Hugo build artifact and is gitignored, so the prior default required either a Hugo build between dropping the CSV and running `prep`, or dropping the CSV into the build dir where it could be blown away on the next clean build. `static/data/` is the source-controlled location the team actually uses.
- `README.md`, `QUICKSTART.md` — Updated CSV path references from `public/data/` to `static/data/`.
- `test_release_notes.py` — Updated expected path to match new default. Fixed two pre-existing assertions that compared a `25.10.3` slug against `25_10_2_2`; the intent was clearly `25.10.2.2 -> 25_10_2_2` and `25.10.3 -> 25_10_3`.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.


Original PR: https://github.com/truenas/documentation/pull/4633
Jira URL: https://ixsystemsinc.atlassian.net/browse/DOCS-2603