### PR TITLE
DOCS-2594 / 26 / DOCS-2594-correct-fusion-pools-content-to-indicate-spares-only-allocate-to-data-vdev (by DjP-iX)

### DIFF
--- a/static/includes/FusionPoolsCommonContent.md
+++ b/static/includes/FusionPoolsCommonContent.md
@@ -1,15 +1,16 @@
 &NewLine;
 
 {{< hint type=important >}}
-Metadata VDEVs are critical for pool operation and data integrity. Protect them with redundancy measures such as mirroring, and optionally hot spare(s) for additional fault tolerance. Each Metadata VDEV must use a redundancy level equal to or greater than the data VDEVs. For example, if data VDEVs are configured as RAIDZ2, use RAIDZ2 or a three-way mirror for Metadata VDEVs. Pool creation fails when Metadata VDEV redundancy is lower than data VDEV redundancy.
+Metadata VDEVs are critical for pool operation and data integrity. Protect them with redundancy measures such as mirroring. Each Metadata VDEV must use a redundancy level equal to or greater than the data VDEVs. For example, if data VDEVs are configured as RAIDZ2, use RAIDZ2 or a three-way mirror for Metadata VDEVs. Pool creation fails when Metadata VDEV redundancy is lower than data VDEV redundancy.
 {{< /hint >}}
 
 {{< expand "UPS Recommendation" "v" >}}
 When using SSDs with an internal cache, add an uninterruptible power supply (UPS) to the system to help minimize the risk from power loss.
 {{< /expand >}}
 
-Using special VDEVs identical to the data VDEVs (so they can use the same hot spares) is recommended, but for performance reasons, you can make a different type of VDEV (like a mirror of SSDs).
-In that case, you must provide hot spare(s) for that drive type as well. Otherwise, if the special VDEV fails and there is no redundancy, the pool becomes corrupted and prevents access to stored data.
+Hot spares only activate in data VDEVs, so a hot spare cannot replace a failed drive in a special VDEV. The special VDEV must protect itself with its own internal redundancy (a mirror at the redundancy level required above). Without it, if the special VDEV fails the pool becomes corrupted and prevents access to stored data.
+
+Special VDEVs often use a different drive type than the data VDEVs (such as a mirror of SSDs) for better performance. Provide sufficient internal redundancy for the special VDEV regardless of drive type.
 
 {{< hint type=important >}}
 While the metadata VDEV can be adjusted after its addition by attaching or detaching drives, the entire metadata VDEV itself can only be removed from the pool when the pool data VDEVs are mirrors. *If the pool uses RAIDZ data VDEVs, a metadata VDEV is a permanent addition to the pool and cannot be removed.*


### PR DESCRIPTION
  static/includes/FusionPoolsCommonContent.md:
  - Removed the false implication that hot spares add fault tolerance to Metadata VDEVs (line 4).
  - Replaced the "share hot spares" / "provide hot spares for that drive type" guidance with the actual rule: hot spares
  activate only in data VDEVs, so the special VDEV must have its own internal redundancy. Kept the pool-corruption
  consequence and the drive-type-choice point (lines 11-12).
  
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.


Original PR: https://github.com/truenas/documentation/pull/4635
Jira URL: https://ixsystemsinc.atlassian.net/browse/DOCS-2594