### PR TITLE
DOCS-2686 / 25.10 / cut over 25.10 to Docs Versioned Sites (enable publish)

### DIFF
--- a/jenkins/docs-build.env
+++ b/jenkins/docs-build.env
@@ -1,4 +1,4 @@
-PUBLISH_TO_PROD=false
+PUBLISH_TO_PROD=true
 OUTPUT_DIR=25.10
 DEPLOY_SCRIPT=docs-scale-25.10-to-prod.sh
 PAGEFIND_GLOB=api,gettingstarted,scalesecurityreports,scaletutorials,scaleuireference


### PR DESCRIPTION
**DOCS-2686 Phase C cutover: 25.10 → live via Docs Versioned Sites.**

Flips PUBLISH_TO_PROD false→true for 25.10. After merge, the new pipeline publishes: rsync → /var/www/html/25.10 → docs-scale-25.10-to-prod.sh → CDN purge. Auto-fires on merge (push-trigger proven).

Merge ONLY after old `Build Version Branch 25.10` + `Symlink … 25.10 into Production` are DISABLED (25.10 is newer-pattern: 2 old jobs, no dev-symlinks).

Rollback: PUBLISH_TO_PROD=false + re-enable old jobs (update-25.10 still present).