### PR TITLE
DOCS-2743 / 25.10 / MinIO/AIStor trademark legal compliance (25.10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ scripts/release_notes/output/
 scripts/release_notes/config.yaml
 *.backup
 
+# Superpowers specs and plans
+docs/superpowers/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/content/GettingStarted/Migrate/MigratePrep.md
+++ b/content/GettingStarted/Migrate/MigratePrep.md
@@ -104,7 +104,7 @@ Please contact Support for assistance!
    If there are issues after a clean install from an <file>iso</file> file, or if you are not using DHCP for network and interface configuration, use the recorded information from your previous settings to configure your network settings and reconfigure your static IPs or aliases after migrating.
       {{< include file="/static/includes/NetworkInstallRequirementsSCALE.md" >}}
 
-7. Offline the deprecated S3 MinIO service (if in use).
+7. Offline the deprecated S3 **MinIO™** service (if in use).
    This might require a manual data backup and restore strategy.
    Enterprise customers can contact iX Support to discuss migration and backup strategies.
 
@@ -192,3 +192,5 @@ Note the UID and GID for this new user to enter in the application configuration
 
 After disabling the WebDAV service and clearing any existing share configurations from the **Shares > WebDAV** screen in Bluefin, install the **WebDAV** application to recreate your shares using the service settings from your notes. Use the **webdav** user and group in control, and the UID and GID (**666**) in the application.
 {{< /expand >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/GettingStarted/VersionNotes.md
+++ b/content/GettingStarted/VersionNotes.md
@@ -1012,3 +1012,5 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeHugoTabs('component-tab-content-source', 'component-tabs-container', 'software-component-versions');
 });
 </script>
+
+{{< trademark-notice minio="true" >}}

--- a/content/SCALEUIReference/Apps/_index.md
+++ b/content/SCALEUIReference/Apps/_index.md
@@ -441,3 +441,5 @@ You can enter a new setting in fields that include a preprogrammed default.
 {{< children depth="2" description="true" >}}
 
 </div>
+
+{{< trademark-notice minio="true" >}}

--- a/layouts/shortcodes/trademark-notice.html
+++ b/layouts/shortcodes/trademark-notice.html
@@ -1,0 +1,13 @@
+{{ $minio := (eq (.Get "minio") "true") }}
+{{ $aistor := (eq (.Get "aistor") "true") }}
+{{ if or $minio $aistor }}
+{{ if and $minio $aistor }}
+<p class="trademark-notice"><small><em>MinIO and AIStor are trademarks of the MinIO Corporation.</em></small></p>
+{{ else if $minio }}
+<p class="trademark-notice"><small><em>MinIO is a trademark of the MinIO Corporation.</em></small></p>
+{{ else if $aistor }}
+<p class="trademark-notice"><small><em>AIStor is a trademark of the MinIO Corporation.</em></small></p>
+{{ end }}
+{{ else }}
+{{- errorf "trademark-notice requires minio=\"true\" and/or aistor=\"true\": %s" .Position }}
+{{ end }}


### PR DESCRIPTION
## Summary
Part of DOCS-2743 (MinIO Legal Compliance), branch `25.10`. Marks the first prose mention of MinIO with bold+™+correct casing and adds the required attribution footer (`MinIO is a trademark of the MinIO Corporation.`) to every page on this branch that names or displays MinIO to a reader.

- `layouts/shortcodes/trademark-notice.html` — new self-contained shortcode (recreated independently on this branch; no Hugo Modules, no cross-branch code sharing).
- `content/GettingStarted/Migrate/MigratePrep.md` — first mention marked (`**MinIO™**`), attribution appended.
- `content/SCALEUIReference/Apps/_index.md` — screenshot-only mention (alt/id text, already correctly cased), attribution appended, no mark.
- `content/GettingStarted/VersionNotes.md` — attribution appended. This page's client-side changelog table (populated from `static/data/25.10-changelog.csv`) displays a JIRA ticket title containing "MinIO" to the reader after page load; this is invisible to a static-HTML grep, so it wasn't caught until an independent whole-branch review. The CSV-sourced text itself is not marked (verbatim third-party ticket title), matching the project's policy that verbatim third-party records never get the bold+™ treatment — only the attribution footer was added.

What wasn't needed on this branch (all confirmed, not assumed):
- No `Copyrights.md` on this branch — central-page attribution is release-branch out of scope per the master spec's decision.
- No casing bugs — both mentions were already correctly cased.
- No taxonomy (`.Summary`) exposure — `MigratePrep.md`'s tag page summary truncates before reaching the marked line.
- No `{{< children >}}` exposure — neither parent `_index.md`'s rendered description mentions MinIO.
- No `content/_archive/` directory on this branch.
- `static/api/{core,scale}_websocket_api.html` and both `static/data/25.10*-changelog.csv` files were checked and confirmed not to need marking (auto-generated API example / third-party ticket titles, respectively — the changelog CSVs' rendered exposure via `VersionNotes.md` is handled above).

## Test plan
- [x] Clean `hugo --gc --minify` build: exit 0, 0 ERROR lines.
- [x] Both primary target pages render exactly 1 attribution sentence each; `MigratePrep.md` renders exactly 1 `MinIO™` mark, its second (later) mention is untouched.
- [x] `VersionNotes.md` renders exactly 1 attribution sentence, 0 marks.
- [x] Site-wide source sweep (`grep -ril "minio\|aistor" content/ static/`) matches the fully-accounted-for file list — no unexplained files.
- [x] Site-wide mark-without-attribution sweep across all of `public/` — zero gaps.
- [x] Independent final whole-branch review (Opus) of the 3-file initial diff — approved after one new finding (VersionNotes.md) was raised and fixed.
- [x] Independent scoped re-review (Sonnet) of the VersionNotes.md fix, including confirming neither changelog CSV contains "AIStor" (so the MinIO-only attribution variant is correct) — approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)