### PR TITLE
DOCS-2704 / 25.10 / checkout resilience against concurrent-DNS-flake (smoke test on 25.10)

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -3,6 +3,7 @@ pipeline {
 
   options {
     disableConcurrentBuilds()                 // no same-branch races (spec 3.5)
+    skipDefaultCheckout()                     // we do our own checkout below (DOCS-2704)
     buildDiscarder(logRotator(numToKeepStr: '15'))
     timestamps()
   }
@@ -12,6 +13,36 @@ pipeline {
   }
 
   stages {
+    stage('Checkout') {
+      // Serializes the SCM checkout across concurrently-triggered branch builds on the shared
+      // agent. Root-caused (DOCS-2704, 2026-09-02): simultaneous git fetches from multiple
+      // branches intermittently fail DNS resolution for github.com on this node; every serial
+      // retry succeeded. Retry only on that specific signature — a real failure (bad ref, auth,
+      // corrupted branch state) still fails fast instead of being masked by blind retries.
+      options {
+        lock('docs-checkout')
+        timeout(time: 5, unit: 'MINUTES')
+      }
+      steps {
+        script {
+          def maxAttempts = 3
+          for (int i = 1; i <= maxAttempts; i++) {
+            try {
+              checkout scm
+              break
+            } catch (e) {
+              def isDnsFlake = e.toString().contains('Could not resolve host')
+              if (!isDnsFlake || i == maxAttempts) {
+                throw e
+              }
+              echo "Checkout failed (attempt ${i}/${maxAttempts}), likely transient DNS — retrying in 10s: ${e.message}"
+              sleep(time: 10, unit: 'SECONDS')
+            }
+          }
+        }
+      }
+    }
+
     stage('Load config') {
       steps {
         script {


### PR DESCRIPTION
**Smoke test — do not roll out to other branches yet.**

Root-caused an incident from the DOCS-2704 cleanup: merging cleanup PRs to several branches within minutes of each other caused `Docs Versioned Sites` to trigger concurrent builds, and simultaneous SCM checkouts on the shared `docbuilds02` agent intermittently failed with `Could not resolve host: github.com`. Confirmed empirically — 3 branches triggered simultaneously gave mixed pass/fail on the same node; every branch went green when retried one at a time.

Change: `skipDefaultCheckout()` + an explicit `Checkout` stage, serialized via `lock('docs-checkout')` (mirrors the existing `docs1-deploy` lock pattern), with a narrow retry (max 3 attempts, 10s backoff) that fires only on the diagnosed DNS-failure signature — any other exception fails immediately, so a real problem doesn't get masked. `timeout(5m)` bounds worst-case queuing latency.

Reviewed by an independent pass before opening this PR: flagged two required fixes (narrow the retry to the DNS signature specifically, add a timeout to bound lock-holding time) — both incorporated above.

After merge, please confirm: build still succeeds, `GIT_COMMIT`/changelog still populate correctly, and the renamed "Checkout" stage (was "Declarative: Checkout SCM") doesn't break anything that reads Jenkins stage names. Once confirmed, I'll open PRs for the other 11 branches.