### PR TITLE
DOCS-2743 / 22.12 / MinIO/AIStor trademark legal compliance (22.12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 tech-doc-hugo
 .vscode
 *.lock
+
+# Superpowers specs and plans
+docs/superpowers/

--- a/content/GettingStarted/Configure/ClusterPreparation.md
+++ b/content/GettingStarted/Configure/ClusterPreparation.md
@@ -8,6 +8,7 @@ tags:
 - scaleminio
 - tcclustering
 - scaleconfig
+trademarkMinio: true
 ---
 
 {{< toc >}}
@@ -22,8 +23,10 @@ Clustering is considered experimental and should not be used in a production env
 
 TrueNAS SCALE provides a few options for setting up system clustering:
 
-* [MinIO-created distributed clustering of TrueNAS SCALE systems]({{< relref "MinIOClustering.md" >}}).
+* [**MinIO™**-created distributed clustering of TrueNAS SCALE systems]({{< relref "MinIOClustering.md" >}}).
 
 * [Clustering and sharing SCALE volumes with TrueCommand](https://www.truenas.com/docs/solutions/integrations/smbclustering/).
 
 {{< taglist tag="scaleclustering" limit="10" title="Related Clustering Articles" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/GettingStarted/SCALEDeprecatedFeatures.md
+++ b/content/GettingStarted/SCALEDeprecatedFeatures.md
@@ -6,3 +6,5 @@ aliases: /scale/scaletutorials/systemsettings/services/lldpservicesscale/
 ---
 
 {{< include file="/static/includes/BluefinDeprecated.md" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/GettingStarted/SCALEReleaseNotes.md
+++ b/content/GettingStarted/SCALEReleaseNotes.md
@@ -188,7 +188,7 @@ iXsystems is pleased to release TrueNAS SCALE 22.12.3!
 
 22.12.3 includes many new features and improved functionality that span new applications for deprecated services, change to SMB service, additional tools for troubleshooting, and web UI improvements. Changes include:
 
-* New applications for deprecated SCALE services Dynamic DNS, TFTP, OpenVPN, WebDAV, rsync daemon, and S3 MinIO.
+* New applications for deprecated SCALE services Dynamic DNS, TFTP, OpenVPN, WebDAV, rsync daemon, and S3 **MinIO™**.
 * Multichannel capabilities added to the SMB configuration form
 * Updates to the Dashboard R50 image
 * Updates to the latest Linux v5.15 kernel branch
@@ -1083,7 +1083,7 @@ SCALE 22.12-RC.1 introduces a change in Applications. Users upgrading to 22.12-R
 
 MinIO has removed backwards compatibility with version 2022-10-24_1.6.58.
 
-MinIO fails to deploy if you update your version 2022-10-24_1.6.58 Minio app to 2022-10-29_1.6.59 or later using the TrueNAS web UI. Use the app roll back function and return to 2022-10-24_1.6.58 to make your MinIO app functional again.
+MinIO fails to deploy if you update your version 2022-10-24_1.6.58 MinIO app to 2022-10-29_1.6.59 or later using the TrueNAS web UI. Use the app roll back function and return to 2022-10-24_1.6.58 to make your MinIO app functional again.
 See the [MinIO Migration documentation](https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/migrate-fs-gateway.html#procedure) to manually update your MinIO app to the latest version without losing functionality.
 {{< /expand >}}
 
@@ -1919,3 +1919,5 @@ Online updates are created every 2 hours and are available in the SCALE UI onlin
 
 * [ISO Installation Files](https://download.truenas.com/truenas-scale-bluefin-nightly/ "SCALE Angelfish Nightly .iso files")
 * [Manual Update File](https://update.freenas.org/scale/TrueNAS-SCALE-Bluefin-Nightlies/TrueNAS-SCALE-Bluefin-Nightly.update)
+
+{{< trademark-notice minio="true" >}}

--- a/content/SCALETutorials/Apps/CommunityApps/MinIOClustersSCALE/MigratingFromS3Service.md
+++ b/content/SCALETutorials/Apps/CommunityApps/MinIOClustersSCALE/MigratingFromS3Service.md
@@ -7,12 +7,13 @@ tags:
 - scaleminio
 - scales3service
 - enterprise
+trademarkMinio: true
 ---
 
 
 {{< toc >}}
 
-This tutorial provides instructions on migrating from the MinIO S3 Filesystem service deployed through the TrueNAS S3 service, deprecated in SCALE Bluefin and removed in Cobia, to the latest release of the MinIO Server application in Bluefin.
+This tutorial provides instructions on migrating from the **MinIO™** S3 Filesystem service deployed through the TrueNAS S3 service, deprecated in SCALE Bluefin and removed in Cobia, to the latest release of the MinIO Server application in Bluefin.
 
 MinIO has deprecated both the S3 Gateway and Filesystem services.
 MinIO no longer supports these offerings, do not provide a direct upgrade path for either, and require users to migrate from these S3 services to a later release of the MinIO Server.
@@ -204,3 +205,5 @@ This procedure uses the MinIO Client (MC), TrueNAS SCALE, and the MinIO web port
 
 {{< taglist tag="scaleminio" limit="10" title="Related MinIO Articles" >}}
 {{< taglist tag="scaleenterprise" limit="10" title="Related Enterprise Articles" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/SCALETutorials/Apps/CommunityApps/MinIOClustersSCALE/MinIOClustering.md
+++ b/content/SCALETutorials/Apps/CommunityApps/MinIOClustersSCALE/MinIOClustering.md
@@ -7,13 +7,14 @@ tags:
 - scaleminio
 - scaleapps
 - scaleclustering
+trademarkMinio: true
 ---
 
 {{< toc >}}
 
 
 {{< hint info >}}
-This article applies to the public release of the **MinIO Official Charts** application.
+This article applies to the public release of the **MinIO™ Official Charts** application.
 {{< /hint >}}
 
 On TrueNAS SCALE 20.12-ALPHA and later, users can create a MinIO S3 distributed instance to scale out and handle individual node failures. A node is a single TrueNAS storage system in a cluster.
@@ -89,7 +90,7 @@ Use the /data path that the following steps set up.
 
 Enter the MinIO S3 root user in **Root User** and the S3 password in **Root Password**. 
 
-Next, create the **Minio Environment Variables**. Click **Add** twice to enter two blocks of settings. 
+Next, create the **MinIO Environment Variables**. Click **Add** twice to enter two blocks of settings. 
 
 ![AppsMinIOEnvironmentVariables](/images/SCALE/22.12/AppsMinIOEnvironmentVariables.png "MinIO Environment Variables")
 
@@ -143,3 +144,5 @@ Log in with the **ROOT_USER** and **ROOT_PASSWORD** keys you created as Containe
 
 {{< taglist tag="scaleminio" limit="10" >}}
 {{< taglist tag="scaleclustering" limit="10" title="Related Clustering Articles" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/SCALETutorials/Apps/CommunityApps/MinIOClustersSCALE/MinioManualUpdate.md
+++ b/content/SCALETutorials/Apps/CommunityApps/MinIOClustersSCALE/MinioManualUpdate.md
@@ -7,6 +7,7 @@ tags:
 - scaleminio
 - scaledocker
 - scaleapps
+trademarkMinio: true
 ---
 
 
@@ -14,12 +15,12 @@ tags:
 
 
 {{< hint info >}}
-This article applies to the public release of the **MinIO Official Charts** application.
+This article applies to the public release of the **MinIO™ Official Charts** application.
 {{< /hint >}}
 
 ## Manual Update Overview
 
-MinIO fails to deploy if you update your version 2022-10-24_1.6.58 Minio app to 2022-10-29_1.6.59 or later using the TrueNAS web UI.
+MinIO fails to deploy if you update your version 2022-10-24_1.6.58 MinIO app to 2022-10-29_1.6.59 or later using the TrueNAS web UI.
 
 Your app logs display an error similar to the following:
 
@@ -199,3 +200,5 @@ Restart the new app to finish migrating.
 When complete and the app is running, restart any share services.
 
 {{< taglist tag="scaleminio" limit="10" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/SCALETutorials/Apps/CommunityApps/MinIOClustersSCALE/_index.md
+++ b/content/SCALETutorials/Apps/CommunityApps/MinIOClustersSCALE/_index.md
@@ -5,6 +5,7 @@ geekdocCollapseSection: true
 weight:
 aliases: 
 tags:
+trademarkMinio: true
 ---
 
 This section has tutorials for using the **MinIO™** apps available for TrueNAS SCALE.

--- a/content/SCALETutorials/Apps/CommunityApps/MinIOClustersSCALE/_index.md
+++ b/content/SCALETutorials/Apps/CommunityApps/MinIOClustersSCALE/_index.md
@@ -7,8 +7,10 @@ aliases:
 tags:
 ---
 
-This section has tutorials for using the MinIO apps available for TrueNAS SCALE.
+This section has tutorials for using the **MinIO™** apps available for TrueNAS SCALE.
 
 ## Section Contents
 
 {{< children depth="2" description="true" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/SCALETutorials/Apps/EnterpriseApps/ConfigMinioEnterprise.md
+++ b/content/SCALETutorials/Apps/EnterpriseApps/ConfigMinioEnterprise.md
@@ -6,13 +6,14 @@ aliases:
 tags:
 - scaleminio
 - scaleenterprise
+trademarkMinio: true
 ---
 
 
 {{< toc >}}
 
 {{< enterprise >}}
-The instructions in this article apply to the Official TrueNAS Enterprise MinIO application. 
+The instructions in this article apply to the Official TrueNAS Enterprise **MinIO™** application. 
 This smaller version of MinIO has been tested and polished for a safe and supportable experience for TrueNAS Enterprise customers. 
 To use the complete MinIO app without iXsystems support, see the application that is available in the Community Apps catalog.
 
@@ -102,3 +103,5 @@ Follow the instructions in [Installing MinIO Enterprise](#installing-minio-enter
 
 {{< taglist tag="scaleminio" limit="10" title="Related MinIO Articles" >}}
 {{< taglist tag="scaleenterprise" limit="10" title="Related Enterprise Articles" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/SCALETutorials/Apps/UsingCatalogs.md
+++ b/content/SCALETutorials/Apps/UsingCatalogs.md
@@ -7,11 +7,12 @@ tags:
 - scaleapps
 - scaledocker
 - scalecatalog
+trademarkMinio: true
 ---
 
 {{< toc >}}
 
-TrueNAS SCALE comes with a pre-built official catalog of iXsystems-approved Docker apps that includes Plex, [MinIO]({{< relref "MinIOClustersSCALE.md" >}}), Nextcloud, [Chia]({{< relref "Chia.md" >}}), and IPFS.
+TrueNAS SCALE comes with a pre-built official catalog of iXsystems-approved Docker apps that includes Plex, [**MinIO™**]({{< relref "MinIOClustersSCALE.md" >}}), Nextcloud, [Chia]({{< relref "Chia.md" >}}), and IPFS.
 
 Users can also configure custom apps catalogs, although iXsystems does not directly support any non-official apps in a custom catalog.
 
@@ -59,3 +60,5 @@ Click **Save**.
 
 {{< taglist tag="scaleapps" limit="10" >}}
 {{< taglist tag="scalecatalog" limit="10" title="Related Catalog Articles" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/SCALETutorials/SystemSettings/Services/S3ServiceSCALE.md
+++ b/content/SCALETutorials/SystemSettings/Services/S3ServiceSCALE.md
@@ -6,6 +6,7 @@ alias:
 tags:
 - scales3
 - scaleminio
+trademarkMinio: true
 ---
 
 
@@ -13,7 +14,7 @@ tags:
 
 {{< include file="/static/includes/SCALEServiceDeprecationNotice.md" >}}
 
-Follow the migration and installation instructions in [Migrating from S3 Service]({{< relref "MigratingFromS3Service.md" >}}) and [Configuring MinIO Enterprise]({{< relref "ConfigMinioEnterprise.md" >}}) to move from the deprecated S3 service.
+Follow the migration and installation instructions in [Migrating from S3 Service]({{< relref "MigratingFromS3Service.md" >}}) and [Configuring **MinIO™** Enterprise]({{< relref "ConfigMinioEnterprise.md" >}}) to move from the deprecated S3 service.
 
 S3 allows you to connect to TrueNAS from a networked client system with the MinIO browser, s3cmd, or S3 browser.
 
@@ -105,3 +106,5 @@ It is possible to access, create new buckets, or upload files to created buckets
 
 
 {{< taglist tag="scaleminio" limit="10" title="Related MinIO Articles" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/SCALETutorials/SystemSettings/UpdateSCALE.md
+++ b/content/SCALETutorials/SystemSettings/UpdateSCALE.md
@@ -5,6 +5,7 @@ weight: 10
 alias:
 tags:
 - scaleupdate
+trademarkMinio: true
 ---
 
 {{< toc >}}
@@ -97,7 +98,7 @@ Create a new dataset on the same pool as the **ix-applications** dataset (the po
 
    * The **ix-applications** dataset to restore the migration JSON files to the earlier version.
    * A recursive replication of the **ix-applications** dataset to see the docker snapshot.
-   * Snapshots of any datasets that deployed apps use for storage, such as the MinIO app **data** dataset.
+   * Snapshots of any datasets that deployed apps use for storage, such as the **MinIO™** app **data** dataset.
 
    If a Bluefin app uses host path(s) to existing datasets, such as with the MinIO and the **/data** dataset, create and run remote replication tasks for these datasets.
    If you nested these datasets for apps under a parent dataset, set up a recursive remote replication of the parent dataset to create the snapshots of all the nested child datasets the apps use.
@@ -165,3 +166,5 @@ Wait for the apps to return to the **Active** state.
 {{< /expand >}}
 
 {{< taglist tag="scaleupdate" limit="10" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/SCALEUIReference/Apps/LaunchDockerImageScreens.md
+++ b/content/SCALEUIReference/Apps/LaunchDockerImageScreens.md
@@ -6,6 +6,7 @@ aliases:
 tags:
  - scaledocker
  - scaleapps
+trademarkMinio: true
 ---
 
 {{< toc >}}
@@ -58,7 +59,7 @@ Check the documentation for the application you want to install using a Docker I
 | Setting | Description |
 |---------|-------------|
 | **Configure Container CMD**| Click **Add** to display a **Command** field. |
-| **Command** | Enter container command. For example, if adding MinIO, enter *SERVER*. |
+| **Command** | Enter container command. For example, if adding **MinIO™**, enter *SERVER*. |
 | **Configure Container Args** | Click **Add** to display an argument entry **Arg** field. Click again to add more arguments. |
 | **Argument** | Enter an argument. For example, if adding MinIO, enter the IP and port string such as *http://0.0.0.0/9000/data*.|
 {{< /truetable >}}
@@ -220,3 +221,5 @@ The **Resource Limits** setting specifies the limits you want to place on the Ku
 The **Portal Configuration** setting specifies whether to **Enable WebUI Portal (only supported in TrueNAS SCALE Bluefin)**.
 
 {{< taglist tag="scaledocker" limit="10" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/SCALEUIReference/SystemSettings/Services/S3ServiceScreen.md
+++ b/content/SCALEUIReference/SystemSettings/Services/S3ServiceScreen.md
@@ -7,6 +7,7 @@ tags:
  - scales3
  - scaleminio
  - scaleservices
+trademarkMinio: true
 ---
 
 
@@ -16,7 +17,7 @@ tags:
 {{< include file="/static/includes/SCALEServiceDeprecationNotice.md" >}}
 
 
-The **Services > S3** screen allows you to specify settings to connect to TrueNAS from a networked client system with the Minio browser, s3cmd, or S3 browser.
+The **Services > S3** screen allows you to specify settings to connect to TrueNAS from a networked client system with the **MinIO™** browser, s3cmd, or S3 browser.
 
 ![S3ServiceSettingsTLS](/images/SCALE/22.12/S3ServiceSettingsTLS.png "S3 Service Options")
 
@@ -35,3 +36,5 @@ The **Services > S3** screen allows you to specify settings to connect to TrueNA
 {{< /truetable >}}
 
 {{< taglist tag="scales3" limit="10" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   {{ range .Paginator.Pages }}
-    <article class="gdoc-post" data-pagefind-ignore>
+    <article class="gdoc-post">
       <header class="gdoc-post__header">
         <h1 class="gdoc-post__title">
           <a href="{{ .RelPermalink }}">{{ partial "utils/title" . }}</a>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,0 +1,52 @@
+{{ define "main" }}
+  {{ range .Paginator.Pages }}
+    <article class="gdoc-post" data-pagefind-ignore>
+      <header class="gdoc-post__header">
+        <h1 class="gdoc-post__title">
+          <a href="{{ .RelPermalink }}">{{ partial "utils/title" . }}</a>
+        </h1>
+      </header>
+
+      <section class="gdoc-markdown">
+        {{ .Summary }}
+        {{ if or .Params.trademarkMinio .Params.trademarkAistor }}
+          {{ partial "trademark-notice.html" (dict "minio" (.Params.trademarkMinio | default false) "aistor" (.Params.trademarkAistor | default false)) }}
+        {{ end }}
+      </section>
+
+      <div class="gdoc-post__readmore">
+        {{ if .Truncated }}
+          <a
+            class="flex-inline align-center fake-link"
+            title="{{ i18n "posts_read_more" }}"
+            href="{{ .RelPermalink }}"
+          >
+            {{ i18n "posts_read_more" }}
+            <i class="gdoc-icon">gdoc_arrow_right_alt</i>
+          </a>
+        {{ end }}
+      </div>
+
+      <footer class="gdoc-post__footer">
+        <div class="flex flex-wrap align-center gdoc-post__meta">
+          {{ partial "posts/metadata.html" . }}
+        </div>
+      </footer>
+    </article>
+  {{ end }}
+  {{ partial "pagination.html" . }}
+{{ end }}
+
+{{ define "post-tag" }}
+  <span class="gdoc-post__tag">
+    <span class="gdoc-button">
+      <a
+        class="gdoc-button__link"
+        href="{{ .page.RelPermalink }}"
+        title="{{ i18n "posts_tagged_with" .name }}"
+      >
+        {{ .name }}
+      </a>
+    </span>
+  </span>
+{{ end }}

--- a/layouts/partials/trademark-notice.html
+++ b/layouts/partials/trademark-notice.html
@@ -1,0 +1,9 @@
+{{ $minio := .minio | default false }}
+{{ $aistor := .aistor | default false }}
+{{ if and $minio $aistor }}
+<p class="trademark-notice"><small><em>MinIO and AIStor are trademarks of the MinIO Corporation.</em></small></p>
+{{ else if $minio }}
+<p class="trademark-notice"><small><em>MinIO is a trademark of the MinIO Corporation.</em></small></p>
+{{ else if $aistor }}
+<p class="trademark-notice"><small><em>AIStor is a trademark of the MinIO Corporation.</em></small></p>
+{{ end }}

--- a/layouts/shortcodes/trademark-notice.html
+++ b/layouts/shortcodes/trademark-notice.html
@@ -1,0 +1,7 @@
+{{ $minio := (eq (.Get "minio") "true") }}
+{{ $aistor := (eq (.Get "aistor") "true") }}
+{{ if or $minio $aistor }}
+{{ partial "trademark-notice.html" (dict "minio" $minio "aistor" $aistor) }}
+{{ else }}
+{{- errorf "trademark-notice requires minio=\"true\" and/or aistor=\"true\": %s" .Position }}
+{{ end }}

--- a/static/includes/BluefinDeprecated.md
+++ b/static/includes/BluefinDeprecated.md
@@ -18,7 +18,7 @@ These software features are affected:
 | OpenVPN Client | The current service is deprecated with no replacement available. |
 | OpenVPN Server | This service is deprecated as several solutions are now available in the Apps menu. Choose a new VPN solution from the Apps menu and configure to provide similar functionality. |
 | Rsyncd Server | Determine if enabling an rsync server is necessary on the system. Rsync tasks that have **Rsync Mode** set to **SSH** or are externally configured with SSH don't need the rsync service enabled. The **rsyncd** application is available when TrueNAS must be used to create insecure non-SSH rsync tasks. |
-| S3 | Deploy the **minio** application from the TrueNAS Enterprise catalog and port any existing configuration from **System Settings > Services > S3** to the deployed application. For instructions on how to migrate from the S3 service to the MinIO application see [Migrating from S3 Service]({{< relref "MigratingFromS3Service.md" >}}). |
+| S3 | Deploy the **MinIO™** application from the TrueNAS Enterprise catalog and port any existing configuration from **System Settings > Services > S3** to the deployed application. For instructions on how to migrate from the S3 service to the MinIO application see [Migrating from S3 Service]({{< relref "MigratingFromS3Service.md" >}}). |
 | TFTP | Deploy the **tftpd-hpa** application and port any existing configuration from **System Settings > Services > TFTP** to the deployed application. |
 | WebDAV | Deploy the **webdav** application and port any existing configuration from **Shares > WebDAV** and **System Settings > Services > WebDAV** to the deployed application. |
 {{< /truetable >}}


### PR DESCRIPTION
## Summary
Part of DOCS-2743 (MinIO Legal Compliance), branch `22.12` — the richest branch in this project. Marks the first mention of MinIO with bold+™+correct casing on 13 pages, fixes pre-existing casing bugs where they're genuine docs typos, adds a from-scratch taxonomy-page attribution fix, and appends the required attribution footer everywhere MinIO is named or shown to a reader.

**New infrastructure:**
- `layouts/partials/trademark-notice.html` + `layouts/shortcodes/trademark-notice.html` — split design (byte-identical to `master`'s approved pattern), needed because...
- `layouts/_default/taxonomy.html` — this branch had no repo-local override at all. New file, diffed byte-for-byte against the vendored theme default plus one small conditional attribution block, gated on a `trademarkMinio`/`trademarkAistor` frontmatter flag added to the 10 pages that need it.

**13 affected pages** (4 MinIO tutorial pages, an Enterprise config tutorial, 3 S3-service reference pages, this branch's own release notes, a cluster-prep page, a launch-docker-image reference page, an update-SCALE page, a using-catalogs page, and a deprecated-services page reached only through a shared include).

**Two notable judgment calls, both independently verified via screenshot inspection and endorsed by the final review:**
- Several bolded lowercase "Minio"/"minio" phrases were deliberately left uncorrected — they are verbatim quotes of a real, confirmed casing bug in the actual TrueNAS Apps install-wizard UI (the MinIO Helm chart's dialog genuinely displays "minio" in lowercase). "Fixing" these would make the documentation inaccurate relative to the real product.
- `static/includes/BluefinDeprecated.md` (a shared include) is this branch's true first mention on one consuming page (`SCALEDeprecatedFeatures.md`) but a later, incidental mention on another (`SCALEReleaseNotes.md`, which already has its own separate first mention). We marked the shared file, accepting a documented, harmless second mark on `SCALEReleaseNotes.md` — the alternative (leaving `SCALEDeprecatedFeatures.md`'s true first mention unmarked) is worse, and a redundant trademark mark is not itself a compliance risk.

What wasn't needed on this branch (all confirmed, not assumed): `Copyrights.md`, `content/_archive/`, changelog-CSV tables (no `static/data/` directory exists at all here), and several classes of arbitrary example values (CLI dataset-path placeholders, auto-generated API examples, screenshot filenames).

## Test plan
- [x] Clean build with this branch's pinned Hugo v0.117.0 (vendored theme incompatible with newer Hugo, unrelated to this change): exit 0, 0 ERROR lines.
- [x] All 13 pages render exactly the expected mark/attribution counts (12 pages at 1/1, one at 2/1 per the documented shared-include tradeoff).
- [x] Verbatim UI-bug quotes independently re-verified via the actual referenced screenshots (not just inferred) — confirmed untouched.
- [x] Ticket-title exclusion on the release notes page confirmed — no `[NAS-XXXXX]` bullet touched.
- [x] New taxonomy.html diffed byte-for-byte against the vendored theme default — zero unrelated differences; verified the gated attribution mechanism actually works across 5 different tag-listing pages with zero unattributed-mark gaps.
- [x] Site-wide source sweep and mark-without-attribution sweep — only the one known, accepted raw-passthrough non-issue remains.
- [x] Independent final whole-branch review (Opus, the most thorough in this project's series given the branch's size): APPROVED. One small, zero-risk hardening fix applied per its suggestion (an inert `trademarkMinio` flag added to close a latent future gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)