### PR TITLE
DOCS-2686 / 3.0 / cut over 3.0 (TrueCommand) to Docs Versioned Sites (enable publish)

### DIFF
--- a/jenkins/docs-build.env
+++ b/jenkins/docs-build.env
@@ -1,4 +1,4 @@
-PUBLISH_TO_PROD=false
+PUBLISH_TO_PROD=true
 OUTPUT_DIR=3.0
 DEPLOY_SCRIPT=docs-truecommand-3.0-to-prod.sh
 PAGEFIND_GLOB=adminguide,api,notices,recommendations,tcgettingstarted,userguide


### PR DESCRIPTION
**DRAFT until old jobs disabled.** DOCS-2686 Phase C cutover: 3.0 (TrueCommand) → live via Docs Versioned Sites.

Flips PUBLISH_TO_PROD false→true for 3.0. After merge: rsync → /var/www/html/3.0 → docs-truecommand-3.0-to-prod.sh → CDN purge. Auto-fires on merge.

**Before marking ready/merging:** DISABLE ALL 4 old 3.0 jobs — `Build Version Branch TrueCommand 3.0`, `Symlink … into Production truenas.com`, AND the two auto dev-symlinks (`… into docs-dev`, `… into docs-dev1`). 3.0 is older-pattern; the dev-symlinks are the unwanted auto-mirror.

Rollback: PUBLISH_TO_PROD=false + re-enable old jobs (update-3.0 still present).