### PR TITLE
DOCS-2686 / 24.04 / sync Jenkinsfile (24.04) — build-status labeling

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -28,6 +28,11 @@ pipeline {
           if (env.PUBLISH_TO_PROD == 'true' && env.ARCHIVED != 'true' && !env.OUTPUT_DIR) {
             error 'PUBLISH_TO_PROD=true but OUTPUT_DIR is empty — refusing to publish to an undefined path.'
           }
+          // self-documenting: label each build by its role (shows in build history / Blue Ocean)
+          currentBuild.description =
+              (env.ARCHIVED == 'true')        ? 'ARCHIVED — frozen, not rebuilt' :
+              (env.PUBLISH_TO_PROD != 'true') ? 'STAGED — build only, not published' :
+                                                "PUBLISHED → /var/www/html/${env.OUTPUT_DIR}"
         }
       }
     }
@@ -58,8 +63,16 @@ pipeline {
 
         stage('Publish') {                    // same node as Build -> has public/
           steps {
+            // The version symlinks live INSIDE the shared docs1 root. master publishes to docs1
+            // with --delete, which would wipe them, and master has no step to recreate them.
+            // Exclude every version dir so master only manages its own content and never touches
+            // the version symlinks (owned by version deploys + the nightly reconcile):
+            //   /scale|core|truecommand/[0-9]*  = existing product-prefixed versions (scale/26, core/13.3, truecommand/3.0)
+            //   /[0-9]*                          = future bare top-level versions (docs/27, docs/28, ... — scale prefix retired)
+            // No-op for version-branch publishes (their target dirs have no such subdirs).
             sh """rsync -rvza -e 'ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no' \
               --delete --exclude='pdf/' --exclude='PRs/' --exclude='CNAME' --exclude='download/' \
+              --exclude='/scale/[0-9]*' --exclude='/core/[0-9]*' --exclude='/truecommand/[0-9]*' --exclude='/[0-9]*' \
               public/ docs@10.242.64.28:/var/www/html/${env.OUTPUT_DIR}"""
           }
         }


### PR DESCRIPTION
Brings 24.04 to the final uniform jenkins/Jenkinsfile: adds currentBuild.description labeling (PUBLISHED/STAGED/ARCHIVED) + the master-symlink-protect rsync excludes (no-op on version branches). No publish-behavior change.