### PR TITLE
DOCS-2686 / 13.0 / cut over 13.0 (Core) to Docs Versioned Sites (enable publish)

### DIFF
--- a/jenkins/docs-build.env
+++ b/jenkins/docs-build.env
@@ -1,4 +1,4 @@
-PUBLISH_TO_PROD=false
+PUBLISH_TO_PROD=true
 OUTPUT_DIR=core/13.0
 DEPLOY_SCRIPT=docs-core-13.0-to-prod.sh
 PAGEFIND_GLOB=


### PR DESCRIPTION
**DRAFT until old jobs disabled.** DOCS-2686 Phase C cutover: 13.0 (Core) → live via Docs Versioned Sites.

Corrects earlier categorization: 13.0 is an ACTIVE LIVE branch (getting limited updates until an EOL/archive decision), NOT dormant. Builds fine on current Hugo. So: PUBLISH_TO_PROD=true, ARCHIVED stays false (keeps rebuilding on updates). After merge: rsync → /var/www/html/core/13.0 → docs-core-13.0-to-prod.sh → CDN purge. Also makes the nightly reconcile maintain 13.0's symlink.

**Before marking ready/merging:** confirm docs-core-13.0-to-prod.sh via old `Symlink Core 13.0 into Production` console, and DISABLE 13.0's old jobs (in Docs/Archived/Core 13.0 — Build + Prod-symlink + any dev-symlinks).

Rollback: PUBLISH_TO_PROD=false + re-enable old jobs (update-core-13.0 still present).