### PR TITLE
DOCS-2743 / 13.3 / MinIO/AIStor trademark legal compliance (13.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 tech-doc-hugo
 .vscode
 *.lock
+
+# Superpowers specs and plans
+docs/superpowers/

--- a/content/CORETutorials/Services/ConfiguringS3.md
+++ b/content/CORETutorials/Services/ConfiguringS3.md
@@ -7,3 +7,5 @@ tags:
 ---
 
 {{< include file="/static/includes/S3Deprecation.md" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/CORETutorials/Services/S3forMinIO.md
+++ b/content/CORETutorials/Services/S3forMinIO.md
@@ -7,3 +7,5 @@ tags:
 ---
 
 {{< include file="/static/includes/S3Deprecation.md" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/GettingStarted/COREReleaseNotes.md
+++ b/content/GettingStarted/COREReleaseNotes.md
@@ -27,7 +27,7 @@ aliases:
 
 * Due to security vulnerabilities and maintainability issues, the S3 service is deprecated in TrueNAS CORE 13.0 and removed in CORE 13.3 ([NAS-127694](https://ixsystems.atlassian.net/browse/NAS-127694)).
   Beginning in CORE 13.0-U6, the CORE web interface generates an alert when the deprecated service is either actively running or is enabled to start on boot.
-  Users should move any production data away from the S3 service storage location before migrating to TrueNAS 24.04 or newer, which have MinIO applications available.
+  Users should move any production data away from the S3 service storage location before migrating to TrueNAS 24.04 or newer, which have **MinIO™** applications available.
   See also [Feature Deprecations]({{< ref "Deprecations" >}}).
 
 * The web UI **Shell** is removed in CORE 13.3. Users can continue to access the shell using [SSH]({{< ref "ConfiguringSSH" >}}) or a physical system connection with serial cable or other direct method ([NAS-124392](https://ixsystems.atlassian.net/browse/NAS-124392)).
@@ -189,7 +189,7 @@ Notable changes:
 
 * Due to security vulnerabilities and maintainability issues, the S3 service is deprecated in TrueNAS CORE 13.0 and removed in CORE 13.3 ([NAS-127694](https://ixsystems.atlassian.net/browse/NAS-127694)).
   Beginning in CORE 13.0-U6, the CORE web interface generates an alert when the deprecated service is either actively running or is enabled to start on boot.
-  Users should move any production data away from the S3 service storage location and consider migrating to TrueNAS 24.04 or newer releases that have Minio Applications available.
+  Users should move any production data away from the S3 service storage location and consider migrating to TrueNAS 24.04 or newer releases that have MinIO Applications available.
   See also [Feature Deprecations]({{< ref "Deprecations" >}}).
 
 * The web UI **Shell** is removed in CORE 13.3. Users can continue to access the shell using [SSH]({{< ref "ConfiguringSSH" >}}) or a physical system connection with serial cable or other direct method ([NAS-124392](https://ixsystems.atlassian.net/browse/NAS-124392)).
@@ -220,3 +220,5 @@ TrueNAS Enterprise HA customers should not upgrade to 13.3-BETA1 at this time.
 <a href="https://ixsystems.atlassian.net/issues/?filter=10549" target="_blank">Click here to see the latest information</a> about public issues discovered in 13.3-BETA1 that are being resolved in a future TrueNAS CORE release.
 
 {{< /expand >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/GettingStarted/Deprecations.md
+++ b/content/GettingStarted/Deprecations.md
@@ -19,7 +19,7 @@ Beginning in CORE 13.0-U6, the CORE web interface generates an alert when the de
 Beginning in CORE 13.0-U6, Enterprise customers with the S3 service running or enabled are prevented from upgrading to 13.3.
 {{< /enterprise >}}
 
-Users should plan to migrate to a separately maintained MinIO application in TrueNAS 22.12 or newer or otherwise move any production data away from the S3 service storage location.
+Users should plan to migrate to a separately maintained **MinIO™** application in TrueNAS 22.12 or newer or otherwise move any production data away from the S3 service storage location.
 Migrating from the built-in S3 service to the separately maintained application could result in an extended data migration window and potential disruption to S3 data access.
 
 ## SAS Multipath
@@ -38,3 +38,5 @@ Users should avoid creating and managing SAS multipath scenarios with TrueNAS.
 
 The web UI **Shell** is removed in CORE 13.3.
 Users can continue to access the shell using [SSH]({{< ref "ConfiguringSSH" >}}) or a physical system connection with serial cable or other direct method.
+
+{{< trademark-notice minio="true" >}}

--- a/content/UIReference/Services/S3Screen.md
+++ b/content/UIReference/Services/S3Screen.md
@@ -7,3 +7,5 @@ tags:
 ---
 
 {{< include file="/static/includes/S3Deprecation.md" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/layouts/shortcodes/trademark-notice.html
+++ b/layouts/shortcodes/trademark-notice.html
@@ -1,0 +1,13 @@
+{{ $minio := (eq (.Get "minio") "true") }}
+{{ $aistor := (eq (.Get "aistor") "true") }}
+{{ if or $minio $aistor }}
+{{ if and $minio $aistor }}
+<p class="trademark-notice"><small><em>MinIO and AIStor are trademarks of the MinIO Corporation.</em></small></p>
+{{ else if $minio }}
+<p class="trademark-notice"><small><em>MinIO is a trademark of the MinIO Corporation.</em></small></p>
+{{ else if $aistor }}
+<p class="trademark-notice"><small><em>AIStor is a trademark of the MinIO Corporation.</em></small></p>
+{{ end }}
+{{ else }}
+{{- errorf "trademark-notice requires minio=\"true\" and/or aistor=\"true\": %s" .Position }}
+{{ end }}

--- a/static/includes/S3Deprecation.md
+++ b/static/includes/S3Deprecation.md
@@ -7,7 +7,7 @@ Beginning in CORE 13.0-U6, the CORE web interface generates an alert when the de
 {{< enterprise >}}
 Beginning in CORE 13.0-U6, Enterprise customers with the S3 service running or enabled are prevented from upgrading to 13.3.
 
-Please contact iX Support to review options for migrating to a TrueNAS release that has Minio applications available.
+Please contact iX Support to review options for migrating to a TrueNAS release that has **MinIO™** applications available.
 
 {{< expand "Contacting Support" "v" >}}
 {{< include file="/static/includes/iXsystemsSupportContact.md" >}}


### PR DESCRIPTION
## Summary
Part of DOCS-2743 (MinIO Legal Compliance), branch `13.3` — the final branch in this project. Fixes a casing bug in a shared include (marking its first-and-only-mention status for 3 consuming stub pages), marks first mentions on two other pages, fixes one more casing bug, and appends the required attribution sentence everywhere MinIO is named to a reader.

- `layouts/shortcodes/trademark-notice.html` — new self-contained shortcode, matching the pattern already approved on `26`/`25.10`/`25.04`/`24.10`/`23.10`/`13.0`.
- `static/includes/S3Deprecation.md` — casing fix + first-mention mark (`Minio applications` → `**MinIO™** applications`). Consumed by 3 stub pages whose entire body is this one include call — no cross-page conflict, genuinely first mention for all 3.
- `content/GettingStarted/COREReleaseNotes.md` — a repeated boilerplate paragraph appears twice; marked the first occurrence, fixed a casing-only bug in the second (leaving unrelated capitalization alone).
- `content/GettingStarted/Deprecations.md` — first (and only) mention marked.
- `content/CORETutorials/Services/ConfiguringS3.md`, `content/CORETutorials/Services/S3forMinIO.md`, `content/UIReference/Services/S3Screen.md` — attribution appended (consuming the shared include's mark).

What wasn't needed on this branch (all confirmed, not assumed):
- No taxonomy fix needed — confirmed via content-block-scoped inspection that all 3 stub pages' `.Summary` truncates before reaching the marked sentence on the relevant tag page (`s3`); the only "minio" noise inside `S3forMinIO`'s article block traces to its own URL slug (`s3forminio` contains "minio" as a substring) plus its already-correctly-cased title, not real content leakage.
- `content/CORETutorials/JailsPluginsVMs/_index.md` — an old URL redirect alias only, same non-issue pattern as `13.0`.
- `static/api/{core,scale}_websocket_api.html` — auto-generated API example content, same as every prior branch.
- One accepted, carried-forward non-issue: `static/includes/S3Deprecation.md`'s raw static-passthrough copy shows the mark without adjacent attribution — the same pre-existing, site-wide Hugo structural characteristic already ruled non-actionable on `25.04`/`22.12`/`13.0`.

Note: this branch's CI pins Hugo v0.145.0; the default `hugo` in the build environment used for verification is newer and fails on an unrelated, pre-existing duplicate-YAML-key bug in `data/properties/scale-downloads.yaml` — building with the pinned 0.145.0 binary confirms this diff is unaffected by that issue.

## Test plan
- [x] Clean build with Hugo v0.145.0 (this branch's CI-pinned version): exit 0, 0 ERROR lines.
- [x] All 5 affected pages render exactly 1 attribution sentence and exactly 1 mark each.
- [x] Content-block-scoped taxonomy check on the `s3` tag page — zero leaks.
- [x] Site-wide source sweep and mark-without-attribution sweep — only the known, accepted raw-passthrough non-issue remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)