### PR TITLE
DOCS-2663 / 26 / Backport DHM copy-edit fixes missed in 26 port

### DIFF
--- a/content/Storage/Disks/DriveHealthManagement.md
+++ b/content/Storage/Disks/DriveHealthManagement.md
@@ -19,7 +19,7 @@ doctype: tutorial
 Drive Health Management (DHM) in TrueNAS monitors the condition of installed HDD and SSD drives (SAS, SATA, and NVMe) and alerts you when action is required. TrueNAS manages drive health with three layers:
 
 - **ZFS** detects sudden failures in real time during active read and write operations.
-- **TrueNAS Middleware** automatically polls SMART (Self-Monitoring, Analysis, and Reporting Technology) data in each drive
+- **TrueNAS Middleware** automatically polls SMART (Self-Monitoring, Analysis, and Reporting Technology) data in each drive.
 - **TrueNAS Middleware** handles the alert logic and provides actionable notifications.
 
 TrueNAS DHM is designed to:
@@ -84,7 +84,7 @@ Click an alert to expand it and view details, including the affected disk, the a
 {{< /truetable >}}
 
 
-## SMART Tests Options for Community Edition
+## SMART Test Options for Community Edition
 
 {{< hint type=note >}}
 TrueNAS handles SMART testing through its automated DHM polling.


### PR DESCRIPTION
Backports two copy-edit fixes to the 26 `DriveHealthManagement` page. Both were authored correctly on master at file creation (`306138f83`) but the 26 copy (`4e2d2fc1d`) regressed them:

- Add missing period to the SMART middleware bullet.
- Correct heading `SMART Tests Options` -> `SMART Test Options`.

Verified no inbound links reference the old `#smart-tests-options` anchor, so the heading rename breaks nothing. Companion to the 25.10 DOCS-2663 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)