### PR TITLE
DOCS-2590 / 25.10 / DOCS-2590 Add Section on setting SSH+NETCAT to the Advance Replicatio… (by micjohnson777)

### DIFF
--- a/content/SCALETutorials/DataProtection/Replication/AdvancedReplication/_index.md
+++ b/content/SCALETutorials/DataProtection/Replication/AdvancedReplication/_index.md
@@ -126,7 +126,7 @@ The **Add Replication Task** configuration screen opens.
 
 When setting **Transport** to **SSH+NETCAT**, the replication administration user on the remote system requires passwordless `sudo` access for both <file>/usr/sbin/zfs</file> and <file>/usr/bin/python3</file>. The automatic SSH configuration only grants sudo rights for <file>/usr/sbin/zfs</file>. Without the additional `python3` entry, the task fails with:
 
-**[EFAULT] Unknown SSH+NETCAT transport error: 'sudo: a terminal is required to read the password**
+**[EFAULT] Unknown SSH+NETCAT transport error: 'sudo: a terminal is required to read the password'**
 
 First, verify the root user password is enabled on the remote TrueNAS system.
 Go to **Credentials > Users**, select the root user, and confirm the password is not disabled and has a password set.

--- a/content/SCALETutorials/DataProtection/Replication/AdvancedReplication/_index.md
+++ b/content/SCALETutorials/DataProtection/Replication/AdvancedReplication/_index.md
@@ -122,6 +122,27 @@ The **Add Replication Task** configuration screen opens.
 
 7. Click **Save**.
 
+### Setting up Replication with SSH+NETCAT
+
+When setting **Transport** to **SSH+NETCAT**, the replication administration user on the remote system requires passwordless `sudo` access for both <file>/usr/sbin/zfs</file> and <file>/usr/bin/python3</file>. The automatic SSH configuration only grants sudo rights for <file>/usr/sbin/zfs</file>. Without the additional `python3` entry, the task fails with:
+
+**[EFAULT] Unknown SSH+NETCAT transport error: 'sudo: a terminal is required to read the password**
+
+First, verify the root user password is enabled on the remote TrueNAS system.
+Go to **Credentials > Users**, select the root user, and confirm the password is not disabled and has a password set.
+
+Next, add the required `sudo` entry on the remote TrueNAS system:
+
+1. Log in to the remote system as root through an SSH session or use the TrueNAS **Shell**.
+2. Run `visudo` to open the <file>sudoers</file> file.
+3. Add the following line for the replication user, replacing *username* with the actual user:
+
+   <code><i>username</i> ALL=(ALL) NOPASSWD: /usr/bin/python3</code>
+4. Save and exit.
+
+You can then create the replication task on the local system using the **Add Replication Task** screen.
+Click **Add** on the **Data Protection > Replication** card to open the wizard, then click **Advanced Replication Task** to open the **Add Replication Task** screen.
+
 ### Setting a Replication Compression Level
 
 Options for compressing data, adding a bandwidth limit, or other data stream customizations are available.


### PR DESCRIPTION

This commit/PR adds instructions when setting Transport to SSH+NETCAT to avoid the sudo error message.

Backports to 26.0 and 25.10

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.


Original PR: https://github.com/truenas/documentation/pull/4636
Jira URL: https://ixsystemsinc.atlassian.net/browse/DOCS-2590