### PR TITLE
DOCS-2727 / 27 / DOCS-2727 Harden nightly-maintenance.groovy against transient network blips

### DIFF
--- a/jenkins/nightly-maintenance.groovy
+++ b/jenkins/nightly-maintenance.groovy
@@ -47,7 +47,11 @@ pipeline {
           ) != 0
           if (changed) {
             echo 'Software status changed — creating/updating PR.'
-            sh 'bash scripts/create-software-status-pr.sh || true'
+            def prStatus = sh(script: 'bash scripts/create-software-status-pr.sh', returnStatus: true)
+            if (prStatus != 0) {
+              currentBuild.result = 'UNSTABLE'
+              echo "create-software-status-pr.sh failed (exit ${prStatus}) — see console output above. Continuing to Reconcile."
+            }
           } else {
             echo 'Software status up to date.'
           }
@@ -63,7 +67,10 @@ pipeline {
           steps {
             script {
               // make sure we can see every remote branch's docs-build.env
-              sh 'git fetch --no-tags --force origin "+refs/heads/*:refs/remotes/origin/*"'
+              // retry(3): this fetch has no relation to Duty 1 above — don't let a
+              // transient network blip there (or here) take down the Reconcile/Purge
+              // safety net, which must still run.
+              retry(3) { sh 'git fetch --no-tags --force origin "+refs/heads/*:refs/remotes/origin/*"' }
               // same version-branch filter as the Multibranch job
               def raw = sh(returnStdout: true, script:
                 "git for-each-ref --format='%(refname:short)' refs/remotes/origin " +


### PR DESCRIPTION
## Summary
- Follow-up to #4798: the 2026-09-11 nightly run hit a transient DNS blip on `docbuilds02` that failed to resolve `github.com` (confirmed as node/infra-level — a separate build's plain Jenkins checkout step failed identically). That's outside this repo's control, but it exposed a real gap in this pipeline's error handling.
- The Reconcile stage's `git fetch` in "Re-assert symlinks" had no retry, so the blip took down the entire build and skipped Purge — the opposite of the stage's own stated purpose as the safety net that "must still run."
- `create-software-status-pr.sh` failures were also silently discarded via `|| true`, with no build signal when that step failed.

## Changes
- Wrap the `git fetch` in "Re-assert symlinks" in `retry(3)`, matching the retry pattern already used for the deploy script (`retry(2)`) and Purge (`retry(3)`) in this same file.
- Replace `|| true` around `create-software-status-pr.sh` with exit-code capture that marks the build UNSTABLE on failure, mirroring how `update-software-status.py` failures are already surfaced.

## Test plan
- [ ] Groovy syntax/brace balance checked locally; no local harness runs this pipeline, so verify on a real Jenkins run (same caveat as #4798 — needs verification against live Jenkins, not just static review)
- [ ] Confirm a forced transient fetch failure in "Re-assert symlinks" now retries instead of aborting the build
- [ ] Confirm a forced `create-software-status-pr.sh` failure now marks the build UNSTABLE (not silently green) and Reconcile/Purge still run

🤖 Generated with [Claude Code](https://claude.com/claude-code)