### PR TITLE
DOCS-2686 / 2.3 / bring TrueCommand 2.3 into pipeline as archived-but-live

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,0 +1,94 @@
+pipeline {
+  agent { label 'hugo-pr' }
+
+  options {
+    disableConcurrentBuilds()                 // no same-branch races (spec 3.5)
+    buildDiscarder(logRotator(numToKeepStr: '15'))
+    timestamps()
+  }
+
+  environment {
+    HUGO_ENV = 'production'
+  }
+
+  stages {
+    stage('Load config') {
+      steps {
+        script {
+          def cfg = readProperties file: 'jenkins/docs-build.env'
+          env.PUBLISH_TO_PROD = (cfg.PUBLISH_TO_PROD ?: 'false').trim()
+          env.OUTPUT_DIR      = (cfg.OUTPUT_DIR ?: '').trim()
+          env.DEPLOY_SCRIPT   = (cfg.DEPLOY_SCRIPT ?: '').trim()
+          env.PAGEFIND_GLOB   = (cfg.PAGEFIND_GLOB ?: '').trim()
+          env.ARCHIVED        = (cfg.ARCHIVED ?: 'false').trim()
+          echo "branch=${env.BRANCH_NAME} publish=${env.PUBLISH_TO_PROD} archived=${env.ARCHIVED} out=${env.OUTPUT_DIR} deploy=${env.DEPLOY_SCRIPT}"
+          if (env.ARCHIVED == 'true') {
+            echo 'ARCHIVED=true — this version is frozen. Build and Deploy are skipped; the live symlink is maintained by the Nightly Maintenance reconcile.'
+          }
+          if (env.PUBLISH_TO_PROD == 'true' && env.ARCHIVED != 'true' && !env.OUTPUT_DIR) {
+            error 'PUBLISH_TO_PROD=true but OUTPUT_DIR is empty — refusing to publish to an undefined path.'
+          }
+        }
+      }
+    }
+
+    stage('Build') {
+      when { expression { env.ARCHIVED != 'true' } }   // frozen versions are not rebuilt
+      steps {
+        sh 'npm install -D --save autoprefixer'
+        sh 'npm install -D --save postcss-cli'
+        sh 'hugo -d public --gc --minify --cleanDestinationDir'
+        script {
+          if (env.PAGEFIND_GLOB) {
+            sh "npx pagefind --site \"public\" --glob \"{${env.PAGEFIND_GLOB}}/**/*.html\""
+          }
+        }
+      }
+    }
+
+    stage('Deploy') {
+      when {
+        allOf {
+          environment name: 'PUBLISH_TO_PROD', value: 'true'
+          expression { env.ARCHIVED != 'true' }   // frozen versions are not re-published here
+        }
+      }
+      options { lock('docs1-deploy') }        // cross-branch mutex (spec 3.5)
+      stages {
+
+        stage('Publish') {                    // same node as Build -> has public/
+          steps {
+            sh """rsync -rvza -e 'ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no' \
+              --delete --exclude='pdf/' --exclude='PRs/' --exclude='CNAME' --exclude='download/' \
+              public/ docs@10.242.64.28:/var/www/html/${env.OUTPUT_DIR}"""
+          }
+        }
+
+        stage('Symlink') {
+          when { expression { env.DEPLOY_SCRIPT?.trim() } }   // empty => skip (e.g. master)
+          agent { label 'security' }
+          steps {
+            retry(3) { sh "/root/docs-hugo/${env.DEPLOY_SCRIPT}" }
+          }
+        }
+
+        stage('Purge') {
+          steps {
+            retry(3) { build job: '/Documentation/PurgeCDNIfInValidState', wait: true }
+          }
+        }
+      }
+    }
+  }
+
+  // Failure alerting deferred (DOCS-2686): the Mailer 'mail' step throws
+  // NoSuchMethodError against the installed Mailer plugin version, and no
+  // Jenkins->Slack integration exists; fixing either needs Jenkins-admin.
+  // For now rely on the RED build status. Wire up email (mail/emailext) or
+  // Slack once IT updates the Mailer plugin — tracked as a DOCS-2686 follow-up.
+  post {
+    failure {
+      echo 'Build FAILED — see console output. Automated alerting is pending an IT plugin fix (Mailer); no email/Slack sent.'
+    }
+  }
+}

--- a/jenkins/docs-build.env
+++ b/jenkins/docs-build.env
@@ -1,0 +1,5 @@
+PUBLISH_TO_PROD=false
+OUTPUT_DIR=2.3
+DEPLOY_SCRIPT=docs-truecommand-2.3-to-prod.sh
+PAGEFIND_GLOB=
+ARCHIVED=true


### PR DESCRIPTION
**DRAFT — confirm DEPLOY_SCRIPT name before marking ready.** DOCS-2686: bring TrueCommand 2.3 into the new pipeline as **archived-but-live** (same handling as 24.04/13.3).

Adds shared jenkins/Jenkinsfile + jenkins/docs-build.env with **ARCHIVED=true** → the pipeline never builds/deploys it (green no-op in Docs Versioned Sites); the nightly reconcile re-asserts its symlink via DEPLOY_SCRIPT. This preserves the symlink re-assertion that the old master fan-out does today, so retiring `TrueNAS Docs Update Master` won't drop 2.3.

- OUTPUT_DIR=2.3 (content at /var/www/html/2.3 — confirmed via git)
- DEPLOY_SCRIPT=docs-truecommand-2.3-to-prod.sh (**INFERRED — confirm via old `Symlink … 2.3 into Production` console before marking ready**)

Must merge before the master cutover (which retires the fan-out). Old 2.3 jobs (Docs/Archived) retired in Phase D.