### PR TITLE
DOCS-2686 / 27 / DOCS-2686 FIX: stop master rsync from deleting version symlinks

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -58,15 +58,16 @@ pipeline {
 
         stage('Publish') {                    // same node as Build -> has public/
           steps {
-            // The version symlinks live INSIDE the shared docs1 root (docs1/scale/26,
-            // docs1/core/13.3, docs1/truecommand/3.0 ...). master publishes to docs1 with
-            // --delete, which would wipe those symlinks. Exclude the version dirs (any
-            // <product>/<digit...>) so master only manages its own content and never touches
-            // the version symlinks (owned by version deploys + the nightly reconcile).
+            // The version symlinks live INSIDE the shared docs1 root. master publishes to docs1
+            // with --delete, which would wipe them, and master has no step to recreate them.
+            // Exclude every version dir so master only manages its own content and never touches
+            // the version symlinks (owned by version deploys + the nightly reconcile):
+            //   /scale|core|truecommand/[0-9]*  = existing product-prefixed versions (scale/26, core/13.3, truecommand/3.0)
+            //   /[0-9]*                          = future bare top-level versions (docs/27, docs/28, ... — scale prefix retired)
             // No-op for version-branch publishes (their target dirs have no such subdirs).
             sh """rsync -rvza -e 'ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no' \
               --delete --exclude='pdf/' --exclude='PRs/' --exclude='CNAME' --exclude='download/' \
-              --exclude='/scale/[0-9]*' --exclude='/core/[0-9]*' --exclude='/truecommand/[0-9]*' \
+              --exclude='/scale/[0-9]*' --exclude='/core/[0-9]*' --exclude='/truecommand/[0-9]*' --exclude='/[0-9]*' \
               public/ docs@10.242.64.28:/var/www/html/${env.OUTPUT_DIR}"""
           }
         }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -58,8 +58,15 @@ pipeline {
 
         stage('Publish') {                    // same node as Build -> has public/
           steps {
+            // The version symlinks live INSIDE the shared docs1 root (docs1/scale/26,
+            // docs1/core/13.3, docs1/truecommand/3.0 ...). master publishes to docs1 with
+            // --delete, which would wipe those symlinks. Exclude the version dirs (any
+            // <product>/<digit...>) so master only manages its own content and never touches
+            // the version symlinks (owned by version deploys + the nightly reconcile).
+            // No-op for version-branch publishes (their target dirs have no such subdirs).
             sh """rsync -rvza -e 'ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no' \
               --delete --exclude='pdf/' --exclude='PRs/' --exclude='CNAME' --exclude='download/' \
+              --exclude='/scale/[0-9]*' --exclude='/core/[0-9]*' --exclude='/truecommand/[0-9]*' \
               public/ docs@10.242.64.28:/var/www/html/${env.OUTPUT_DIR}"""
           }
         }


### PR DESCRIPTION
**INCIDENT FIX — master publish was wiping version symlinks.**

Root cause: master rsyncs to /var/www/html/docs1 with --delete. The version symlinks live inside docs1 (docs1/scale/26, docs1/core/13.3, docs1/truecommand/3.0, ...), so --delete wiped them, and the master pipeline has no step to recreate them. (The old TrueNAS Docs Update Master masked this via its fan-out recreate.)

Fix: exclude the version dirs from master's rsync — `--exclude='/scale/[0-9]*' --exclude='/core/[0-9]*' --exclude='/truecommand/[0-9]*'`. master keeps its own content hygiene (--delete still prunes master pages) but never touches the version symlinks (owned by version deploys + nightly reconcile).

**Verified locally** (reproduced the exact scenario): version symlinks survive, stale master content still deleted, master content still updates. No-op for version-branch publishes.

**Merge ONLY AFTER the site is restored via Nightly Maintenance** (this fix prevents future wiping; it does not recreate the already-wiped symlinks — the reconcile does). Watch the resulting master build log to confirm NO 'deleting scale/*' lines. Then propagate the Jenkinsfile to the other branches for uniformity.