### PR TITLE
DOCS-2707 / 27 / Replace UserCentrics with CookieYes cookie banner

### DIFF
--- a/layouts/partials/head/custom.html
+++ b/layouts/partials/head/custom.html
@@ -12,8 +12,9 @@
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-P87FM6K');</script>
 
-<!-- Usercentrics Cookie Consent Management -->
-<script id="usercentrics-cmp" src="https://web.cmp.usercentrics.eu/ui/loader.js" data-ruleset-id="44bxGXioqiqorL" async></script>
+<!-- Start cookieyes banner -->
+<script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/c005e666a046ac87072fe64f27dbdc4e/script.js"></script>
+<!-- End cookieyes banner -->
 
 <!-- Favicon -->
 <link rel="icon" href="{{ "favicon/TN-favicon-16x16.png" | relURL }}" type="image/png">


### PR DESCRIPTION
## Summary
- Replaces the UserCentrics cookie-consent script with the new CookieYes snippet in `layouts/partials/head/custom.html`.

## Test plan
- [x] Local `hugo` build confirms the CookieYes `<script>` tag renders on every page.
- [ ] Confirm the CookieYes banner renders on truenas.com/docs after merge (CookieYes is domain-locked; it will not render locally).