### PR TITLE
DOCS-2743 / 24.10 / MinIO/AIStor trademark legal compliance (24.10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 tech-doc-hugo
 .vscode
 *.lock
+
+# Superpowers specs and plans
+docs/superpowers/

--- a/content/GettingStarted/Migrate/MigratePrep.md
+++ b/content/GettingStarted/Migrate/MigratePrep.md
@@ -80,7 +80,7 @@ If you must use a USB type device, verify you can access files on the device bef
    If there are issues after a clean install of SCALE from an <file>iso</file> file or you are not using DHCP for network and interface configuration, use the information from your CORE settings to configure your SCALE network settings and to reconfigure your static IPs or aliases.
       {{< include file="/static/includes/NetworkInstallRequirementsSCALE.md" >}}
 
-6. Migrate the deprecated S3 MinIO service (if in use). See [services deprecated in SCALE](#migrating-from-deprecated-services).
+6. Migrate the deprecated S3 **MinIO™** service (if in use). See [services deprecated in SCALE](#migrating-from-deprecated-services).
    This is a lengthy process depending on the amount of data stored while using the S3 service.
    Read and follow instructions in [Migrating MinIO Data from CORE to SCALE](https://www.truenas.com/docs/solutions/miniocoretoscale/)!
 
@@ -93,3 +93,5 @@ If you must use a USB type device, verify you can access files on the device bef
 
 After completing the steps that apply to your CORE system listed above, download the [SCALE ISO file](https://www.truenas.com/download-tn-scale/) and save it to your computer.
 Burn the iso to a USB drive (see **Installing on Physical Hardware** in [Installing SCALE]({{< ref "InstallingSCALE.md#installing-on-physical-hardware" >}})) when upgrading a physical system.
+
+{{< trademark-notice minio="true" >}}

--- a/content/GettingStarted/SCALEReleaseNotes.md
+++ b/content/GettingStarted/SCALEReleaseNotes.md
@@ -601,4 +601,5 @@ This has software component updates and new features that are in the polishing p
 
 <a href="https://ixsystems.atlassian.net/issues/?filter=10588" target="_blank">Click here to see the latest information on Jira</a> about public issues discovered in 24.10-BETA.1 that are being resolved in a future TrueNAS release.
 {{< /expand >}}
+
 {{< trademark-notice minio="true" >}}

--- a/content/GettingStarted/SCALEReleaseNotes.md
+++ b/content/GettingStarted/SCALEReleaseNotes.md
@@ -601,3 +601,4 @@ This has software component updates and new features that are in the polishing p
 
 <a href="https://ixsystems.atlassian.net/issues/?filter=10588" target="_blank">Click here to see the latest information on Jira</a> about public issues discovered in 24.10-BETA.1 that are being resolved in a future TrueNAS release.
 {{< /expand >}}
+{{< trademark-notice minio="true" >}}

--- a/content/SCALEUIReference/Apps/_index.md
+++ b/content/SCALEUIReference/Apps/_index.md
@@ -307,3 +307,4 @@ You can enter a new setting in fields that include a preprogrammed default.
 {{< children depth="2" description="true" >}}
 
 </div>
+{{< trademark-notice minio="true" >}}

--- a/layouts/shortcodes/trademark-notice.html
+++ b/layouts/shortcodes/trademark-notice.html
@@ -1,0 +1,13 @@
+{{ $minio := (eq (.Get "minio") "true") }}
+{{ $aistor := (eq (.Get "aistor") "true") }}
+{{ if or $minio $aistor }}
+{{ if and $minio $aistor }}
+<p class="trademark-notice"><small><em>MinIO and AIStor are trademarks of the MinIO Corporation.</em></small></p>
+{{ else if $minio }}
+<p class="trademark-notice"><small><em>MinIO is a trademark of the MinIO Corporation.</em></small></p>
+{{ else if $aistor }}
+<p class="trademark-notice"><small><em>AIStor is a trademark of the MinIO Corporation.</em></small></p>
+{{ end }}
+{{ else }}
+{{- errorf "trademark-notice requires minio=\"true\" and/or aistor=\"true\": %s" .Position }}
+{{ end }}

--- a/static/includes/AppsHostIP.md
+++ b/static/includes/AppsHostIP.md
@@ -147,7 +147,7 @@ All applications added after this date also support this feature.
 * Minecraft  
 * Minecraft Bedrock  
 * MineOS  
-* Minio  
+* **MinIO™**  
 * Mumble  
 * N8N  
 * Navidrome  


### PR DESCRIPTION
## Summary
Part of DOCS-2743 (MinIO Legal Compliance), branch `24.10`. Marks the first mention of MinIO with bold+™+correct casing and adds the required attribution footer (`MinIO is a trademark of the MinIO Corporation.`) to every page on this branch that names MinIO to a reader.

- `layouts/shortcodes/trademark-notice.html` — new self-contained shortcode (recreated independently, byte-identical to the versions on `26`/`25.10`/`25.04`).
- `content/GettingStarted/Migrate/MigratePrep.md` — first mention marked (`**MinIO™**`); three later mentions in the same paragraph, including two markdown link-texts, are untouched. Attribution appended.
- `static/includes/AppsHostIP.md` — this branch's actual first mention lives in a shared include (identical gap to `25.04`, confirmed in advance). Fixed the casing (`Minio` → `**MinIO™**`) once, in the shared file, since it's the true reading-order-first mention on both consuming pages.
- `content/SCALEUIReference/Apps/_index.md` — attribution appended. This branch also has a second shared include (`static/includes/AppsInstallWizardSettings.md`) with a real, already-correctly-cased, later mention — confirmed via reading-order trace to need no edit.
- `content/GettingStarted/SCALEReleaseNotes.md` — attribution appended (this page never names MinIO directly; the mention only reaches it via the shared include above).

What wasn't needed on this branch (all confirmed, not assumed):
- No `Copyrights.md`, no `content/_archive/`, no client-side changelog-CSV tables.
- No taxonomy (`.Summary`) exposure — the Apps and Migrate tag-listing summaries both truncate before reaching the relevant content.
- No `{{< children >}}` exposure — no parent `_index.md`'s rendered description mentions MinIO.
- `static/api/{core,scale}_websocket_api.html` and `static/includes/TNDataCollection.md` — auto-generated/lowercase non-prose examples.
- One accepted non-issue (carried forward from `25.04`): `static/includes/AppsHostIP.md`'s raw static-passthrough copy shows the mark without adjacent attribution — an already-ruled, site-wide structural characteristic unrelated to this ticket.

An independent final whole-branch review (Opus) caught one markup regression during implementation — `SCALEReleaseNotes.md` was missing a blank line before the appended shortcode, causing Goldmark to nest the notice's `<p>` inside the page's closing paragraph (invalid HTML, no compliance impact since the text was still present and visible). Fixed and independently re-reviewed.

## Test plan
- [x] Clean `hugo --gc --minify` build: exit 0, 0 ERROR lines.
- [x] All three affected pages render exactly 1 attribution sentence and exactly 1 mark each; all later/second mentions (including two markdown link-texts on MigratePrep.md and the AppsInstallWizardSettings.md mention) are byte-for-byte untouched.
- [x] Full transitive include-graph trace (DOM-offset enumeration, not just source order) confirms the shared mention is genuinely first on both consuming pages.
- [x] Site-wide source sweep and mark-without-attribution sweep (across all of `public/`, not just `.html`) — only the known, accepted raw-passthrough non-issue remains.
- [x] Print view, RSS/XML aggregation (co-presence checked per-item, not just per-file), and taxonomy pages all checked.
- [x] Independent final whole-branch review (Opus): found and required the blank-line fix above; fix independently re-reviewed and approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)