### PR TITLE
DOCS-2692 / 26 / Update keyword search version labels (26)

### DIFF
--- a/layouts/partials/search-modal.html
+++ b/layouts/partials/search-modal.html
@@ -26,6 +26,10 @@
           </div>
           <div class="docs-version-menu" id="docs-version-menu">
             <label class="docs-version-option">
+              <input type="checkbox" data-site="docs-27">
+              <span>27 (Nightly)</span>
+            </label>
+            <label class="docs-version-option">
               <input type="checkbox" data-site="docs-26">
               <span>26</span>
             </label>

--- a/layouts/partials/search-modal.html
+++ b/layouts/partials/search-modal.html
@@ -59,10 +59,12 @@
           <input type="checkbox" data-site="apps" checked>
           <span>Apps</span>
         </label>
+        <!-- TEMPORARILY DISABLED - Uncomment to re-enable when pagefind is fixed
         <label class="filter-checkbox">
           <input type="checkbox" data-site="security" checked>
-          <span>Security Advisories</span>
+          <span>Security</span>
         </label>
+        -->
         <label class="filter-checkbox">
           <input type="checkbox" data-site="connect" checked>
           <span>TrueNAS Connect</span>

--- a/layouts/partials/search-modal.html
+++ b/layouts/partials/search-modal.html
@@ -59,12 +59,10 @@
           <input type="checkbox" data-site="apps" checked>
           <span>Apps</span>
         </label>
-        <!-- TEMPORARILY DISABLED - Uncomment to re-enable when pagefind is fixed
         <label class="filter-checkbox">
           <input type="checkbox" data-site="security" checked>
-          <span>Security</span>
+          <span>Security Advisories</span>
         </label>
-        -->
         <label class="filter-checkbox">
           <input type="checkbox" data-site="connect" checked>
           <span>TrueNAS Connect</span>

--- a/static/js/search-multi-site.js
+++ b/static/js/search-multi-site.js
@@ -69,14 +69,15 @@ const searchConfig = {
       priority: 11,
       group: 'other'
     },
-    security: {
-      url: 'https://security.truenas.com/pagefind/',
-      name: 'Security Advisories',
-      displayName: 'Security Advisories',
-      iconSvg: '<svg style="width: 20px; height: 20px; stroke-width: 0.5;" viewBox="0 0 24 24"><path d="M12,1L3,5V11C3,16.55 6.84,21.74 12,23C17.16,21.74 21,16.55 21,11V5L12,1M12,21C7.59,21 4,17.41 4,13V6.31L12,3.11L20,6.31V13C20,17.41 16.41,21 12,21Z"/></svg>',
-      priority: 12,
-      group: 'other'
-    },
+    // TEMPORARILY DISABLED - Uncomment to re-enable when pagefind is fixed
+    // security: {
+    //   url: 'https://security.truenas.com/pagefind/',
+    //   name: 'Security Advisories',
+    //   displayName: 'Security Advisories',
+    //   iconSvg: '<svg style="width: 20px; height: 20px; stroke-width: 0.5;" viewBox="0 0 24 24"><path d="M12,1L3,5V11C3,16.55 6.84,21.74 12,23C17.16,21.74 21,16.55 21,11V5L12,1M12,21C7.59,21 4,17.41 4,13V6.31L12,3.11L20,6.31V13C20,17.41 16.41,21 12,21Z"/></svg>',
+    //   priority: 12,
+    //   group: 'other'
+    // },
     connect: {
       url: 'https://connect.truenas.com/pagefind/',
       name: 'TrueNAS Connect',

--- a/static/js/search-multi-site.js
+++ b/static/js/search-multi-site.js
@@ -7,13 +7,22 @@ const searchConfig = {
   indexes: {
     // TrueNAS Documentation versions
     // NOTE: Default version is determined dynamically from URL or scale-releases.yaml
-    'docs-26': {
+    'docs-27': {
       url: LOCAL_TESTING ? '/pagefind/' : 'https://www.truenas.com/docs/pagefind/',
       name: 'TrueNAS Documentation',
-      displayName: 'TrueNAS 26 Nightly',
-      version: '26 Nightly',
+      displayName: 'TrueNAS 27 Nightly',
+      version: '27 Nightly',
       icon: LOCAL_TESTING ? '/favicon/TN-favicon-32x32.png' : 'https://www.truenas.com/docs/favicon/TN-favicon-32x32.png',
       priority: 1,
+      group: 'docs'
+    },
+    'docs-26': {
+      url: 'https://www.truenas.com/docs/scale/26/pagefind/',
+      name: 'TrueNAS Documentation',
+      displayName: 'TrueNAS 26',
+      version: '26',
+      icon: 'https://www.truenas.com/docs/favicon/TN-favicon-32x32.png',
+      priority: 2,
       group: 'docs'
     },
     'docs-25.10': {
@@ -22,7 +31,7 @@ const searchConfig = {
       displayName: 'TrueNAS 25.10',
       version: '25.10',
       icon: 'https://www.truenas.com/docs/favicon/TN-favicon-32x32.png',
-      priority: 2,
+      priority: 3,
       group: 'docs'
     },
     'docs-25.04': {
@@ -31,7 +40,7 @@ const searchConfig = {
       displayName: 'TrueNAS 25.04',
       version: '25.04',
       icon: 'https://www.truenas.com/docs/favicon/TN-favicon-32x32.png',
-      priority: 3,
+      priority: 4,
       group: 'docs'
     },
     'docs-24.10': {
@@ -40,7 +49,7 @@ const searchConfig = {
       displayName: 'TrueNAS 24.10',
       version: '24.10',
       icon: 'https://www.truenas.com/docs/favicon/TN-favicon-32x32.png',
-      priority: 4,
+      priority: 5,
       group: 'docs'
     },
     // Other sites (non-expandable)

--- a/static/js/search-multi-site.js
+++ b/static/js/search-multi-site.js
@@ -69,15 +69,14 @@ const searchConfig = {
       priority: 11,
       group: 'other'
     },
-    // TEMPORARILY DISABLED - Uncomment to re-enable when pagefind is fixed
-    // security: {
-    //   url: 'https://security.truenas.com/pagefind/',
-    //   name: 'Security Advisories',
-    //   displayName: 'Security Advisories',
-    //   iconSvg: '<svg style="width: 20px; height: 20px; stroke-width: 0.5;" viewBox="0 0 24 24"><path d="M12,1L3,5V11C3,16.55 6.84,21.74 12,23C17.16,21.74 21,16.55 21,11V5L12,1M12,21C7.59,21 4,17.41 4,13V6.31L12,3.11L20,6.31V13C20,17.41 16.41,21 12,21Z"/></svg>',
-    //   priority: 12,
-    //   group: 'other'
-    // },
+    security: {
+      url: 'https://security.truenas.com/pagefind/',
+      name: 'Security Advisories',
+      displayName: 'Security Advisories',
+      iconSvg: '<svg style="width: 20px; height: 20px; stroke-width: 0.5;" viewBox="0 0 24 24"><path d="M12,1L3,5V11C3,16.55 6.84,21.74 12,23C17.16,21.74 21,16.55 21,11V5L12,1M12,21C7.59,21 4,17.41 4,13V6.31L12,3.11L20,6.31V13C20,17.41 16.41,21 12,21Z"/></svg>',
+      priority: 12,
+      group: 'other'
+    },
     connect: {
       url: 'https://connect.truenas.com/pagefind/',
       name: 'TrueNAS Connect',


### PR DESCRIPTION
## Summary
- Same fix as the master PR, applied to the 26 branch: adds "27 (Nightly)" to the search dropdown and corrects 26's own labeling/URL in the search config.
- Draft PR — holding for manual verification before merge.

## Test plan
- [x] Local `hugo` build confirms `data-site="docs-27"` renders.
- [x] Manually verify the dropdown and result badges render correctly.