### PR TITLE
DOCS-2686 / 26 / cut over 26 to Docs Versioned Sites (enable publish)

### DIFF
--- a/jenkins/docs-build.env
+++ b/jenkins/docs-build.env
@@ -1,4 +1,4 @@
-PUBLISH_TO_PROD=false
+PUBLISH_TO_PROD=true
 OUTPUT_DIR=26
 DEPLOY_SCRIPT=docs-scale-26-to-prod.sh
 PAGEFIND_GLOB=api,apps,containers,credentials,dashboard,dataprotection,datasets,gettingstarted,network,reporting,scalesecurityreports,shares,storage,systemsettings,toptoolbar,virtualmachines


### PR DESCRIPTION
**DRAFT until old jobs disabled.** DOCS-2686 Phase C cutover: 26 → live via Docs Versioned Sites.

Flips PUBLISH_TO_PROD false→true for 26. After merge: rsync → /var/www/html/26 → docs-scale-26-to-prod.sh → CDN purge. Auto-fires on merge.

**Before marking ready/merging:** DISABLE old `Build Version Branch 26` + `Symlink … 26 into Production` (newer-pattern: 2 old jobs, no dev-symlinks).

Rollback: PUBLISH_TO_PROD=false + re-enable old jobs (update-26 still present).