### PR TITLE
DOCS-2686 / 3.0 / add Multibranch Jenkinsfile + docs-build.env (3.0, observe-only)

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
 
   environment {
     HUGO_ENV = 'production'
+    ALERT_EMAIL = 'docs@truenas.com'          // docs-team Google Group (role alias)
   }
 
   stages {
@@ -73,18 +74,16 @@ pipeline {
 
   post {
     failure {
-      withCredentials([string(credentialsId: 'docs-slack-webhook', variable: 'HOOK')]) {
-        sh '''curl -s -X POST -H 'Content-type: application/json' \
-          --data "{\\"text\\":\\":x: Docs Versioned Sites — ${JOB_NAME} #${BUILD_NUMBER} FAILED (${BRANCH_NAME}) ${BUILD_URL}\\"}" \
-          "$HOOK" || true'''
-      }
+      mail to: env.ALERT_EMAIL,
+           subject: "[DOCS BUILD FAILED] ${env.JOB_NAME} #${env.BUILD_NUMBER} (${env.BRANCH_NAME})",
+           body: "A Docs Versioned Sites build failed; the site may not be fully published.\n\n" +
+                 "Branch: ${env.BRANCH_NAME}\nBuild:  ${env.BUILD_URL}\n\n" +
+                 "Publish/Symlink/Purge fail-fast, so a red build here means rsync/symlink/purge did not all complete. Check the console, fix, and re-run."
     }
     fixed {
-      withCredentials([string(credentialsId: 'docs-slack-webhook', variable: 'HOOK')]) {
-        sh '''curl -s -X POST -H 'Content-type: application/json' \
-          --data "{\\"text\\":\\":white_check_mark: Docs Versioned Sites — ${JOB_NAME} #${BUILD_NUMBER} recovered (${BRANCH_NAME})\\"}" \
-          "$HOOK" || true'''
-      }
+      mail to: env.ALERT_EMAIL,
+           subject: "[DOCS BUILD RECOVERED] ${env.JOB_NAME} #${env.BUILD_NUMBER} (${env.BRANCH_NAME})",
+           body: "A previously failing Docs Versioned Sites build is green again.\n\nBranch: ${env.BRANCH_NAME}\nBuild:  ${env.BUILD_URL}"
     }
   }
 }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -20,8 +20,12 @@ pipeline {
           env.OUTPUT_DIR      = (cfg.OUTPUT_DIR ?: '').trim()
           env.DEPLOY_SCRIPT   = (cfg.DEPLOY_SCRIPT ?: '').trim()
           env.PAGEFIND_GLOB   = (cfg.PAGEFIND_GLOB ?: '').trim()
-          echo "branch=${env.BRANCH_NAME} publish=${env.PUBLISH_TO_PROD} out=${env.OUTPUT_DIR} deploy=${env.DEPLOY_SCRIPT}"
-          if (env.PUBLISH_TO_PROD == 'true' && !env.OUTPUT_DIR) {
+          env.ARCHIVED        = (cfg.ARCHIVED ?: 'false').trim()
+          echo "branch=${env.BRANCH_NAME} publish=${env.PUBLISH_TO_PROD} archived=${env.ARCHIVED} out=${env.OUTPUT_DIR} deploy=${env.DEPLOY_SCRIPT}"
+          if (env.ARCHIVED == 'true') {
+            echo 'ARCHIVED=true — this version is frozen. Build and Deploy are skipped; the live symlink is maintained by the Nightly Maintenance reconcile.'
+          }
+          if (env.PUBLISH_TO_PROD == 'true' && env.ARCHIVED != 'true' && !env.OUTPUT_DIR) {
             error 'PUBLISH_TO_PROD=true but OUTPUT_DIR is empty — refusing to publish to an undefined path.'
           }
         }
@@ -29,6 +33,7 @@ pipeline {
     }
 
     stage('Build') {
+      when { expression { env.ARCHIVED != 'true' } }   // frozen versions are not rebuilt
       steps {
         sh 'npm install -D --save autoprefixer'
         sh 'npm install -D --save postcss-cli'
@@ -42,7 +47,12 @@ pipeline {
     }
 
     stage('Deploy') {
-      when { environment name: 'PUBLISH_TO_PROD', value: 'true' }
+      when {
+        allOf {
+          environment name: 'PUBLISH_TO_PROD', value: 'true'
+          expression { env.ARCHIVED != 'true' }   // frozen versions are not re-published here
+        }
+      }
       options { lock('docs1-deploy') }        // cross-branch mutex (spec 3.5)
       stages {
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,0 +1,90 @@
+pipeline {
+  agent { label 'hugo-pr' }
+
+  options {
+    disableConcurrentBuilds()                 // no same-branch races (spec 3.5)
+    buildDiscarder(logRotator(numToKeepStr: '15'))
+    timestamps()
+  }
+
+  environment {
+    HUGO_ENV = 'production'
+  }
+
+  stages {
+    stage('Load config') {
+      steps {
+        script {
+          def cfg = readProperties file: 'jenkins/docs-build.env'
+          env.PUBLISH_TO_PROD = (cfg.PUBLISH_TO_PROD ?: 'false').trim()
+          env.OUTPUT_DIR      = (cfg.OUTPUT_DIR ?: '').trim()
+          env.DEPLOY_SCRIPT   = (cfg.DEPLOY_SCRIPT ?: '').trim()
+          env.PAGEFIND_GLOB   = (cfg.PAGEFIND_GLOB ?: '').trim()
+          echo "branch=${env.BRANCH_NAME} publish=${env.PUBLISH_TO_PROD} out=${env.OUTPUT_DIR} deploy=${env.DEPLOY_SCRIPT}"
+          if (env.PUBLISH_TO_PROD == 'true' && !env.OUTPUT_DIR) {
+            error 'PUBLISH_TO_PROD=true but OUTPUT_DIR is empty — refusing to publish to an undefined path.'
+          }
+        }
+      }
+    }
+
+    stage('Build') {
+      steps {
+        sh 'npm install -D --save autoprefixer'
+        sh 'npm install -D --save postcss-cli'
+        sh 'hugo -d public --gc --minify --cleanDestinationDir'
+        script {
+          if (env.PAGEFIND_GLOB) {
+            sh "npx pagefind --site \"public\" --glob \"{${env.PAGEFIND_GLOB}}/**/*.html\""
+          }
+        }
+      }
+    }
+
+    stage('Deploy') {
+      when { environment name: 'PUBLISH_TO_PROD', value: 'true' }
+      options { lock('docs1-deploy') }        // cross-branch mutex (spec 3.5)
+      stages {
+
+        stage('Publish') {                    // same node as Build -> has public/
+          steps {
+            sh """rsync -rvza -e 'ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no' \
+              --delete --exclude='pdf/' --exclude='PRs/' --exclude='CNAME' --exclude='download/' \
+              public/ docs@10.242.64.28:/var/www/html/${env.OUTPUT_DIR}"""
+          }
+        }
+
+        stage('Symlink') {
+          when { expression { env.DEPLOY_SCRIPT?.trim() } }   // empty => skip (e.g. master)
+          agent { label 'security' }
+          steps {
+            retry(3) { sh "/root/docs-hugo/${env.DEPLOY_SCRIPT}" }
+          }
+        }
+
+        stage('Purge') {
+          steps {
+            retry(3) { build job: '/Documentation/PurgeCDNIfInValidState', wait: true }
+          }
+        }
+      }
+    }
+  }
+
+  post {
+    failure {
+      withCredentials([string(credentialsId: 'docs-slack-webhook', variable: 'HOOK')]) {
+        sh '''curl -s -X POST -H 'Content-type: application/json' \
+          --data "{\\"text\\":\\":x: Docs Versioned Sites — ${JOB_NAME} #${BUILD_NUMBER} FAILED (${BRANCH_NAME}) ${BUILD_URL}\\"}" \
+          "$HOOK" || true'''
+      }
+    }
+    fixed {
+      withCredentials([string(credentialsId: 'docs-slack-webhook', variable: 'HOOK')]) {
+        sh '''curl -s -X POST -H 'Content-type: application/json' \
+          --data "{\\"text\\":\\":white_check_mark: Docs Versioned Sites — ${JOB_NAME} #${BUILD_NUMBER} recovered (${BRANCH_NAME})\\"}" \
+          "$HOOK" || true'''
+      }
+    }
+  }
+}

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
 
   environment {
     HUGO_ENV = 'production'
-    ALERT_EMAIL = 'docs@truenas.com'          // docs-team Google Group (role alias)
   }
 
   stages {
@@ -72,18 +71,14 @@ pipeline {
     }
   }
 
+  // Failure alerting deferred (DOCS-2686): the Mailer 'mail' step throws
+  // NoSuchMethodError against the installed Mailer plugin version, and no
+  // Jenkins->Slack integration exists; fixing either needs Jenkins-admin.
+  // For now rely on the RED build status. Wire up email (mail/emailext) or
+  // Slack once IT updates the Mailer plugin — tracked as a DOCS-2686 follow-up.
   post {
     failure {
-      mail to: env.ALERT_EMAIL,
-           subject: "[DOCS BUILD FAILED] ${env.JOB_NAME} #${env.BUILD_NUMBER} (${env.BRANCH_NAME})",
-           body: "A Docs Versioned Sites build failed; the site may not be fully published.\n\n" +
-                 "Branch: ${env.BRANCH_NAME}\nBuild:  ${env.BUILD_URL}\n\n" +
-                 "Publish/Symlink/Purge fail-fast, so a red build here means rsync/symlink/purge did not all complete. Check the console, fix, and re-run."
-    }
-    fixed {
-      mail to: env.ALERT_EMAIL,
-           subject: "[DOCS BUILD RECOVERED] ${env.JOB_NAME} #${env.BUILD_NUMBER} (${env.BRANCH_NAME})",
-           body: "A previously failing Docs Versioned Sites build is green again.\n\nBranch: ${env.BRANCH_NAME}\nBuild:  ${env.BUILD_URL}"
+      echo 'Build FAILED — see console output. Automated alerting is pending an IT plugin fix (Mailer); no email/Slack sent.'
     }
   }
 }

--- a/jenkins/docs-build.env
+++ b/jenkins/docs-build.env
@@ -1,0 +1,4 @@
+PUBLISH_TO_PROD=false
+OUTPUT_DIR=3.0
+DEPLOY_SCRIPT=docs-truecommand-3.0-to-prod.sh
+PAGEFIND_GLOB=adminguide,api,notices,recommendations,tcgettingstarted,userguide


### PR DESCRIPTION
**DOCS-2686 Workstream A — Phase B (observe-only).**

Adds shared `jenkins/Jenkinsfile` + per-branch `jenkins/docs-build.env` to `3.0` (diff = these two files only).

- `PUBLISH_TO_PROD=false` → new `Docs Versioned Sites` Multibranch pipeline build-validates this branch but **publishes nothing**; existing `jenkins/update-*` job stays sole publisher until Phase C cutover.
- Merging triggers the existing **Build Version Branch 3.0** job (normal per-version rebuild).

Part of DOCS-2686 (consolidate per-version Build/Symlink jobs into one Multibranch pipeline).