### PR TITLE
DOCS-2743 / 26 / MinIO/AIStor trademark legal compliance (26)

### DIFF
--- a/content/Apps/AppsScreens.md
+++ b/content/Apps/AppsScreens.md
@@ -453,3 +453,5 @@ You can enter a new setting in fields that include a preprogrammed default.
 {{< children depth="2" description="true" >}}
 
 </div>
+
+{{< trademark-notice minio="true" >}}

--- a/content/GettingStarted/Migrate/MigratePrep.md
+++ b/content/GettingStarted/Migrate/MigratePrep.md
@@ -108,7 +108,7 @@ Please contact Support for assistance!
    If there are issues after a clean install from an <file>iso</file> file, or if you are not using DHCP for network and interface configuration, use the recorded information from your previous settings to configure your network settings and reconfigure your static IPs or aliases after migrating.
       {{< include file="/static/includes/NetworkInstallRequirementsSCALE.md" >}}
 
-7. Offline the deprecated S3 MinIO service (if in use).
+7. Offline the deprecated S3 **MinIO™** service (if in use).
    This might require a manual data backup and restore strategy.
    Enterprise customers can contact iX Support to discuss migration and backup strategies.
 
@@ -196,3 +196,5 @@ Note the UID and GID for this new user to enter in the application configuration
 
 After disabling the WebDAV service and clearing any existing share configurations from the **Shares > WebDAV** screen in Bluefin, install the **WebDAV** application to recreate your shares using the service settings from your notes. Use the **webdav** user and group in control, and the UID and GID (**666**) in the application.
 {{< /expand >}}
+
+{{< trademark-notice minio="true" >}}

--- a/layouts/shortcodes/trademark-notice.html
+++ b/layouts/shortcodes/trademark-notice.html
@@ -1,0 +1,13 @@
+{{ $minio := (eq (.Get "minio") "true") }}
+{{ $aistor := (eq (.Get "aistor") "true") }}
+{{ if or $minio $aistor }}
+{{ if and $minio $aistor }}
+<p class="trademark-notice"><small><em>MinIO and AIStor are trademarks of the MinIO Corporation.</em></small></p>
+{{ else if $minio }}
+<p class="trademark-notice"><small><em>MinIO is a trademark of the MinIO Corporation.</em></small></p>
+{{ else if $aistor }}
+<p class="trademark-notice"><small><em>AIStor is a trademark of the MinIO Corporation.</em></small></p>
+{{ end }}
+{{ else }}
+{{- errorf "trademark-notice requires minio=\"true\" and/or aistor=\"true\": %s" .Position }}
+{{ end }}


### PR DESCRIPTION
## Summary
Same ticket as master (DOCS-2743, PR #4775) — this is branch 2 of 9. Branch `26` has a much smaller footprint than master: recon confirmed only 2 files mention MinIO here, no casing bugs, and none of master's systemic gaps apply (verified before writing the plan, and independently reconfirmed by the final review):

- Marks the first mention of MinIO on `content/GettingStarted/Migrate/MigratePrep.md` with correct capitalization, bold, and the ™ symbol; adds the required attribution sentence to the page's footer.
- Adds the attribution-only notice to `content/Apps/AppsScreens.md` (MinIO is named only in a screenshot's alt/id text, never in body prose).
- Adds a self-contained `layouts/shortcodes/trademark-notice.html` (this repo has no Hugo Modules and branches don't share code, so this is recreated independently per branch) — fails the build loudly on a bad/missing param, same as master's design.

Unlike master, this branch doesn't need: a `Copyrights.md` entry (doesn't exist on release branches), a taxonomy-page fix (the marked mention sits well past Hugo's `.Summary` cutoff), a `{{< children >}}` fix (neither affected page's frontmatter description mentions MinIO), or any archive-changelog fix (this branch has no `content/_archive/` directory).

## Test plan
- [x] `hugo --gc --minify` builds clean (0 errors)
- [x] Both affected pages carry the exact attribution sentence once
- [x] First-mention-only marking verified (the page's second MinIO mention is untouched)
- [x] Site-wide sweep: no MinIO mark anywhere lacks an adjacent attribution
- [x] Each task individually reviewed; a dedicated recon pass (checking for master's known gap classes) preceded the plan; final whole-branch review approved in a single round, independently re-verifying each pre-check against live build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)