### PR TITLE
DOCS-2686 / 24.10 / cut over 24.10 to Docs Versioned Sites (enable publish)

### DIFF
--- a/jenkins/docs-build.env
+++ b/jenkins/docs-build.env
@@ -1,4 +1,4 @@
-PUBLISH_TO_PROD=false
+PUBLISH_TO_PROD=true
 OUTPUT_DIR=24.10
 DEPLOY_SCRIPT=docs-scale-24.10-to-prod.sh
 PAGEFIND_GLOB=api,gettingstarted,scalesecurityreports,scaletutorials,scaleuireference


### PR DESCRIPTION
**DOCS-2686 Workstream A — Phase C cutover: 24.10 → live via Docs Versioned Sites.**

Flips `PUBLISH_TO_PROD` false→true for 24.10. After merge, the new `Docs Versioned Sites` pipeline publishes 24.10: rsync → `/var/www/html/24.10` → `docs-scale-24.10-to-prod.sh` → CDN purge.

**Merge ONLY after the old `Build Version Branch 24.10` and `Symlink … 24.10` jobs are DISABLED.**

This merge also serves as the **push-trigger test** — watch whether the new pipeline auto-fires on merge (no Build Now).

Rollback: PUBLISH_TO_PROD=false + re-enable old 24.10 jobs (`jenkins/update-24.10` still present).