### PR TITLE
DOCS-2609 / 27 / DOCS-2609 Add SNMP v3 Service Migration Instructions

### DIFF
--- a/content/SCALE/GettingStarted/Migrate/MigratePrep.md
+++ b/content/SCALE/GettingStarted/Migrate/MigratePrep.md
@@ -74,6 +74,8 @@ Please contact Support for assistance!
    <input type="checkbox"> Credentials - Copy or write down the credentials for SSH connections and keypairs, and any configured cloud service backup providers if you do not have the credential settings saved in other files kept secured outside of TrueNAS.
 
    <input type="checkbox"> Data protection tasks - Write down or take screenshots of replication, rsync tasks, periodic snapshots, cloud sync, or other task settings to reconfigure these after migrating.
+
+   <input type="checkbox"> SNMP v3 service settings - Write down or take a screenshot of the SNMP service V3 settings to use after migrating.
    
    TrueNAS uses SSH connections in data protection tasks, so data protection tasks (especially replication tasks) might require reconfiguration in some cases.
    After migrating to 25.10, SSH connections have failed with an authentication error in some cases.

--- a/content/SCALE/GettingStarted/Migrate/MigratingFromCORE.md
+++ b/content/SCALE/GettingStarted/Migrate/MigratingFromCORE.md
@@ -143,3 +143,7 @@ Use the information gathered during your preparation to migrate to restore setti
 
 In the event you need to revert to the FreeBSD-based release and you are joined to Active Directory, first leave AD, then clean-install the FreeBSD-based version, and upload the system config file to recover. Rejoin AD. Verify the system is configured as desired, and AD is healthy.
 Save a new debug file, then save the system configuration file with the secret seed. Use the procedures above to migrate to the latest Debian-Linux version of TrueNAS.
+
+## SNMP v3 Service Migration
+
+{{< include file="/static/includes/SNMPv3ServiceMigrationInstructions.md" >}}

--- a/content/SCALE/SystemSettings/Services/SNMPService.md
+++ b/content/SCALE/SystemSettings/Services/SNMPService.md
@@ -41,3 +41,7 @@ truenas_admin@mytruenas.example.com's password:
 TRUENAS-MIB.txt                                                 100%   11KB 112.0KB/s   00:00
 PS C:\Users\tnuser>
 ```
+
+## SNMP v3 Service Migration
+
+{{< include file="/static/includes/SNMPv3ServiceMigrationInstructions.md" >}}

--- a/static/includes/SNMPv3ServiceMigrationInstructions.md
+++ b/static/includes/SNMPv3ServiceMigrationInstructions.md
@@ -1,0 +1,9 @@
+&NewLine;
+
+It is possible for SNMP v3 service settings to not fully migrate from FreeBSD-based releases to a Debian-Linux version, and then not carry over after upgrading from release 25.10.4 to later releases.
+To avoid this, go to **System > Services** in the Debian-Linux TrueNAS UI:
+
+1. Stop the SNMP service.
+2. Edit the SNMP service by re-entering the SNMP v3 service values, and then click **Save**.
+3. Toggle the SNMP service **Start Automatically** to on.
+4. Start the SNMP service.

--- a/static/includes/SNMPv3ServiceMigrationInstructions.md
+++ b/static/includes/SNMPv3ServiceMigrationInstructions.md
@@ -4,6 +4,6 @@ It is possible for SNMP v3 service settings to not fully migrate from FreeBSD-ba
 To resolve this, go to **System > Services** in the Debian-Linux TrueNAS UI:
 
 1. Stop the SNMP service.
-2. Edit the SNMP service by re-entering the SNMP v3 service values you recorded when [Preparing to Migrate]({{< relref "MigratePrep.md" >}}), and then click Save.
+2. Edit the SNMP service by re-entering the SNMP v3 service values you recorded when [Preparing to Migrate]({{< relref "MigratePrep.md" >}}), and then click **Save**.
 3. Toggle the SNMP service **Start Automatically** to on.
 4. Start the SNMP service.

--- a/static/includes/SNMPv3ServiceMigrationInstructions.md
+++ b/static/includes/SNMPv3ServiceMigrationInstructions.md
@@ -1,7 +1,7 @@
 &NewLine;
 
 It is possible for SNMP v3 service settings to not fully migrate from FreeBSD-based releases to a Debian-Linux version, and then not carry over after upgrading from release 25.10.4 to later releases.
-To avoid this, go to **System > Services** in the Debian-Linux TrueNAS UI:
+To resolve this, go to **System > Services** in the Debian-Linux TrueNAS UI:
 
 1. Stop the SNMP service.
 2. Edit the SNMP service by re-entering the SNMP v3 service values, and then click **Save**.

--- a/static/includes/SNMPv3ServiceMigrationInstructions.md
+++ b/static/includes/SNMPv3ServiceMigrationInstructions.md
@@ -4,6 +4,6 @@ It is possible for SNMP v3 service settings to not fully migrate from FreeBSD-ba
 To resolve this, go to **System > Services** in the Debian-Linux TrueNAS UI:
 
 1. Stop the SNMP service.
-2. Edit the SNMP service by re-entering the SNMP v3 service values, and then click **Save**.
+2. Edit the SNMP service by re-entering the SNMP v3 service values you recorded when [Preparing to Migrate]({{< relref "MigratePrep.md" >}}), and then click Save.
 3. Toggle the SNMP service **Start Automatically** to on.
 4. Start the SNMP service.


### PR DESCRIPTION
This PR adds a troubleshooting steps snippet on SNMP v3 service settings not fully migrating from FreeBSD to Debian-Linux versions after upgrades from 25.10.4 to later releases to the SNMPService.md, MigratingFromCORE.md articles and a checklist item to the MigratePrep.md article.

Backports to 25.10 and 26

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
