### PR TITLE
DOCS-2686 / 25.04 / cut over 25.04 to Docs Versioned Sites (enable publish)

### DIFF
--- a/jenkins/docs-build.env
+++ b/jenkins/docs-build.env
@@ -1,4 +1,4 @@
-PUBLISH_TO_PROD=false
+PUBLISH_TO_PROD=true
 OUTPUT_DIR=25.04
 DEPLOY_SCRIPT=docs-scale-25.04-to-prod.sh
 PAGEFIND_GLOB=api,gettingstarted,scalesecurityreports,scaletutorials,scaleuireference

--- a/static/includes/25.04FeatureList.md
+++ b/static/includes/25.04FeatureList.md
@@ -29,6 +29,6 @@ TrueNAS 25.04 (Fangtooth) brings many new features and improvements to the TrueN
   
 * (Updated for 25.04.2) Reintroduced "classic virtualization" with the [**Virtual Machines**]({{< ref "/scaletutorials/virtualmachines/" >}}) feature.
 
-* Improvements to the TrueNAS apps service, including per-app selection of IP addresses (See [TrueNAS Apps](/gettingstarted/scalereleasenotes/#truenas-apps) in the Upgrade Notes).
+* Improvements to the TrueNAS apps service, including per-app selection of IP addresses (See [TrueNAS Apps](/gettingstarted/scalereleasenotes/#truenas-apps) in Upgrade Notes).
 
 {{< /columns >}}


### PR DESCRIPTION
**DOCS-2686 Workstream A — Phase C cutover: 25.04 → live via Docs Versioned Sites.**

Flips `PUBLISH_TO_PROD` false→true for 25.04 (one-line change). After merge, the new `Docs Versioned Sites` pipeline publishes 25.04: rsync → `/var/www/html/25.04` → `docs-scale-25.04-to-prod.sh` → CDN purge.

**Merge ONLY after the old `Build Version Branch 25.04` and `Symlink … 25.04` jobs are DISABLED** (so the two publishers don't both run).

Rollback if needed: set PUBLISH_TO_PROD=false + re-enable the old 25.04 jobs (`jenkins/update-25.04` is still present).