### PR TITLE
DOCS-2686 / 27 / cut over master (root docs hub) to Docs Versioned Sites (enable publish)

### DIFF
--- a/jenkins/docs-build.env
+++ b/jenkins/docs-build.env
@@ -1,4 +1,4 @@
-PUBLISH_TO_PROD=false
+PUBLISH_TO_PROD=true
 OUTPUT_DIR=docs1
 DEPLOY_SCRIPT=
 PAGEFIND_GLOB=api,archive,contributing,core,hardware,references,scale,softwarestatus,solutions,truecommand,truenasupgrades


### PR DESCRIPTION
**DRAFT — highest blast radius (root docs hub /var/www/html/docs1 = truenas.com/docs). Do LAST, carefully.**

Flips PUBLISH_TO_PROD false→true for master. After merge, the new pipeline publishes master: rsync → /var/www/html/docs1 → CDN purge. DEPLOY_SCRIPT is empty (root publish, NO symlink stage — matches old behavior). Mechanically identical rsync to the old `TrueNAS Docs Update Master`; both rsync+purge already proven on version cutovers.

**Prerequisite ordering (do NOT merge until all done):**
1. All version cutovers green (25.10, 26, 3.0).
2. **Create + verify the `Nightly Maintenance` job FIRST** (software-status auto-PR + reconcile/purge). This must exist before we retire the old master job, so the scheduled symlink/purge safety net is in place.
3. **Disable `TrueNAS Docs Update Master`** immediately before merging this — so a master push does NOT trigger BOTH the old job and the new pipeline rsyncing to docs1 concurrently (would race on --delete).
4. Merge → new pipeline publishes docs1 → verify truenas.com/docs live.

**Rollback:** PUBLISH_TO_PROD=false + re-enable `TrueNAS Docs Update Master` + manually run it to republish docs1 from master. (jenkins/update-master still present.)