### PR TITLE
DOCS-2551 / master / Revert pnpm version pin to latest

### DIFF
--- a/.github/workflows/build-external-contrib.yml
+++ b/.github/workflows/build-external-contrib.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: latest
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2.6.0

--- a/.github/workflows/build-internal-contrib.yml
+++ b/.github/workflows/build-internal-contrib.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: latest
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2.6.0


### PR DESCRIPTION
Reverts the temporary pnpm pin in `build-internal-contrib.yml` and `build-external-contrib.yml` from `9` back to `latest`, targeting `master`.

## Background
The pin was added in #4581 (May 7, 2026) because pnpm 11 — which `latest` resolved to — requires Node.js v22.13+, while GitHub's default runner provided Node.js v20 at the time.

Per [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/), runners default to Node.js 24 as of June 2, 2026, which satisfies pnpm 11's requirement. The workaround is no longer needed.

## Change
```yaml
- uses: pnpm/action-setup@v4
  with:
    version: latest   # was: 9
```

This restores the files to their exact pre-pin state.

Draft pending green build checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)