### PR TITLE
DOCS-2705-sed-password-key-backup-and-restore-information-is-unclear-26

### DIFF
--- a/content/Storage/Disks/SED.md
+++ b/content/Storage/Disks/SED.md
@@ -58,6 +58,9 @@ Using a global password for all SEDs is strongly recommended to simplify deploym
 
 SED passwords are used during initial setup and for unlocking SEDs.
 
+A system configuration backup includes SED passwords only when you download the configuration file with the **Export Password Secret Seed** option selected.
+For a full list of what a configuration backup includes, see [Configuration Backup Contents]({{< relref "ManageSysConfig.md#configuration-backup-contents" >}}).
+
 ### Configuring Global SED Settings
 
 {{< include file="/static/includes/SEDGlobalPW.md" >}}

--- a/content/SystemSettings/Advanced/ManageSysConfig.md
+++ b/content/SystemSettings/Advanced/ManageSysConfig.md
@@ -21,8 +21,8 @@ TrueNAS allows users to manage the system configuration by uploading or download
 
 The **Manage Configuration** option on the **System > Advanced Settings** screen provides three options:
 
-* **Download File** that downloads your system configuration settings to a file on your system.
-* **Upload File** that allows you to upload a replacement configuration file.
+* **Download File** downloads your system configuration settings to a file on your system.
+* **Upload File** allows you to upload a replacement configuration file.
 * **Reset to Defaults** resets system configuration settings back to factory settings.
 
 ### Downloading the File
@@ -89,7 +89,7 @@ If you do not save the secret seed by downloading the system config file, variou
 Without the secret seed, encrypted fields are set to empty values. For example, SMB via local accounts and apps.
 Always select the option to save the secret seed when downloading the system config file!
 
-Uploading a configuration file from a FreeBSD-based release wipes any existing administrative users and replaces with the original root user and password from the uploaded configuration file.
+Uploading a configuration file from a FreeBSD-based release wipes any existing administrative users and replaces them with the original root user and password from the uploaded configuration file.
 To secure the system after restoring from a FreeBSD-based TrueNAS config file, log in with the original root user credentials, recreate an administrative account, and finally re-disable the root account password.
 
 ### Resetting to Defaults

--- a/content/SystemSettings/Advanced/ManageSysConfig.md
+++ b/content/SystemSettings/Advanced/ManageSysConfig.md
@@ -33,6 +33,52 @@ A system config file is a database file containing your settings, including acco
 
 {{< include file="/static/includes/DownloadSystemConfigFileSCALE.md" >}}
 
+### Configuration Backup Contents
+
+A downloaded configuration file always contains the full settings database.
+The **Export Password Secret Seed** option determines whether TrueNAS can restore the sensitive, encrypted fields in that database.
+
+The secret seed (the <file>pwenc_secret</file> file) is the key TrueNAS uses to decrypt protected fields in the configuration database.
+When you download the configuration file without the secret seed and later restore it, TrueNAS cannot decrypt these fields.
+It generates a new secret seed and clears the affected values.
+It empties some values and removes others entirely.
+For example, it disables SMB authentication for all local users and deletes saved cloud and SSH connection credentials.
+Download the file with the secret seed to keep these values on restore.
+
+In this table, **Yes** means the item is present and usable after a restore.
+TrueNAS does not store items marked **Never** in the configuration file, so back them up separately.
+
+{{< truetable >}}
+| Item | Without Secret Seed | With Secret Seed |
+|------|---------------------|------------------|
+| User and root or admin login passwords | Yes | Yes |
+| API keys | Yes | Yes |
+| Local user SMB (NT) password hashes | No | Yes |
+| Global and per-disk SED passwords | No | Yes |
+| ZFS encryption keys (key-type datasets and pools) | No | Yes |
+| ZFS encryption passphrases (passphrase-type datasets) | Never | Never |
+| SSH host keys (server keypairs) | No | Yes |
+| SSH connection keypairs (keychain credentials) | No | Yes |
+| Cloud sync and cloud backup credentials | No | Yes |
+| Certificate and CSR private keys | No | Yes |
+| iSCSI CHAP secrets | No | Yes |
+| Directory services credentials and Kerberos keytabs | No | Yes |
+| Service passwords (email, UPS, SNMP v3, and similar) | No | Yes |
+| App and container registry credentials | No | Yes |
+| IPMI/BMC password | Never | Never |
+{{< /truetable >}}
+
+{{< hint type=info title="Notes on Backup Contents" >}}
+TrueNAS stores login passwords and API keys as one-way hashes rather than encrypted values, so it restores them correctly with or without the secret seed.
+
+Only you know ZFS passphrases, and TrueNAS never writes them to the configuration file.
+The BMC hardware stores the IPMI/BMC password, not TrueNAS.
+
+When you configure [KMIP]({{< relref "ConfiguringKMIP.md" >}}), the KMIP server holds SED keys and ZFS key-type encryption keys, and the configuration file does not contain them.
+
+Always back up encryption key files and passphrases separately in a secure location.
+{{< /hint >}}
+
 ### Uploading the File
 
 The **Upload File** option gives users the ability to replace the current system configuration with any previously saved TrueNAS configuration file.


### PR DESCRIPTION

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
