### PR TITLE
DOCS-2743 / 25.04 / MinIO/AIStor trademark legal compliance (25.04)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 tech-doc-hugo
 .vscode
 *.lock
+
+# Superpowers specs and plans
+docs/superpowers/

--- a/content/GettingStarted/Migrate/MigratePrep.md
+++ b/content/GettingStarted/Migrate/MigratePrep.md
@@ -97,7 +97,7 @@ Please contact Support for assistance!
    If there are issues after a clean install from an <file>iso</file> file, or if you are not using DHCP for network and interface configuration, use the recorded information from your previous settings to configure your network settings and reconfigure your static IPs or aliases after migrating.
       {{< include file="/static/includes/NetworkInstallRequirementsSCALE.md" >}}
 
-7. Offline the deprecated S3 MinIO service (if in use).
+7. Offline the deprecated S3 **MinIO™** service (if in use).
    This might require a manual data backup and restore strategy.
    Enterprise customers can contact iX Support to discuss migration and backup strategies.
 
@@ -180,3 +180,5 @@ Note the UID and GID for this new user to enter in the application configuration
 
 After disabling the WebDAV service and clearing any existing share configurations from the **Shares > WebDAV** screen in Bluefin, install the **WebDAV** application to recreate your shares using the service settings from your notes. Use the **webdav** user and group in control, and the UID and GID (**666**) in the application.
 {{< /expand >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/GettingStarted/SCALEReleaseNotes.md
+++ b/content/GettingStarted/SCALEReleaseNotes.md
@@ -480,3 +480,5 @@ This first public release version of TrueNAS 25.04 (Fangtooth) has software comp
 
 <a href="https://ixsystems.atlassian.net/issues/?filter=11745" target="_blank">Click here to see the latest information</a> about public issues discovered in 25.04-BETA.1 that are being resolved in a future TrueNAS release.
 {{< /expand >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/SCALEUIReference/Apps/_index.md
+++ b/content/SCALEUIReference/Apps/_index.md
@@ -365,3 +365,5 @@ You can enter a new setting in fields that include a preprogrammed default.
 {{< children depth="2" description="true" >}}
 
 </div>
+
+{{< trademark-notice minio="true" >}}

--- a/layouts/shortcodes/trademark-notice.html
+++ b/layouts/shortcodes/trademark-notice.html
@@ -1,0 +1,13 @@
+{{ $minio := (eq (.Get "minio") "true") }}
+{{ $aistor := (eq (.Get "aistor") "true") }}
+{{ if or $minio $aistor }}
+{{ if and $minio $aistor }}
+<p class="trademark-notice"><small><em>MinIO and AIStor are trademarks of the MinIO Corporation.</em></small></p>
+{{ else if $minio }}
+<p class="trademark-notice"><small><em>MinIO is a trademark of the MinIO Corporation.</em></small></p>
+{{ else if $aistor }}
+<p class="trademark-notice"><small><em>AIStor is a trademark of the MinIO Corporation.</em></small></p>
+{{ end }}
+{{ else }}
+{{- errorf "trademark-notice requires minio=\"true\" and/or aistor=\"true\": %s" .Position }}
+{{ end }}

--- a/static/includes/AppsHostIP.md
+++ b/static/includes/AppsHostIP.md
@@ -147,7 +147,7 @@ All applications added after this date also support this feature.
 * Minecraft  
 * Minecraft Bedrock  
 * MineOS  
-* Minio  
+* **MinIO™**  
 * Mumble  
 * N8N  
 * Navidrome  


### PR DESCRIPTION
## Summary
Part of DOCS-2743 (MinIO Legal Compliance), branch `25.04`. Marks the first mention of MinIO with bold+™+correct casing and adds the required attribution footer (`MinIO is a trademark of the MinIO Corporation.`) to every page on this branch that names MinIO to a reader.

- `layouts/shortcodes/trademark-notice.html` — new self-contained shortcode (recreated independently on this branch).
- `content/GettingStarted/Migrate/MigratePrep.md` — first mention marked (`**MinIO™**`), attribution appended.
- `static/includes/AppsHostIP.md` — this branch's actual first mention lives in a shared include (an alphabetized ~150-item app-name list), transcluded into two different pages. Fixed the casing (`Minio` → `**MinIO™**`) once, in the shared file, since it's the true reading-order-first mention on both consuming pages (verified by tracing every `{{< include >}}` before it on each page).
- `content/SCALEUIReference/Apps/_index.md` — attribution appended. Its own later screenshot alt/id mention (already correctly cased) is a second mention and stays untouched.
- `content/GettingStarted/SCALEReleaseNotes.md` — attribution appended (this page never names MinIO directly; the mention only reaches it via the shared include above).

What wasn't needed on this branch (all confirmed, not assumed):
- No `Copyrights.md` on this branch.
- No taxonomy (`.Summary`) exposure — the Apps page's tag-listing summary truncates before reaching the shared include's nested content; the RSS/XML variant (which does render full content) carries the mark and attribution together, not one without the other.
- No `{{< children >}}` exposure — neither parent `_index.md`'s rendered description mentions MinIO.
- No `content/_archive/` directory, no client-side changelog-CSV tables (no `static/data/` directory exists on this branch at all).
- `static/api/{core,scale}_websocket_api.html` and `static/includes/TNDataCollection.md` — auto-generated API example / lowercase chart-release-name example, neither a prose product reference.
- One accepted non-issue: `static/includes/AppsHostIP.md` is also raw-served byte-for-byte at `public/includes/AppsHostIP.md` (a pre-existing, site-wide Hugo static-passthrough characteristic affecting all 201 files under `static/includes/`, unrelated to this ticket) — that raw copy shows the mark without adjacent attribution. Confirmed via `robots.txt` (`Disallow: /includes/*`) and zero inbound site links that this raw asset is unreachable through normal site navigation; restructuring how `static/includes/` is published is a large, unrelated architectural change out of scope here.

## Test plan
- [x] Clean `hugo --gc --minify` build: exit 0, 0 ERROR lines.
- [x] All three affected pages render exactly 1 attribution sentence and exactly 1 mark each; `MigratePrep.md`'s second (later) mention and the Apps page's screenshot alt/id text are both untouched.
- [x] Full transitive include-graph trace (not just line numbers) confirms the shared mention is genuinely first on both consuming pages.
- [x] Site-wide source sweep and mark-without-attribution sweep (across all of `public/`, not just `.html`) — only the known, accepted raw-passthrough non-issue remains.
- [x] Print view, RSS/XML aggregation, and taxonomy pages all checked — mark and attribution always co-present where either appears.
- [x] Independent final whole-branch review (Opus): APPROVED, no fixes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)