### PR TITLE
DOCS-2743 / 13.0 / MinIO/AIStor trademark legal compliance (13.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 tech-doc-hugo
 .vscode
 *.lock
+
+# Superpowers specs and plans
+docs/superpowers/

--- a/content/CORETutorials/Services/ConfiguringS3.md
+++ b/content/CORETutorials/Services/ConfiguringS3.md
@@ -8,3 +8,5 @@ tags:
 ---
 
 {{< include file="/static/includes/S3Deprecation.md" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/CORETutorials/Services/S3forMinIO.md
+++ b/content/CORETutorials/Services/S3forMinIO.md
@@ -8,3 +8,5 @@ tags:
 ---
 
 {{< include file="/static/includes/S3Deprecation.md" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -20,7 +20,7 @@ weight: 3
 
 * Due to security vulnerabilities and maintainability issues, the S3 service is deprecated in TrueNAS CORE 13.0 and removed in CORE 13.3 ([NAS-127694](https://ixsystems.atlassian.net/browse/NAS-127694)).
   Beginning in CORE 13.0-U6, the CORE web interface generates an alert when the deprecated service is either actively running or enabled to start on boot.
-  Users should move any production data away from the S3 service storage location before migrating to TrueNAS 24.04 or newer, which has MinIO applications available.
+  Users should move any production data away from the S3 service storage location before migrating to TrueNAS 24.04 or newer, which has **MinIO™** applications available.
   See also [Feature Deprecations]({{< ref "Deprecations" >}}).
 
 * SAS Multipath is supported *as-is* and receives no further maintenance updates.
@@ -127,7 +127,7 @@ The improvements include:
 Due to security vulnerabilities and maintainability issues, the S3 service is deprecated in TrueNAS CORE 13.0 and scheduled for removal in CORE 13.3.
 Beginning in CORE 13.0-U6, the CORE web interface generates an alert when the deprecated service is either actively running or is enabled to start on boot.
 Users should plan to use a separately maintained MinIO app available from TrueNAS 22.12 or newer releases or otherwise move any production data away from the S3 service storage location.
-Enterprise customers can contact iX Support for assistance with moving away from S3 or Minio services in TrueNAS 13.0.
+Enterprise customers can contact iX Support for assistance with moving away from S3 or MinIO services in TrueNAS 13.0.
 
 ### TrueNAS 13.0-U6 Changelog
 
@@ -1375,3 +1375,5 @@ Please use CLI commands carefully and **always back up critical data** before at
 	root@examplemini[~]#
    ```
 {{< /expand >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/UIReference/Services/S3Screen.md
+++ b/content/UIReference/Services/S3Screen.md
@@ -8,3 +8,5 @@ tags:
 ---
 
 {{< include file="/static/includes/S3Deprecation.md" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/layouts/shortcodes/trademark-notice.html
+++ b/layouts/shortcodes/trademark-notice.html
@@ -1,0 +1,13 @@
+{{ $minio := (eq (.Get "minio") "true") }}
+{{ $aistor := (eq (.Get "aistor") "true") }}
+{{ if or $minio $aistor }}
+{{ if and $minio $aistor }}
+<p class="trademark-notice"><small><em>MinIO and AIStor are trademarks of the MinIO Corporation.</em></small></p>
+{{ else if $minio }}
+<p class="trademark-notice"><small><em>MinIO is a trademark of the MinIO Corporation.</em></small></p>
+{{ else if $aistor }}
+<p class="trademark-notice"><small><em>AIStor is a trademark of the MinIO Corporation.</em></small></p>
+{{ end }}
+{{ else }}
+{{- errorf "trademark-notice requires minio=\"true\" and/or aistor=\"true\": %s" .Position }}
+{{ end }}

--- a/static/includes/S3Deprecation.md
+++ b/static/includes/S3Deprecation.md
@@ -7,7 +7,7 @@ Beginning in CORE 13.0-U6, the CORE web interface generates an alert when the de
 {{< enterprise >}}
 Beginning in CORE 13.0-U6, Enterprise customers with the S3 service running or enabled are prevented from upgrading to the next major version.
 
-Please contact iX Support to review options for migrating to a TrueNAS release that has Minio applications available.
+Please contact iX Support to review options for migrating to a TrueNAS release that has **MinIO™** applications available.
 
 {{< expand "Contacting Support" "v" >}}
 {{< include file="/static/includes/iXsystemsSupportContact.md" >}}


### PR DESCRIPTION
## Summary
Part of DOCS-2743 (MinIO Legal Compliance), branch `13.0`. Fixes a casing bug in a shared include (marking its first-and-only-mention status for 3 consuming stub pages), marks and fixes a casing bug on the CORE 13.0 release notes page, and appends the required attribution sentence everywhere MinIO is named to a reader.

- `layouts/shortcodes/trademark-notice.html` — new self-contained shortcode, byte-identical (md5-verified) to the versions on `26`/`25.10`/`25.04`/`24.10`/`23.10`.
- `static/includes/S3Deprecation.md` — casing fix + first-mention mark (`Minio applications` → `**MinIO™** applications`). Consumed by exactly 3 pages, each a stub whose entire body is this one include call — unlike `22.12`'s shared-include case, there's no cross-page conflict here since the shared mention is genuinely the first mention on all 3 consumers.
- `content/GettingStarted/COREReleaseNotes.md` — first mention marked; one genuine docs-authored casing bug fixed; every `[NAS-XXXXX]`-prefixed ticket-title bullet (9 total, both modern markdown-link and legacy `<li>` HTML formats) left byte-for-byte untouched per established policy — confirmed via `git diff --numstat` that the diff touches only 4 lines total in this large changelog file.
- `content/CORETutorials/Services/ConfiguringS3.md`, `content/CORETutorials/Services/S3forMinIO.md`, `content/UIReference/Services/S3Screen.md` — attribution appended to each (consuming the shared include's mark).

What wasn't needed on this branch (all confirmed, not assumed):
- No special Hugo binary required — this branch's CI-pinned version builds cleanly with the environment's default `hugo`, unlike `23.10`/`22.12`.
- No taxonomy fix needed — confirmed via content-block-scoped inspection that the 3 stub pages' `.Summary` truncates before reaching the marked sentence on both relevant tag pages (`cores3`, `cores3minio`); RSS feeds (which render full content) show mark and attribution co-present.
- `content/CORETutorials/JailsPluginsVMs/_index.md` — an old URL redirect alias only; confirmed via a rendered build to produce a bare meta-refresh stub with zero visible text.
- `static/api/{core,scale}_websocket_api.html` — auto-generated API example content, same as every prior branch.
- One accepted, carried-forward non-issue: `static/includes/S3Deprecation.md`'s raw static-passthrough copy at `public/includes/S3Deprecation.md` shows the mark without adjacent attribution — the same pre-existing, site-wide Hugo structural characteristic already ruled non-actionable on `25.04`/`22.12`.

## Test plan
- [x] Clean `hugo --gc --minify` build: exit 0, 0 ERROR lines, 587 pages.
- [x] All 4 affected pages render exactly 1 attribution sentence and exactly 1 mark each.
- [x] Ticket-title exclusion structurally confirmed — no `[NAS-XXXXX]` bullet appears in the diff at all.
- [x] Taxonomy pages checked with content-block-scoped inspection (immune to the `cores3minio` tag's own sitewide nav-noise, same class as `23.10`'s `scaleminio`) — zero leaks; RSS counterparts confirmed co-present.
- [x] Site-wide source sweep and mark-without-attribution sweep — only the known, accepted raw-passthrough non-issue remains.
- [x] Print view and RSS/book aggregation paths checked for all four affected pages.
- [x] Independent final whole-branch review (Opus): APPROVED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)