### PR TITLE
DOCS-2607 / 25.10 / Docs 2607 update core migration, boot environment rollbacks, and ad config (by micjohnson777)

### DIFF
--- a/content/GettingStarted/Migrate/MigratePrep.md
+++ b/content/GettingStarted/Migrate/MigratePrep.md
@@ -110,7 +110,10 @@ Please contact Support for assistance!
 
 8. Back up any critical data.
 
-9. Download your [system configuration file](https://www.truenas.com/docs/core/coretutorials/systemconfiguration/usingconfigurationbackups/) and a [debug file](https://www.truenas.com/docs/core/uireference/system/advanced/).
+9. Verify AD is in a healthy state, if TrueNAS is joined to AD. Migrating with AD healthy and joined should not result in desynchronization issues.
+   The stored secret should move forward to the upgraded release without issues.
+
+10. Download your [system configuration file](https://www.truenas.com/docs/core/coretutorials/systemconfiguration/usingconfigurationbackups/) and a [debug file](https://www.truenas.com/docs/core/uireference/system/advanced/).
    After updating to the latest publicly available release of TrueNAS 13.0 (or 13.3 for community users) and making any changes to user accounts or any other settings, download these files and keep them in a safe place and where you can access them if you need to revert with a clean install using the TrueNAS 13.0 or 13.3 <file>iso</file> file.
 
 {{< enterprise >}}

--- a/content/GettingStarted/Migrate/MigratingFromCORE.md
+++ b/content/GettingStarted/Migrate/MigratingFromCORE.md
@@ -35,6 +35,8 @@ The process requires an extended maintenance window, requires executing steps in
 
 Depending on system configuration, migrating can be more or less complicated.
 
+If your FreeBSD based system is joined to Active Directory, leave AD before migrating to a Debian-based release to avoid desynchronization issues that can result between release types.
+
 ## Migration Methods
 
 {{< include file="/static/includes/MigrateCOREtoSCALEWarning.md" >}}
@@ -133,3 +135,8 @@ Use the information gathered during your preparation to migrate to restore setti
 ## Recreating the Admin User Account
 
 {{< include file="/static/includes/AddAdminUserAccount.md" >}}
+
+## Reverting Back to FreeBSD-Based Releases
+
+In the event you need to revert to the FreeBSD-based release and you are joined to Active Directory, first leave AD, then clean-install the FreeBSD-based version, and upload the system config file to recover. Rejoin AD. Verify the system is configured as desired, and AD is healthy.
+Save a new debug file, then save the system configuration file with the secret seed. Use the procedures above to migrate to the latest Debian-Linux version of TrueNAS.

--- a/content/SCALETutorials/Credentials/DirectoryServices/ConfigADSCALE.md
+++ b/content/SCALETutorials/Credentials/DirectoryServices/ConfigADSCALE.md
@@ -16,6 +16,7 @@ keywords:
 {{< include file="/static/includes/DirectoryServiceConflictAdmonition.md" >}}
 
 ## Configuring TrueNAS Active Directory Access
+
 The Active Directory (AD) service shares resources in a Windows network.
 AD provides authentication and authorization services for the users in a network, eliminating the need to recreate the user accounts on TrueNAS.
 
@@ -27,6 +28,7 @@ Joining an AD domain also configures the Privileged Access Manager (PAM) to let 
 Users can configure AD services on Windows or Unix-like operating systems using [Samba version 4](https://wiki.samba.org/index.php/Setting_up_Samba_as_an_Active_Directory_Domain_Controller#Provisioning_a_Samba_Active_Directory).
 
 ### Preparing to Configure AD in TrueNAS
+
 Before configuring Active Directory (AD) in TrueNAS:
 
 You need to know the hostname assigned to the TrueNAS system. The default value is **truenas**.
@@ -46,6 +48,7 @@ After taking these actions, you can [connect to the Active Directory domain](#co
 {{< include file="/static/includes/NetBIOSValidationWarning.md" >}}
 
 ### Setting Time Synchronization
+
 Active Directory relies on the time-sensitive [Kerberos](https://tools.ietf.org/html/rfc1510) protocol.
 TrueNAS adds the AD domain controller with the [PDC Emulator FSMO Role](https://support.microsoft.com/en-us/help/197132/active-directory-fsmo-roles-in-windows) as the preferred NTP server during the domain join process.
 If your environment requires something different, go to **System > Advanced Settings**, click **Add** to open the **NTP Servers** screen, then add a new or edit a listed server.
@@ -190,6 +193,7 @@ If the cache becomes out of sync or fewer users than expected are available in t
 The name in **TrueNAS Hostname** should match the name in **Hostname** on the **Network > Global Configuration** screen.
 
 ## Disabling Active Directory
+
 To disable your AD server connection without deleting your configuration or leaving the AD domain, click **Settings** in the **Active Directory** widget to open the **Active Directory** settings screen.
 Clear the **Enable Service** checkbox and click **Save** to disable the AD service.
 
@@ -199,8 +203,13 @@ Click **Configure Directory Services** to open the **Directory Services Configur
 Select **Enable Service** again, and click **Save** to reactivate your connection to your AD server.
 
 ## Leaving Active Directory
+
 Users must cleanly leave an Active Directory for TrueNAS to delete the configuration.
 To cleanly leave AD, click **Leave Domain** on the **Active Directory** settings screen to remove the AD object.
 Remove the computer account and associated DNS records from the Active Directory.
 
 If the AD server moves or shuts down without you using **Leave Domain**, TrueNAS does not remove the AD object, and you have to clean up the Active Directory.
+
+### Rolling Back to Earlier Boot Environments with AD Joined
+
+{{< include file="/static/includes/ADandBERollBacks.md" >}}

--- a/content/SCALETutorials/SystemSettings/ManageBootEnvironSCALE.md
+++ b/content/SCALETutorials/SystemSettings/ManageBootEnvironSCALE.md
@@ -116,6 +116,13 @@ The **System Boot** screen status changes to **Reboot** and the current **Active
 Activating and booting into an older environment restores only that environment state. Any changes made there do not carry forward into newer environments.
 {{< /hint >}}
 
+### Rolling Back a Boot Environment
+
+{{< include file="/static/includes/ADandBERollBacks.md" >}}
+
+To roll back to a previous Debian-Linux based boot environment, click the **Activate** icon for the environment you want to roll back to, then restart the system.
+See [Migrating CORE to SCALE]({{< ref "MigratingFromCore" >}}) for information on rolling back or reverting to FreeBSD-based releases.
+
 ### Cloning a Boot Environment
 
 Cloning copies the selected boot environment into a new inactive boot environment that preserves the **boot-pool** state at the clone-creation time.

--- a/static/includes/ADandBERollBacks.md
+++ b/static/includes/ADandBERollBacks.md
@@ -1,0 +1,9 @@
+&NewLine;
+
+When the system is joined to Active Directory and you roll back to (activate) an earlier boot environment, or in the case where you migrated from a FreeBSD-based version to a current Debian-Linux version of TrueNAS and then need to revert back to FreeBSD-based, this can result in desynchronization of the system account password in AD between the different environments.
+The directory service-stored secret moves forward with upgrades, while the rolled-back boot environment retains the old one.
+If desynchronization occurs, you might see a Kerberos credentials not valid error message.
+
+To avoid possible issues, leave AD, then rollback or revert to the earlier version, and then rejoin AD.
+
+To recover from the error, leave and then rejoin Active Directory.


### PR DESCRIPTION
This PR adds information on rolling back boot environments where AD is joined and possible desynchronization issues that can happen. It updates the MigratePrep.md and MigratingFromCORE.md articles with AD related preparation and roll-back information, and updates the ManageBootEnviron.md and ConfigAD.md articles with rolling back and resolving desynchronization issue instructions.

Backport to 25.10 and 26

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.


Original PR: https://github.com/truenas/documentation/pull/4785
Jira URL: https://ixsystemsinc.atlassian.net/browse/DOCS-2607