### PR TITLE
Document SCALE REST API snapshot and 25.10 CA migration

### DIFF
--- a/static/api/scale_rest_api.html
+++ b/static/api/scale_rest_api.html
@@ -1,15 +1,36 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>TrueNAS REST API Documentation</title>
+  <title>TrueNAS SCALE 24.10-RC.1 REST API Documentation</title>
   <link rel="stylesheet" href="//unpkg.com/swagger-ui-dist@3.26.0/swagger-ui.css" />
   <script src="//unpkg.com/swagger-ui-dist@3.26.0/swagger-ui-bundle.js"></script>
   <style>
 	.scheme-container { display:none; }
 	.try-out { display:none; }
+	.api-version-notice {
+	  border-left: 4px solid #f0ad4e;
+	  margin: 1rem;
+	  padding: 1rem;
+	}
   </style>
 </head>
 <body>
+  <div class="api-version-notice" role="note">
+    <strong>Version notice:</strong>
+    This page is a snapshot of the TrueNAS SCALE 24.10-RC.1 REST API.
+    The <code>certificateauthority</code> endpoints shown here, including <code>GET /certificateauthority</code>
+    (<code>certificateauthority.query</code>), belong to the legacy API represented by this snapshot. TrueNAS 25.10
+    removes the built-in certificate authority (CA) service and its <code>certificateauthority.*</code> methods. During
+    an upgrade to 25.10, TrueNAS migrates existing CAs to certificate records. In the 25.10 JSON-RPC 2.0 API, call
+    <a href="https://api.truenas.com/v25.10/api_methods_certificate.query.html"><code>certificate.query</code></a> with
+    <code>[[&quot;cert_type_CA&quot;, &quot;=&quot;, true]]</code> as the
+    <code>filters</code> parameter to list CA certificates. TrueNAS provides no direct replacement for creating CAs,
+    signing certificate signing requests (CSRs), or revoking
+    certificates through the removed CA service. Use an external CA to sign CSRs and manage revocation, or use ACME for
+    supported certificate issuance. See the
+    <a href="https://www.truenas.com/docs/scale/25.10/gettingstarted/versionnotes/">TrueNAS 25.10 version notes</a>
+    for details.
+  </div>
   <div id="root" class="swagger-ui" />
   <script>
     const ui = SwaggerUIBundle({


### PR DESCRIPTION
## Summary

- Identify the unversioned SCALE REST API page as a 24.10-RC.1 snapshot.
- Identify `GET /certificateauthority` as the legacy REST route for `certificateauthority.query`.
- Document the removal of `certificateauthority.*` and migration of existing CAs in TrueNAS 25.10.
- Point CA listing callers to `certificate.query` with a `cert_type_CA = true` filter.
- Clarify that CA creation, CSR signing, and CA-service revocation have no direct replacement.

## Why

`static/api/scale_rest_api.html` currently embeds `scale_24.10-rc1_apiv2.json`, but the rendered page does not show that version boundary. Readers can therefore mistake the legacy `certificateauthority` resources for current 25.10 API methods.

TrueNAS 25.10 removed the CA service in [truenas/middleware#15972](https://github.com/truenas/middleware/pull/15972). Existing CA rows migrate into certificate records, which remain discoverable through `certificate.query` using the `cert_type_CA` field. External CAs handle CSR signing and revocation, while ACME provides a supported certificate-issuance workflow.

Related implementation and UI PRs confirm this direction, and searches found no existing documentation issue or PR for this API wrapper or endpoint-level mapping.

## Validation

- Parsed the edited standalone HTML successfully.
- Ran `git -c core.whitespace=cr-at-eol diff --check`.
- Confirmed all linked official TrueNAS pages return HTTP 200.
- Built the full site successfully with Hugo Extended 0.145.0 (CI) and 0.157.0 (README).
- Verified desktop and mobile rendering with no new console errors or notice overflow.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.