### PR TITLE
DOCS-2609 / 25.10 / DOCS-2609 Add SNMP v3 Service Migration Instructions (by micjohnson777)

### DIFF
--- a/content/GettingStarted/Migrate/MigratePrep.md
+++ b/content/GettingStarted/Migrate/MigratePrep.md
@@ -72,7 +72,9 @@ Please contact Support for assistance!
 
    <input type="checkbox"> Credentials - Copy or write down the credentials for SSH connections and keypairs, and any configured cloud service backup providers if you do not have the credential settings saved in other files kept secured outside of TrueNAS.
 
-   <input type="checkbox"> Data protection tasks - Write down or take screenshots of replication, periodic snapshots, cloud sync, or other task settings to reconfigure these after migrating.
+   <input type="checkbox"> Data protection tasks - Write down or take screenshots of replication, rsync tasks, periodic snapshots, cloud sync, or other task settings to reconfigure these after migrating.
+
+   <input type="checkbox"> SNMP v3 service settings - Write down or take a screenshot of the SNMP service V3 settings to use after migrating.
    
    TrueNAS uses SSH connections in data protection tasks, so data protection tasks (especially replication tasks) might require reconfiguration in some cases.
    After migrating to 25.10, SSH connections have failed with an authentication error in some cases.

--- a/content/GettingStarted/Migrate/MigratingFromCORE.md
+++ b/content/GettingStarted/Migrate/MigratingFromCORE.md
@@ -140,3 +140,7 @@ Use the information gathered during your preparation to migrate to restore setti
 
 In the event you need to revert to the FreeBSD-based release and you are joined to Active Directory, first leave AD, then clean-install the FreeBSD-based version, and upload the system config file to recover. Rejoin AD. Verify the system is configured as desired, and AD is healthy.
 Save a new debug file, then save the system configuration file with the secret seed. Use the procedures above to migrate to the latest Debian-Linux version of TrueNAS.
+
+## SNMP v3 Service Migration
+
+{{< include file="/static/includes/SNMPv3ServiceMigrationInstructions.md" >}}

--- a/content/SCALETutorials/SystemSettings/Services/SNMPServiceSCALE.md
+++ b/content/SCALETutorials/SystemSettings/Services/SNMPServiceSCALE.md
@@ -37,3 +37,7 @@ admin@mytruenas.example.com's password:
 TRUENAS-MIB.txt                                                 100%   11KB 112.0KB/s   00:00
 PS C:\Users\ixuser>
 ```
+
+## SNMP v3 Service Migration
+
+{{< include file="/static/includes/SNMPv3ServiceMigrationInstructions.md" >}}

--- a/static/includes/SNMPv3ServiceMigrationInstructions.md
+++ b/static/includes/SNMPv3ServiceMigrationInstructions.md
@@ -1,0 +1,9 @@
+&NewLine;
+
+It is possible for SNMP v3 service settings to not fully migrate from FreeBSD-based releases to a Debian-Linux version, and then not carry over after upgrading from release 25.10.4 to later releases.
+To resolve this, go to **System > Services** in the Debian-Linux TrueNAS UI:
+
+1. Stop the SNMP service.
+2. Edit the SNMP service by re-entering the SNMP v3 service values you recorded when [Preparing to Migrate]({{< relref "MigratePrep.md" >}}), and then click **Save**.
+3. Toggle the SNMP service **Start Automatically** to on.
+4. Start the SNMP service.


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x e98b65f51d966d5263d3043275c6f2a0450f70c6
    git cherry-pick -x a93b1d0f22aa380e04f98c662c1536d521316a27
    git cherry-pick -x 0da2f7d26ace631f6535d6aaef5bd92432e5f5f5
    git cherry-pick -x 82163d70033c9277164938de2e7cb31ff6e5626d

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x bceb09f2746561b1b6dfa8cdbfd75bb82c56c796

This PR adds a troubleshooting steps snippet on SNMP v3 service settings not fully migrating from FreeBSD to Debian-Linux versions after upgrades from 25.10.4 to later releases to the SNMPService.md, MigratingFromCORE.md articles and a checklist item to the MigratePrep.md article.

Backports to 25.10 and 26

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.


Original PR: https://github.com/truenas/documentation/pull/4794
Jira URL: https://ixsystemsinc.atlassian.net/browse/DOCS-2609