### PR TITLE
DOCS-2724 / 25.10 / Docs 2724 smb audit documentation is misleading (by DjP-iX)

### DIFF
--- a/content/SCALETutorials/SystemSettings/AuditingSCALE.md
+++ b/content/SCALETutorials/SystemSettings/AuditingSCALE.md
@@ -1,5 +1,5 @@
 ---
-title: "Audit Logs"
+title: "Using Audit Logs"
 description: "Provides information on the System and SMB Share auditing screens and function in TrueNAS."
 weight: 90
 tags:
@@ -90,19 +90,13 @@ Does not log internally-initiated create operations.
 Each SMB tree connection can have multiple open files.
 {{< /expand >}}
 {{< expand "Read or Write Events" "v" >}}
-Generated at configurable intervals as an SMB client reads from or writes to a file.
-Specifies the minimum time to wait before generating another read or write event for a given file type.
-
-For example, when set to 5 and an SMB client does constant writes to a file, only 12 events are generated per minute.
-The default value is **60**, or one event per type per minute.
+Generated as an SMB client reads from or writes to a file.
+TrueNAS waits at least 60 seconds after a read or write event before generating another one for the same file type, so constant reads or writes to a file produce one event per type per minute.
 File-based counters are printed within close messages, and connection-based counters are included in disconnect messages.
 {{< /expand >}}
 {{< expand "Read or Write Offload Events" "v" >}}
-Generated at configurable intervals as an SMB client performs offloads of reads from or writes to a file.
-Specifies the minimum time to wait before generating another offload read or write event for a given file type.
-
-For example, when set to 5 and an SMB client does constant writes to a file, only 12 events are generated per minute.
-The default value is **60**, or one event per type per minute.
+Generated as an SMB client performs offloads of reads from or writes to a file.
+TrueNAS waits at least 60 seconds after an offload read or write event before generating another one for the same file type, so constant offload reads or writes to a file produce one event per type per minute.
 File-based counters are printed within close messages, and connection-based counters are included in disconnect messages.
 {{< /expand >}}
 {{< expand "Open or Close Events" "v" >}}

--- a/static/includes/ConfigureSMBShareAuditingSCALE.md
+++ b/static/includes/ConfigureSMBShareAuditingSCALE.md
@@ -16,7 +16,7 @@ At least one of **Watch List** or **Ignore List** must contain entries when enab
 
 Auditing all SMB operations without restrictions creates large audit databases that grow rapidly and consume significant disk space. High-volume SMB environments can generate hundreds of thousands of audit entries per day, leading to increased disk I/O that affects overall system performance and database query delays when reviewing audit logs.
 
-Configure filtering to audit only necessary operations.
+Use **Watch List** or **Ignore List** to limit auditing to specific groups and reduce audit volume.
 {{< /hint >}}
 
 {{< hint type=note >}}


### PR DESCRIPTION
Updates SMB auditing documentation inconsistencies identified in the ticket.

Also updates the title of the Audit Logs tutorial to use a gerund form title, matching the convention for other tutorials.

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.


Original PR: https://github.com/truenas/documentation/pull/4786
Jira URL: https://ixsystemsinc.atlassian.net/browse/DOCS-2724