### PR TITLE
DOCS-2649 / 26 / DOCS-2649 Update Directory Services UI Ref and Tutorials with Changes (by micjohnson777)

### DIFF
--- a/content/Credentials/DirectoryServices/ConfigAD.md
+++ b/content/Credentials/DirectoryServices/ConfigAD.md
@@ -14,7 +14,6 @@ doctype: tutorial
 ---
 
 
-
 {{< include file="/static/includes/DirectoryServiceAccessAdmonition.md" >}}
 
 {{< include file="/static/includes/DirectoryServiceConflictAdmonition.md" >}}
@@ -218,11 +217,7 @@ Select **Enable Service** again, and click **Save** to reactivate your connectio
 ## Leaving Active Directory
 
 Users must cleanly leave an Active Directory for TrueNAS to delete the configuration.
-To cleanly leave AD, click **Leave Domain** on the **Active Directory** settings screen to remove the AD object.
+To cleanly leave AD, click on the triple-dot icon on the **Active Directory** card shown on the main **Directory Services** screen, then click **Leave** to remove the AD object.
 Remove the computer account and associated DNS records from the Active Directory.
 
-If the AD server moves or shuts down without you using **Leave Domain**, TrueNAS does not remove the AD object, and you have to clean up the Active Directory.
-
-### Rolling Back to Earlier Boot Environments with AD Joined
-
-{{< include file="/static/includes/ADandBERollBacks.md" >}}
+If the AD server moves or shuts down without you using **Leave**, TrueNAS does not remove the AD object, and you have to clean up the Active Directory.

--- a/content/Credentials/DirectoryServices/ConfigIPA.md
+++ b/content/Credentials/DirectoryServices/ConfigIPA.md
@@ -50,23 +50,23 @@ Configure TrueNAS to use an IPA directory server:
 
    {{< trueimage src="/images/SCALE/Credentials/DirectoryServicesCredentialConfig.png" alt="Credential Configuration" id="Credential Configuration" >}}
 
-   * Select **Kerberos User** from the **Credential Type** dropdown list. Required.
+   * Select required **Kerberos User** from the **Credential Type** dropdown list.
 
-   * Enter the IPA user account username in **Username**. Required.
+   * Enter the required IPA user account username in **Username**.
 
-   * Enter the password for the user account in **Password**. Required.
+   * Enter the required password for the user account in **Password**.
 
 5. Enter the **IPA Configuration** settings:
 
    {{< trueimage src="/images/SCALE/Credentials/IPAConfigurationSettings.png" alt="IPA Configuration" id="IPA Configuration" >}}
 
-   * Enter the IPA server hostname or IP address in **Target Server**. Required.
+   * Enter the required IPA server hostname or IP address in **Target Server**.
 
-   * Enter the hostname for your TrueNAS system in **TrueNAS Hostname**. Required.
+   * Enter the required hostname for your TrueNAS system in **TrueNAS Hostname**.
 
-   * Enter the domain name in **Domain**. Required.
+   * Enter the required domain name in **Domain**.
 
-   * Enter the base distinguished name for the IPA directory in **Base DN**. Required. For example, *dc=example,dc=com*.
+   * Enter the required base distinguished name for the IPA directory in **Base DN**. For example, *dc=example,dc=com*.
 
    * (Optional) Select the **Validate Certificates** checkbox to verify certificate authenticity when connecting to the IPA server. TrueNAS validates the full certificate chain when this option is selected.
 

--- a/content/Credentials/DirectoryServices/ConfigLDAP.md
+++ b/content/Credentials/DirectoryServices/ConfigLDAP.md
@@ -39,31 +39,27 @@ To configure TrueNAS to use an LDAP directory server:
 
    * (Optional) Enter the Kerberos realm in **Kerberos Realm**. This is usually the uppercase version of the domain name, for example, *EXAMPLE.COM*.
 
-4. Enter the **Credential Configuration** settings:
+4. Enter the **Credential Configuration** settings. Select the credential type from the **Credential Type** dropdown list. Options are:
 
-   * Select the credential type from the **Credential Type** dropdown list. Options are **LDAP Anonymous**, **LDAP Plain**, **LDAP MTLS**, **Kerberos Principal**, or **Kerberos User**. Required.
-
-   * If you selected **Kerberos User**, enter the LDAP administrative account username and password in the respective **Username** and **Password** fields. Required.
-
-   * If you selected **LDAP Plain**, enter the applicable credentials in the **Bind DN** and **Bind Password** fields. Required.
-
-   * If you selected **LDAP MTLS**, select the desired **Client Certificate** from the dropdown menu. Required.
-
-   * If you selected **Kerberos Principal**, select the desired **Kerberos Principal** from the dropdown menu. Required.
+   * **LDAP Anonymous** - No additional settings shown.
+   * **LDAP Plain** - Requires entering the applicable credentials in the **Bind DN** and **Bind Password** fields.
+   * **LDAP MTLS** - Requires entering or selecting the desired **Client Certificate** from the dropdown menu.
+   * **Kerberos Principal** - Requires entering or selecting the desired **Kerberos Principal** from the dropdown menu.
+   * **Kerberos User** - Requires entering the LDAP administrative account username and password in the respective **Username** and **Password** fields.
 
 5. Enter the **LDAP Configuration** settings:
 
    {{< trueimage src="/images/SCALE/Credentials/LDAPBasicOptionsSettings.png" alt="LDAP Configuration" id="LDAP Configuration" >}}
 
-   * Enter the LDAP server URLs in **Server URLs**. Required. Separate multiple entries by pressing <kbd>Enter</kbd>. If using a cloud service LDAP server, do not include the full URL.
+   * Enter the required LDAP server URLs in **Server URLs**. Press <kbd>Enter</kbd> to separate multiple entries. If using a cloud service LDAP server, do not include the full URL.
 
-   * Enter the LDAP server base DN in **Base DN**. Required. This is the top level of the LDAP directory tree to use when searching for resources. For example, *dc=example,dc=org*.
+   * Enter the required LDAP server base DN in **Base DN**. This is the top level of the LDAP directory tree to use when searching for resources. For example, *dc=example,dc=org*.
 
    * (Optional) Select the **Start TLS** checkbox if needed for your environment.
 
    * (Optional) Select the **Validate Certificates** checkbox to verify certificate authenticity when connecting to the LDAP server.
 
-   * Select the LDAP NSS schema from the **Schema** dropdown list. Required. Options are **RFC2307** or **RFC2307BIS**.
+   * Select the required LDAP NSS schema from the **Schema** dropdown list. Options are **RFC2307** or **RFC2307BIS**.
 
 6. (Optional) Configure auxiliary parameters:
 
@@ -77,11 +73,9 @@ To configure TrueNAS to use an LDAP directory server:
 
    To customize search bases, clear **Use Standard Search Bases** to reveal additional configuration options: **User Base DN**, **Group Base DN**, and **Netgroup Base DN**.
 
-8. (Optional) Configure attribute maps:
+8. (Optional) Configure attribute maps. Select **Use Standard Attribute Maps** to use default attribute mappings. Selected by default.
 
-   Select **Use Standard Attribute Maps** to use default attribute mappings. Selected by default.
-
-   To customize attribute maps, clear **Use Standard Attribute Maps** to reveal four subsections for customization:
+   To customize attribute maps, clear **Use Standard Attribute Maps** to show four subsections for customization:
 
    * **LDAP Password Attributes** - Enter custom password attribute mappings.
 

--- a/content/Credentials/DirectoryServices/DirectoryServicesScreens.md
+++ b/content/Credentials/DirectoryServices/DirectoryServicesScreens.md
@@ -28,6 +28,11 @@ The main option displays:
 * **Configure Directory Services** opens the **Directory Services Configuration** form where you can set up Active Directory, IPA, or LDAP connections.
 * [**Advanced Settings**](#advanced-settings)
 
+After configuring a directory service, the card for it shows a menu with two to three options:
+* **Settings**, which opens the Edit Directory Service screen.
+* **Rebuild Directory Service Cache**, which synchronizes the cache if it gets out of sync or there are fewer users than expected available in the permissions editors.
+* **Leave**, which shows only when the AD server is joined and healthy. This removes the computer account and associated DNS records from Active Directory.
+
 ## Directory Services Configuration Screen
 
 The **Directory Services Configuration** screen shows common and directory service-specific settings based on the type of directory service selected in **Configuration Type**.
@@ -38,14 +43,19 @@ Common settings:
 
 Directory Service-specific settings:
 * [Active Directory Configuration](#active-directory-configuration)
-  * [AD Trusted Domain Configuration](#active-directory-trusted-domain-configuration)
-  * [IDMAP Configuration](#idmap-configuration-ad)
+ * [AD Trusted Domain Configuration](#active-directory-trusted-domain-configuration)
+ * [IDMAP Configuration](#idmap-configuration-ad)
 * [LDAP Configuration](#ldap-configuration)
-  * [Auxiliary Parameters (LDAP)](#auxiliary-parameters-ldap)
-  * [Search Bases](#search-bases)
-  * [Attribute Maps](#attribute-maps)
+ * [Auxiliary Parameters (LDAP)](#auxiliary-parameters-ldap)
+ * [Search Bases](#search-bases)
+ * [Attribute Maps](#attribute-maps)
 * [IPA Configuration](#ipa-configuration)
-  * [SMB Domain Configuration](#smb-domain-configuration)
+ * [SMB Domain Configuration](#smb-domain-configuration)
+
+After configuring a directory service, the **Settings** option opens the **Directory Services Configuration** screen showing the editable settings for that directory service screen.
+
+**Clear Config** clears the current directory service configuration settings.
+**Save** retains changes. After using **Clear Config**, **Save** removes the cleared directory service configuration from TrueNAS allowing you to configure a new directory service configuration, for example, clearing an LDAP configuration to allow configuring Active Directory.
 
 ### Basic Configuration
 
@@ -57,16 +67,16 @@ The **Basic Configuration** settings show settings common to the three directory
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Configuration Type** | Sets the type of directory service. Options are: **Active Directory**, **LDAP**, and **IPA**. Each option shows the **Credential Configuration** settings and changes the setting options shown for each type of directory service. |
-| **Enable Service** | Enables the directory service when selected. If TrueNAS has never joined the specified domain (IPA or Active Directory), enabling causes TrueNAS to attempt to join the domain. <br>NOTE: The domain join process for Active Directory and IPA makes changes to the domain, such as creating a new computer account for the TrueNAS server and creating DNS records for TrueNAS. Enabled by default. Leave disabled to deactivate the configuration without deleting it and allow reenabling it later without reconfiguring it. The screen returns to the default settings and provides the option to configure AD, LDAP, or IPA. |
-| **Enable Account Cache** | Enables backend caching for user and group lists. When enabled, directory services users and groups are presented as choices in the UI dropdowns and in API responses for user and group queries. Also controls whether users and groups appear in getent results. Disable to reduce load on the directory server when necessary. Enabled by default. |
+| **Configuration Type** | Sets the type of directory service. Options are: **Active Directory**, **LDAP**, and **IPA**. Each option shows the **Credential Configuration** settings and changes the setting options shown for each type of directory service. Only one directory service can be active at a time. |
+| **Enable Service** | Enables the directory service when selected. If TrueNAS has never been joined to the specified domain (IPA or Active Directory), enabling causes TrueNAS to attempt to join the domain. <br>NOTE! The domain join process for Active Directory and IPA makes changes to the domain, such as creating a new computer account for the TrueNAS server and creating DNS records for TrueNAS. Enabled by default. Leave disabled to deactivate the configuration without deleting it and allow reenabling it later without reconfiguring it. The screen returns to the default settings and provides the option to configure AD, LDAP, or IPA. |
+| **Enable Account Cache** | Enables backend caching for user and group lists. Caches user/group information for performance. When enabled, directory services users and groups are presented as choices in the UI dropdowns and in API responses for user and group queries. Also controls whether users and groups appear in getent results. Disable to reduce load on the directory server when necessary. Enabled by default. |
 | **Enable DNS Updates** | Allows TrueNAS to automatically register and update its DNS records on the DNS server for the domain when its IP address changes. Uses Kerberos authentication to verify TrueNAS has permission to update its own records. Enabled by default. Disable only if your DNS server does not support dynamic updates or if DNS is managed manually. |
-| **Timeout (seconds)** | The number of seconds before the directory service connection times out. Valid range is 1-40 seconds. The timeout value for DNS queries that are performed as part of the join process and NETWORK_TIMEOUT for LDAP requests (5-60 seconds). |
-| **Kerberos Realm** |  Specifies the name of the Kerberos realm used for authentication to the directory service, for example, *EXAMPLE.COM*. When left empty, Kerberos is not used for binding to the directory service, but when joining an Active Directory or IPA domain for the first time, the realm is detected and configured automatically if not specified. |
+| **Timeout (seconds)** | Sets the number of seconds before the directory service connection times out. The timeout value for DNS queries that are performed as part of the join process and NETWORK_TIMEOUT for LDAP requests (5-60 seconds). Valid range is 1-40 seconds. |
+| **Kerberos Realm** | Specifies the existing Kerberos realm from Kerberos Realms configuration in an uppercase domain format like *EXAMPLE.COM*. When left empty, Kerberos is not used for binding to the directory service, but when joining an Active Directory or IPA domain for the first time, the realm is detected and configured automatically if not specified. |
 {{< /truetable >}}
 {{< /expand >}}
 
-### Credential Configuration 
+### Credential Configuration
 
 The **Credential Type** setting changes the authentication settings shown for the directory service no matter which type is selected in **Configuration Type**. Active Directory, IPA and LDAP all show Kerberos authentication options, but LDAP shows additional settings based on LDAP options.
 
@@ -80,10 +90,10 @@ The **Credential Type** setting changes the authentication settings shown for th
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Credential Type** | Sets the credential type for authentication. Options: **Kerberos User** or **Kerberos Principal**. **Kerberos User** shows the **Username** and **Password** settings. **Kerberos Principal** shows the **Kerberos Principal** dropdown list. **Kerberos Principal**, and **Kerberos User**. |
-| **Username** | Username of the account to use to create a Kerberos ticket for authentication to directory services. This account must exist on the domain controller. A *Kerberos ticket* is a time-limited encrypted credential issued by the domain controller that allows TrueNAS to authenticate to domain services without transmitting passwords over the network. |
-| **Password** | Password for the user account that obtains the Kerberos ticket. A *Kerberos ticket* is a time-limited encrypted credential issued by the domain controller that allows TrueNAS to authenticate to domain services without transmitting passwords over the network. |
-| **Kerberos Principal** | A Kerberos principal is the unique identity, formatted as *username@DOMAIN.COM*, that Kerberos uses to issue authentication tickets. Kerberos keytabs configured in TrueNAS show on the dropdown list. The specified principal must have a matching entry in a keytab stored on TrueNAS. Keytabs are managed in **Directory Services > Advanced Settings > Kerberos Keytabs**. If a keytab entry does not exist for the specified principal, authentication fails. |
+| **Credential Type** | Sets the credential type for authentication. Options: **Kerberos User** or **Kerberos Principal**. **Kerberos User** shows the **Username** and **Password** settings. **Kerberos Principal** shows the **Kerberos Principal**. Kerberos credentials are required for Active Directory or IPA domains. Generic LDAP environments support various authentication methods. Available methods depend on the remote LDAP server configuration. If Kerberos credentials are selected for LDAP, GSSAPI binds replace plain LDAP binds. Use Kerberos or mutual TLS authentication when possible for better security. |
+| **Username** | Specifies the username of the account to used to create a Kerberos ticket for authentication to directory services. This account must exist on the domain controller. A *Kerberos ticket* is a time-limited encrypted credential issued by the domain controller that allows TrueNAS to authenticate to domain services without transmitting passwords over the network. |
+| **Password** | Specifies the password for the bind account that obtains the Kerberos ticket. A *Kerberos ticket* is a time-limited encrypted credential  issued by the domain controller that allows TrueNAS to authenticate to domain services without transmitting passwords over the network. Required for first configuration only. After initial configuration, uses Kerberos Principal. |
+| **Kerberos Principal** | Sets the location of the principal in the keytab from Kerberos Keytab. Shows when <b> Credential Type</b> is set to <b>Kerberos Principal</b>. A *Kerberos principal* is the unique identity, formatted as *username@DOMAIN.COM*, that Kerberos uses to issue authentication tickets. Kerberos keytabs configured in TrueNAS show on the dropdown list. The specified principal must have a matching entry in a keytab stored on TrueNAS. Keytabs are managed in **Directory Services > Advanced Settings > Kerberos Keytabs**. If a keytab entry does not exist for the specified principal, authentication fails. |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -110,13 +120,10 @@ Each option shows different settings in **Credential Configuration**.
 |---------|-------------|
 | **Bind DN** | Specifies the distinguished name to use for authentication. This is the administrative account name for the LDAP server. Shows when **LDAP Plain** is selected. For example, *cn=Manager,dc=test,dc=org*. |
 | **Bind Password** | Specifies the password for the **Bind DN**. Shows when **LDAP Plain** is selected. |
-| **Client Certificate** | Specifies the client certificate to use for mutual TLS authentication to the remote LDAP server. Shows when **LDAP MTLS** is selected. |
-| **Kerberos Principal** | A Kerberos principal is the unique identity, formatted as *username@DOMAIN.COM*, that Kerberos uses to issue authentication tickets. Kerberos keytabs configured in TrueNAS show on the dropdown list. The specified principal must have a matching entry in a keytab stored on TrueNAS. Keytabs are managed in **Directory Services > Advanced Settings > Kerberos Keytabs**. If a keytab entry does not exist for the specified principal, authentication fails. |
-| **Kerberos User** | Shows the **Username** and **Password** authentication fields, and sets authentication to use the LDAP administrative account credentials. |
-| **Username** | Username of the account used to obtain a Kerberos ticket for authentication to the LDAP server. A Kerberos ticket is a time-limited, encrypted
-  credential that allows TrueNAS to authenticate without transmitting passwords over the network. |
-| **Password** | Password for the user account that obtains the Kerberos ticket. A *Kerberos ticket* is a time-limited encrypted
-  credential that allows TrueNAS to authenticate without transmitting passwords over the network. |
+| **Client Certificate** | Specifies the client certificate to use for mutual TLS authentication to the remote LDAP server. Shows when **Configuration Type** is **LDAP** and **Credential Type** is **LDAP MTLS**. |
+| **Kerberos Principal** | Sets the location of the principal in the keytab from Kerberos Keytab. Shows when <b> Credential Type</b> is set to <b>Kerberos Principal</b>. A *Kerberos principal* is the unique identity, formatted as *username@DOMAIN.COM*, that Kerberos uses to issue authentication tickets. Kerberos keytabs configured in TrueNAS show on the dropdown list. The specified principal must have a matching entry in a keytab stored on TrueNAS. Keytabs are managed in **Directory Services > Advanced Settings > Kerberos Keytabs**. If a keytab entry does not exist for the specified principal, authentication fails. |
+| **Username** | Specifies the username of the account to used to create a Kerberos ticket for authentication to directory services. This account must exist on the domain controller. A *Kerberos ticket* is a time-limited encrypted credential issued by the domain controller that allows TrueNAS to authenticate to domain services without transmitting passwords over the network. Shows when **Credential Type** is set to **Kerberos User**. |
+| **Password** | Specifies the password for the bind account that obtains the Kerberos ticket. A *Kerberos ticket* is a time-limited encrypted credential  issued by the domain controller that allows TrueNAS to authenticate to domain services without transmitting passwords over the network. Required for first configuration only. After initial configuration, uses Kerberos Principal. Shows when **Credential Type** is set to **Kerberos User**. |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -130,11 +137,11 @@ The **Active Directory Configuration** section settings define the connection pa
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **TrueNAS Hostname** | The hostname for the TrueNAS system to register in Active Directory, for example, *truenasnyc*. This value must match the **Hostname** setting on the **Network > Global Configuration** screen and cannot exceed 15 characters. Cannot contain these special characters: \ / : * ? " < > |. Cannot use Microsoft or RFC 852 reserved words (ANONYMOUS, AUTHENTICATED USER, BATCH, BUILTIN, DIALUP, DOMAIN, ENTERPRISE, INTERACTIVE, INTERNET, LOCAL, NETWORK, NULL, PROXY, RESTRICTED, SELF, SERVER, USERS, WORLD, GATEWAY, GW, TAC). Must differ from the Workgroup name. |
-| **Domain Name** | The full DNS domain name of the Active Directory domain name (for example, *mydomain.internal*) or child domain (for example, *sales.example.com*) if configuring access to a child domain. This must not be a domain controller! |
-| **Site Name** | The Active Directory site where the TrueNAS server is located. TrueNAS detects this automatically during the domain join process. |
-| **Computer Account OU** | The organizational unit (OU) where the TrueNAS computer object is created when joining the Active Directory domain for the first time. The OU string includes the distinguished name (DN) of the Computer Account OU. For example, *OU=Computers,DC=example,DC=com*.  Use this setting to override the default organizational unit (OU) in which the TrueNAS computer account is created during the domain join. Use it to set a custom location for TrueNAS computer accounts. |
-| **Use Default Domain** | Removes the domain name prefix from AD users and groups. This setting might be required for specific configurations, such as Kerberos authentication with NFS for AD users. Note that using this setting can cause collisions with local user account names.  Controls if the system removes the domain prefix from Active Directory user and group names. If enabled, users appear as "administrator" instead of "EXAMPLE\administrator". In most cases, disable this (default) to avoid name conflicts between Active Directory and local accounts. |
+| **TrueNAS Hostname** | Specifies the hostname of the TrueNAS server to register in AD or IPA during the join process. Cannot exceed 15 characters or contain the `\ / : * ? < > |` special characters. Cannot use Microsoft/RFC 852 reserved words (ANONYMOUS, AUTHENTICATED USER, BATCH, BUILTIN, DIALUP, DOMAIN, ENTERPRISE, INTERACTIVE, INTERNET, LOCAL, NETWORK, NULL, PROXY, RESTRICTED, SELF, SERVER, USERS, WORLD, GATEWAY, GW, TAC). Must differ from **Workgroup**. TrueNAS 25.04+ enforces validation. For example: *truenasnyc*. |
+| **Domain Name** | Specifies the name of the name of the Active Directory, IPA, or SMB domain (e.g., example.com) or child domain. Editable after saving. The full DNS domain name of the Active Directory or IP domain must not be a domain controller. for example, *mydomain.internal*. The name of the SMB domain is as defined in the IPA configuration for the IPA domain to which TrueNAS is joined. SMB configuration **Domain Name** shows when ***Configuration Type** is IPA and **Use Default SMB Domain Configuration** is disabled. |
+| **Site Name** | Specifies the Active Directory site where the TrueNAS server is located. TrueNAS detects this automatically during the domain join process. Sets the relative distinguished name (RDN) of the AD site object. |
+| **Computer Account OU** | Specifies the organizational unit (OU) where the TrueNAS computer object is created when joining the Active Directory domain for the first time. The OU string includes the distinguished name (DN) of the **Computer Account OU** value. For example, *OU=Computers,DC=example,DC=com*. Use this setting to override the default organizational unit (OU) in which the TrueNAS computer account is created during the domain join. Use it to set a custom location for TrueNAS computer accounts. |
+| **Use Default Domain** | Enables removing domain name prefix (DOMAIN\) from users/groups. Might be required for specific configurations, such as Kerberos authentication with NFS for AD users. Controls if the system removes the domain prefix from Active Directory user and group names. When enabled, users show as **administrator** instead of EXAMPLE\administrator. Leave disabled to avoid name conflicts between Active Directory and local accounts. NOT RECOMMENDED as this can cause collisions with local accounts. |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -144,13 +151,14 @@ Beginning in TrueNAS 25.10, trusted domains are configured as part of the Active
 
 The **Trusted Domains Configuration** section controls access for trusted domains.
 
-**Enable Trusted Domains** shows the **Trusted Domains** options that allow clients to access TrueNAS if they are members of domains with a trust relationship. When enabled,  the **Trusted Domain** section and **Add** button show.
-**Add** shows the **Basic Configuration** section with the **IDMAP Backend** options. 
+**Enable Trusted Domains** sets the **Trusted Domains** option that allow clients to access TrueNAS if they are members of domains with a trust relationship. Shows the **Trusted Domains** option that allow clients to access TrueNAS if they are members of domains with a trust relationship. When enabled, shows the **Trusted Domain** section and **Add** button. As of TrueNAS 25.10 and later, configured in directory services vs separate IDMAP entries.
+
+**Add** shows the **Basic Configuration** section with the **IDMAP Backend** options.
 
 {{< trueimage src="/images/SCALE/Credentials/ADConfigTrustedDomainConfig.png" alt="Trusted Domain Configuration" id="Trusted Domain Configuration" >}}
 
-The **IDMAP Backend** configuration defines how domain accounts joined to TrueNAS are mapped to Unix UIDs and GIDs on the TrueNAS server.
-Most TrueNAS deployments use the RID backend, which algorithmically assigns UIDs and GIDs based on the Active Directory account SID.
+**IDMAP Backend** defines how domain accounts joined to TrueNAS are mapped to Unix UIDs and GIDs on the TrueNAS server.
+Most TrueNAS deployments use the RID backend, which algorithmically assigns UIDs and GIDs based on the Active Directory account SID. Another common option is the AD backend, which reads predefined Active Directory LDAP schema attributes that assign explicit UID and GID numbers to accounts.
 Another common option is the AD backend, which reads predefined Active Directory LDAP schema attributes that assign explicit UID and GID numbers to accounts.
 
 The **IDMAP Backend** dropdown list shows four options:
@@ -168,12 +176,12 @@ Each option shows different settings.
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Name** | Short name for the domain. This should match the NetBIOS domain name for Active Directory domains. |
-| **Range Low** | The lowest UID or GID that the IDMAP backend can assign. |
-| **Range High** | The highest UID or GID that the IDMAP backend can assign. |
-| **Schema Mode** | The schema mode the IDMAP backend uses to query Active Directory for user and group information. The RFC2307 schema applies to Windows Server 2003 R2 and newer. The Services for Unix (SFU) schema applies to versions before Windows Server 2003 R2. |
+| **Name** | Specifies the short name for the domain. This should match the NetBIOS domain name for Active Directory domains. |
+| **Range Low** | Specifies the lowest UID or GID that the IDMAP backend can assign for the trusted domain. Shows for all IDMAP backend types, and when **Configuration Type** is **Active Directory** and **Enable Trusted Domains** is enabled. |
+| **Range High** | Sets the highest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **Schema Mode** | Specifies the schema mode the IDMAP backend uses to query Active Directory for user and group information. The schema mode in the IDMAP backend uses to query Active Directory for user and group information. The RFC2307 schema applies to Windows Server 2003 R2 and newer. The Services for Unix (SFU) schema applies to versions before Windows Server 2003 R2. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **AD (RFC2307/SFU attributes from Active Directory)**. |
 | **Unix Primary Group** | Defines if the user's primary group is fetched from Unix attributes (Services for Unix) or the Active Directory primary group. If enabled, the TrueNAS server uses the gidNumber LDAP attribute. If disabled, it uses the primaryGroupID LDAP attribute. |
-|**Unix NSS Info**  | If enabled, the login shell and home directory are retrieved from LDAP attributes (Unix attributes in Active Directory). If disabled, or if the Active Directory LDAP entry lacks Unix attributes, the home directory defaults to /var/empty. |
+|**Unix NSS Info** | If enabled, the login shell and home directory are retrieved from LDAP attributes (Unix attributes in Active Directory). If disabled, or if the Active Directory LDAP entry lacks Unix attributes, the home directory defaults to /var/empty. |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -184,14 +192,14 @@ Each option shows different settings.
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Name** | Short name for the domain. This should match the NetBIOS domain name for Active Directory domains. |
-| **Range Low** | The lowest UID or GID that the IDMAP backend can assign. |
-| **Range High** | The highest UID or GID that the IDMAP backend can assign. |
-| **LDAP Base DN** | Directory base suffix to use for mapping UIDs and GIDs to SIDs. |
-| **LDAP User DN** |Defines the user DN to be used for authentication to the LDAP server.|
-| **LDAP User DN Password** | Secret to use for authenticating the user specified by ldap_user_dn.  |
-| **LDAP Url** | LDAP server to use for the IDMAP entries. |
-| **Readonly** | If enabled, TrueNAS does not attempt to write new IDMAP entries. |
+| **Name** | Specifies the short name for the domain. This should match the NetBIOS domain name for Active Directory domains. |
+| **Range Low** | Specifies the lowest UID or GID that the IDMAP backend can assign for the trusted domain. Shows for all IDMAP backend types, and when **Configuration Type** is **Active Directory** and **Enable Trusted Domains** is enabled. |
+| **Range High** | Sets the highest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **LDAP Base DN** | Sets the directory base suffix to use for mapping UIDs and GIDs to SIDs. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **LDAP**. |
+| **LDAP User DN** | Defines the user DN to be used for authentication to the trusted domain LDAP server. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **LDAP**. |
+| **LDAP User DN Password** | Specifies the secret to use for authenticating the user specified by LDAP User DN to the trusted domain RFC2307 LDAP server. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **LDAP Url** | Specifies the LDAP server to use for the IDMAP entries. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **Readonly** | Prevents TrueNAS from writing new IDMAP entries to the trusted domain LDAP server. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **LDAP**. |
 | **Validate Certificates** | Verify certificate authenticity. |
 {{< /truetable >}}
 {{< /expand >}}
@@ -203,17 +211,18 @@ Each option shows different settings.
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Name** | Short name for the domain. This should match the NetBIOS domain name for Active Directory domains. |
-| **Range Low** | The lowest UID or GID that the IDMAP backend can assign. |
-| **Range High** | The highest UID or GID that the IDMAP backend can assign. |
-| **LDAP Url** | LDAP server to use for the IDMAP entries. |
-| **LDAP User DN** |Defines the user DN to be used for authentication to the LDAP server.|
-| **LDAP User DN Password** | Secret to use for authenticating the user specified by ldap_user_dn.  |
-| **Bind Path User** | The search base that contains user objects in the LDAP server. |
-| **Bind Path Group** | The search base that contains group objects in the LDAP server. |
-| **User CN** | If set, query the CN attribute instead of the UID attribute for the user name in LDAP. |
-| **LDAP Realm** | Append @realm to the CN for groups. Also, append it to users if user_cn is specified. |
-| **Validate Certificate** | Verify certificate authenticity. |
+| **Name** | Specifies the short name for the domain. This should match the NetBIOS domain name for Active Directory domains. |
+| **Range Low** | Specifies the lowest UID or GID that the IDMAP backend can assign for the trusted domain. Shows for all IDMAP backend types, and when **Configuration Type** is **Active Directory** and **Enable Trusted Domains** is enabled.|
+| **Range High** | Sets the highest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **LDAP Url** | Specifies the LDAP server to use for the IDMAP entries. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **LDAP User DN** | Defines the user DN used for authentication to the trusted domain RFC2307 LDAP server. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **LDAP User DN Password** | Specifies the secret to use for authenticating the user specified by LDAP User DN to the trusted domain RFC2307 LDAP server. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **LDAP Url** | Specifies the LDAP server to use for the IDMAP entries. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **Bind Path User** | Specifies the search base that contains user objects in the LDAP server. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **Bind Path Group** | Specifies the search base that contains group objects in the LDAP server. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **User CN** | Queries the CN attribute instead of the UID attribute for the user name in LDAP. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **LDAP Realm** | Appends @realm to the CN for groups. Also, append it to users if User CN is specified. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **Validate Certificate** | Verify certificate authenticity. TrueNAS validates the full certificate chain. TrueNAS does not support non-CA certificates when certificate validation is required. When disabled, TrueNAS does not validate certificates from a remote LDAP server. It is better to use valid certificates or import them into the TrueNAS server trusted certificate store. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **LDAP** or **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -224,10 +233,10 @@ Each option shows different settings.
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Name** | Short name for the domain. This should match the NetBIOS domain name for Active Directory domains. |
-| **Range Low** | The lowest UID or GID that the IDMAP backend can assign. |
-| **Range High** | The highest UID or GID that the IDMAP backend can assign. |
-| **SSSD Compat**  | Generate an IDMAP low range using the algorithm from SSSD. Use this option if the domain uses only a single SSSD IDMAP slice. |
+| **Name** | Specifies the short name for the domain. This should match the NetBIOS domain name for Active Directory domains. |
+| **Range Low** | Specifies the lowest UID or GID that the IDMAP backend can assign for the trusted domain. Shows for all IDMAP backend types, and when **Configuration Type** is **Active Directory** and **Enable Trusted Domains** is enabled. |
+| **Range High** | Sets the highest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **SSSD Compat** | Generates an IDMAP low range using the algorithm from SSSD. Use this option if the domain uses only a single SSSD IDMAP slice. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RID (Default - algorithmic mapping based on RID values)**. |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -255,9 +264,9 @@ The **Builtin** settings map Windows built-in local groups to Unix GIDs, definin
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Name** | Short name for the joined domain. This should match the NetBIOS domain name for Active Directory domains. |
-| **Range Low** | The lowest UID or GID that the IDMAP backend can assign. |
-| **Range High** | The highest UID or GID that the IDMAP backend can assign. |
+| **Name** | Specifies the short name for the joined domain. This should match the NetBIOS domain name for Active Directory domains. |
+| **Range Low** | Sets the lowest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **Range High** | Sets the highest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -286,12 +295,12 @@ Each option shows different settings.
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Name** | Short name for the joined domain. Typically matches the NetBIOS domain name. |
-| **Range Low** | The lowest UID or GID that the IDMAP backend can assign. |
-| **Range High** | The highest UID or GID that the IDMAP backend can assign. |
-| **Schema Mode** | The schema mode the IDMAP backend uses to query Active Directory for user and group information. The RFC2307 schema applies to Windows Server 2003 R2 and newer. The Services for Unix (SFU) schema applies to versions before Windows Server 2003 R2. |
-| **Unix Primary Group** | Defines if the user's primary group is fetched from Unix attributes (Services for Unix) or the Active Directory primary group. If enabled, the TrueNAS server uses the gidNumber LDAP attribute. If disabled, it uses the primaryGroupID LDAP attribute. |
-|**Unix NSS Info**  | If enabled, the login shell and home directory are retrieved from LDAP attributes (Unix attributes in Active Directory). If disabled, or if the Active Directory LDAP entry lacks Unix attributes, the home directory defaults to /var/empty. |
+| **Name** | Specifies the short name for the joined domain. Typically matches the NetBIOS domain name. |
+| **Range Low** | Sets the lowest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **Range High** | Sets the highest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **Schema Mode** | Specifies the schema mode the IDMAP backend uses to query Active Directory for user and group information. The schema mode in the IDMAP backend uses to query Active Directory for user and group information. The RFC2307 schema applies to Windows Server 2003 R2 and newer. The Services for Unix (SFU) schema applies to versions before Windows Server 2003 R2. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **AD (RFC2307/SFU attributes from Active Directory)**. |
+| **Unix Primary Group** | Defines if the user primary group is fetched from Unix attributes (Services for Unix) or the Active Directory primary group. If enabled, TrueNAS ses the gidNumber LDAP attribute. If disabled, it uses the primaryGroupID LDAP attribute. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **AD (RFC2307/SFU attributes from Active Directory)**. |
+|**Unix NSS Info** | Controls whether login shell and home directory are retrieved from LDAP Unix attributes in Active Directory. When disabled, or if the Active Directory LDAP entry lacks Unix attributes, the home directory defaults to <file>/var/empty</file>. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **AD (RFC2307/SFU attributes from Active Directory)**. |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -302,15 +311,15 @@ Each option shows different settings.
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Name** | Short name for the joined domain. Typically matches the NetBIOS domain name. |
-| **Range Low** | The lowest UID or GID that the IDMAP backend can assign. |
-| **Range High** | The highest UID or GID that the IDMAP backend can assign. |
-| **LDAP Base DN** | Directory base suffix to use for mapping UIDs and GIDs to SIDs. |
-| **LDAP User DN** |Defines the user DN to be used for authentication to the LDAP server.|
-| **LDAP User DN Password** | Secret to use for authenticating the user specified by ldap_user_dn.  |
-| **LDAP Url** | LDAP server to use for the IDMAP entries. |
-| **Readonly** | If enabled, TrueNAS does not attempt to write new IDMAP entries. |
-| **Validate Certificates** | Verify certificate authenticity. |
+| **Name** | Specifies the short name for the joined domain. Typically matches the NetBIOS domain name. |
+| **Range Low** | Sets the lowest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **Range High** | Sets the highest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **LDAP Base DN** | Sets the directory base suffix to use for mapping UIDs and GIDs to SIDs. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **LDAP**. |
+| **LDAP User DN** | Defines the user DN used for authentication to the trusted domain RFC2307 LDAP server. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **LDAP User DN Password** | Specifies the secret to use for authenticating the user specified by ldap_user_dn to the trusted domain LDAP server. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **LDAP** or **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **LDAP Url** | LDAP server to use for the IDMAP entries. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **Readonly** | Prevents TrueNAS from writing new IDMAP entries to the trusted domain LDAP server. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **LDAP**. |
+| **Validate Certificates** | Verify certificate authenticity. TrueNAS validates the full certificate chain. TrueNAS does not support non-CA certificates when certificate validation is required. When disabled, TrueNAS does not validate certificates from a remote LDAP server. It is better to use valid certificates or import them into the TrueNAS server trusted certificate store. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **LDAP** or **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -321,17 +330,17 @@ Each option shows different settings.
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Name** | Short name for the joined domain. Typically matches the NetBIOS domain name. |
-| **Range Low** | The lowest UID or GID that the IDMAP backend can assign. |
-| **Range High** | The highest UID or GID that the IDMAP backend can assign. |
-| **LDAP Url** | LDAP server to use for the IDMAP entries. |
-| **LDAP User DN** |Defines the user DN to be used for authentication to the LDAP server.|
-| **LDAP User DN Password** | Secret to use for authenticating the user specified by ldap_user_dn.  |
-| **Bind Path User** | The search base that contains user objects in the LDAP server. |
-| **Bind Path Group** | The search base that contains group objects in the LDAP server. |
-| **User CN** | If set, query the CN attribute instead of the UID attribute for the user name in LDAP. |
-| **LDAP Realm** | Append @realm to the CN for groups. Also append it to users if user_cn is specified. |
-| **Validate Certificate** | Verify certificate authenticity. |
+| **Name** | Specifies the short name for the joined domain. Typically matches the NetBIOS domain name. |
+| **Range Low** | Sets the lowest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **Range High** | Sets the highest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **LDAP Url** | LDAP server to use for the IDMAP entries. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **LDAP User DN** | Defines the user DN used for authentication to the trusted domain RFC2307 LDAP server. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **LDAP User DN Password** | Specifies the secret to use for authenticating the user specified by ldap_user_dn to the trusted domain LDAP server. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **LDAP** or **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **Bind Path User** | Specifies the search base that contains user objects in the LDAP server. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **Bind Path Group** | Specifies the search base that contains group objects in the LDAP server. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **User CN** | Queries the CN attribute instead of the UID attribute for the user name in LDAP. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **LDAP Realm** | Appends @realm to the CN for groups. Also, append it to users if User CN is specified. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **Validate Certificate** | Verify certificate authenticity. TrueNAS validates the full certificate chain. TrueNAS does not support non-CA certificates when certificate validation is required. When disabled, TrueNAS does not validate certificates from a remote LDAP server. It is better to use valid certificates or import them into the TrueNAS server trusted certificate store. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **LDAP** or **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -342,10 +351,10 @@ Each option shows different settings.
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Name** | Short name for the joined domain. Typically matches the NetBIOS domain name. |
-| **Range Low** | The lowest UID or GID that the IDMAP backend can assign. |
-| **Range High** | The highest UID or GID that the IDMAP backend can assign. |
-| **SSSD Compat**  | Generate an IDMAP low range using the algorithm from SSSD. Use this option if the domain uses only a single SSSD IDMAP slice. |
+| **Name** | Specifies the short name for the joined domain. Typically matches the NetBIOS domain name. |
+| **Range Low** | Sets the lowest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **Range High** | Sets the highest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **SSSD Compat** | Generate an IDMAP low range using the algorithm from SSSD. Use this option if the domain uses only a single SSSD IDMAP slice. |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -360,18 +369,18 @@ The **LDAP Configuration** section settings define the connection parameters and
 | Setting | Description |
 |---------|-------------|
 | **Server URLs** | Specifies the hostname or IP address of the LDAP server. Separate entries by pressing <kbd>Enter</kbd>. Multiple URLs create an LDAP failover priority list. If a host does not respond, TrueNAS tries the next host until it establishes a connection. If using a cloud service LDAP server, do not include the full URL. |
-| **Base DN** | The top level of the LDAP directory tree to use when searching for resources. For example, *dc=test,dc=org*. |
-| **Start TLS** | Encrypts the LDAP connection with STARTTLS on the default LDAP port *389*. Options for encrypting the LDAP connection:<br><li>**OFF** - Does not encrypt the LDAP connection.<br><li>**ON**- Encrypts the LDAP connection with SSL on port 636.<br><li>**START_TLS**- Encrypts the LDAP connection with STARTTLS on the default LDAP port 389</li>. |
-| **Validate Certificates** | Verifies certificate authenticity when connecting to the LDAP server, when enabled. |
-| **Schema** | Sets the LDAP NSS schema. Options are **RFC2307** or **RFC2307BIS**.<br><li>**RFC2307** — Standard Unix attributes schema. Compatible with most LDAP servers, including OpenLDAP.<br><li>**RFC2307BIS** — Extended schema that supports nested group membership. Use if your LDAP server is configured with RFC2307bis.</li> |
+| **Base DN** | Specifies the base distinguished name (base DN) to use when performing LDAP operations. For Example, *dc=example,dc=com*. |
+| **Start TLS** | Encrypts the LDAP connection with STARTTLS on the default LDAP port *389*. Options for encrypting the LDAP connection:<ul><li>**OFF** - Does not encrypt the LDAP connection.</li><li>**ON**- Encrypts the LDAP connection with SSL on port 636.</li><li>**START_TLS**- Encrypts the LDAP connection with STARTTLS on the default LDAP port 389</li></ul>. |
+| **Validate Certificates** | Verify certificate authenticity. TrueNAS validates the full certificate chain. TrueNAS does not support non-CA certificates when certificate validation is required. When disabled, TrueNAS does not validate certificates from a remote LDAP server. It is better to use valid certificates or import them into the TrueNAS server trusted certificate store. Shows when **Configuration Type** is **Active Directory**, **Enable Trusted Domains** is enabled, and **IDMAP Backend** is **LDAP** or **RFC2307 (RFC2307 attributes from a standalone LDAP server)**. |
+| **Schema** | Sets the LDAP NSS schema. Options are **RFC2307** or **RFC2307BIS**.<ul><li>**RFC2307** — Standard Unix attributes schema. Compatible with most LDAP servers, including OpenLDAP.</li><li>**RFC2307BIS** — Extended schema that supports nested group membership. Use if your LDAP server is configured with RFC2307bis.</li></ul> |
 {{< /truetable >}}
 {{< /expand >}}
 
 ### Auxiliary Parameters (LDAP)
 
-The **Auxiliary Parameters** subsection allows customization of auxiliary parameters. 
+The **Auxiliary Parameters** subsection allows customization of auxiliary parameters.
 
-**Use Standard Auxiliary Parameters** is enabled by default. Disable to enter custom options for [nslcd.conf](https://arthurdejong.org/nss-pam-ldapd/nslcd.conf.5).
+**Use Standard Auxiliary Parameters** sets the LDAP directory server to use standard auxiliary parameters. Disable to enter custom options for [nslcd.conf](https://arthurdejong.org/nss-pam-ldapd/nslcd.conf.5). Warning! Auxiliary parameters are an unsupported configuration. Parameters entered here are not validated and can cause undefined system behaviors, including data corruption or data loss! Disabled by default.
 
 {{< trueimage src="/images/SCALE/Credentials/LDAPAuxiliaryParametersSettings.png" alt="LDAP Auxiliary Parameters" id="LDAP Auxiliary Parameters" >}}
 
@@ -390,15 +399,15 @@ Use custom search bases only if the LDAP server uses a non-standard LDAP schema 
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **User Base DN** | Sets the base DN to use when searching for LDAP user accounts. Restricts user searches to a specific directory subtree. For example, *ou=users,dc=example,dc=org*. |
-| **Group Base DN** | Sets the base DN to use when searching for LDAP group accounts. Restricts group searches to a specific directory subtree. For example, *ou=groups,dc=example,dc=org*. |
-| **Netgroup Base DN** | Sets the base DN to use when searching for LDAP group accounts. Restricts netgroup searches to a specific directory subtree. For example, *ou=netgroups,dc=example,dc=org*. |
+| **User Base DN** | Sets the base DN to use when searching for LDAP user accounts. Restricts user searches to a specific directory subtree. For example, ou=users,dc=example,dc=org. Shows when **Configuration Type** is **LDAP** and **Use Standard Search Bases** is disabled. |
+| **Group Base DN** | Sets the base DN to use when searching for LDAP group accounts. Restricts group searches to a specific directory subtree. For example, ou=groups,dc=example,dc=org. SShows when **Configuration Type** is **LDAP** and **Use Standard Search Bases** is disabled. |
+| **Netgroup Base DN** | Sets the base DN to use when searching for LDAP netgroup accounts. Restricts netgroup searches to a specific directory subtree. For example, ou=netgroups,dc=example,dc=org. Shows when **Configuration Type** is **LDAP** and **Use Standard Search Bases** is disabled. |
 {{< /truetable >}}
 {{< /expand >}}
 
-### Attribute Maps 
+### Attribute Maps
 
-The **Attribute Maps**  settings allow customization of attribute mappings by defining custom LDAP attribute names for user and group account fields. 
+The **Attribute Maps** settings allow customization of attribute mappings by defining custom LDAP attribute names for user and group account fields.
 An attribute left blank uses the default attribute name for that field.
 Only use custom attribute maps if the LDAP server is non-standard, if your LDAP schema uses non-standard attribute names.
 
@@ -414,13 +423,13 @@ The screen groups settings into LDAP password attributes, shadow attributes, and
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **User Object Class** | Specifies the entry object class in LDAP for the user. |
-| **Username Attribute** | Specifies the LDAP attribute for the login name for the user. | 
-| **UID Attribute** | Specifies the LDAP attribute for the id of the user. |
-| **GID Attribute** | Specifies the  LDAP attribute for the primary group id for the user. |
-| **GECOS Attribute** | Specifies the LDAP attribute for the gecos field for the user. |
-| **Home Directory Attribute** | Specifies the LDAP attribute for the home directory for the user. |
-| **Shell Attribute** | Specifies the LDAP attribute for the path to the default shell for the user. |
+| **User Object Class** | Specifies the entry object class in LDAP for the user entries. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
+| **Username Attribute** | Specifies the LDAP attribute for the login name for the user. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
+| **UID Attribute** | Specifies the LDAP attribute for the id of the user. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
+| **GID Attribute** | Specifies the LDAP attribute for the primary group id for the user. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
+| **GECOS Attribute** | Specifies the LDAP attribute for the gecos field for the user. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
+| **Home Directory Attribute** | Specifies the LDAP attribute for the home directory for the user. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
+| **Shell Attribute** | Specifies the LDAP attribute for the path to the default shell for the user. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -431,12 +440,12 @@ The screen groups settings into LDAP password attributes, shadow attributes, and
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Last Change Attribute** | Specifies the LDAP attribute for password last change. |
-| **Min Days Attribute** | Specifies the LDAP attribute for minimum password age. |
-| **Max Days Attribute** | Specifies the  LDAP attribute for maximum password age. |
-| **Warning Attribute** | Specifies the LDAP attribute for password warning period. |
-| **Inactive Attribute** | Specifies the LDAP attribute for the account inactive period. |
-| **Expire Attribute** | Specifies the LDAP attribute for account expiration. |
+| **Last Change Attribute** | Specifies the LDAP attribute for password last change date. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
+| **Min Days Attribute** | Specifies the LDAP attribute for minimum password age. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
+| **Max Days Attribute** | Specifies the LDAP attribute for maximum password age. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
+| **Warning Attribute** | Specifies the LDAP attribute for password warning period. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
+| **Inactive Attribute** | Specifies the LDAP attribute for the account inactive period. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
+| **Expire Attribute** | Specifies the LDAP attribute for account expiration. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -447,9 +456,10 @@ The screen groups settings into LDAP password attributes, shadow attributes, and
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Group Object Class** | Specifies the LDAP object class for groups. |
-| **Netgroup Member Attribute** | Specifies the LDAP attribute for group members. |
-| **Netgroup Triple Attribute** | Specifies the LDAP attribute for group triples. |
+| **Group Object Class** | Specifies the LDAP object class for groups. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
+| **Netgroup Member Attribute** | Specifies the LDAP attribute for group members. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps**is disabled. |
+| **Netgroup Triple Attribute** | Specifies the LDAP attribute for group triples. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled.
+ type: input |
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -460,9 +470,9 @@ The screen groups settings into LDAP password attributes, shadow attributes, and
 {{< truetable >}}
 | Setting | Description |
 |---------|-------------|
-| **Netgroup Object Class** | Specifies the LDAP object class for netgroups. |
-| **Netgroup Member Attribute** | Specifies the LDAP attribute for netgroup members. |
-| **Netgroup Triple Attribute** | Specifies the LDAP attribute for netgroup triples. |
+| **Netgroup Object Class** | Specifies the LDAP object class for netgroup entries. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled. |
+| **Netgroup Member Attribute** | Specifies the LDAP attribute for group members. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps**is disabled. |
+| **Netgroup Triple Attribute** | Specifies the LDAP attribute for group triples. Shows when **Configuration Type** is **LDAP** and **Use Standard Attribute Maps** is disabled.
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -474,11 +484,11 @@ The **IPA Configuration** settings define the connection parameters and validati
 
 {{< expand "IPA Configuration Settings" "v" >}}
 {{< truetable >}}
-| Setting | Description |  
-|---------|-------------|  
+| Setting | Description |
+|---------|-------------|
 | **Target Server** | Specifies the name of the IPA server (hostname or IP address) that TrueNAS uses to build URLs when it joins or leaves the IPA domain. For example: *ipa.example.internal*. |
-| **TrueNAS Hostname** | Specifies the hostname of the TrueNAS server to register in IPA during the join process. For example: *truenasnyc*. |
-| **Domain** | Specifies the domain name of the IPA Server. For example: *ipa.internal*. |
+| **TrueNAS Hostname** | Specifies the hostname of the TrueNAS server to register in AD or IPA during the join process. Cannot exceed 15 characters or contain the `\ / : * ? < > |` sepcial characters. Cannot use Microsoft/RFC 852 reserved words (ANONYMOUS, AUTHENTICATED USER, BATCH, BUILTIN, DIALUP, DOMAIN, ENTERPRISE, INTERACTIVE, INTERNET, LOCAL, NETWORK, NULL, PROXY, RESTRICTED, SELF, SERVER, USERS, WORLD, GATEWAY, GW, TAC). Must differ from **Workgroup**. TrueNAS 25.04+ enforces validation. For example: *truenasnyc*. |
+| **Domain** | Specifies the name of the Active Directory, IPA, or SMB domain (e.g., example.com) or child domain. Editable after saving. The full DNS domain name of the Active Directory or IP domain must not be a domain controller, for example, *mydomain.internal*. The name of the SMB domain is as defined in the IPA configuration for the IPA domain to which TrueNAS is joined. SMB configuration **Domain Name** shows when ***Configuration Type** is IPA and **Use Default SMB Domain Configuration** is disabled. |
 | **Base DN** | Specifies the base distinguished name (base DN) to use when performing LDAP operations. For example: *dc=example,dc=com*. |
 | **Validate Certificates** | Verifies certificate authenticity when connecting to the IPA server. When enabled, TrueNAS validates the full certificate chain. TrueNAS does not support non-CA certificates when certificate validation is required. When disabled, TrueNAS does not validate certificates from the remote LDAP server. It is better to use valid certificates or import them into the TrueNAS server trusted certificate store. |
 {{< /truetable >}}
@@ -490,20 +500,20 @@ The **SMB Domain Configuration** settings control SMB integration.
 
 **Use Default SMB Domain Configuration** is enabled by default, and uses the default SMB domain settings detected during the IPA join.
 Settings for the IPA SMB domain are automatically detected by TrueNAS during the domain join process.
-Some IPA domains might not include SMB schema configuration. IPA includes integrated Samba support and can provide user and group information for SMB authentication. 
+Some IPA domains might not include SMB schema configuration. IPA includes integrated Samba support and can provide user and group information for SMB authentication.
 Disable to enter custom settings.
 
 {{< trueimage src="/images/SCALE/Credentials/IPASMBDomainConfiguration.png" alt="IPA SMB Domain Configuration" id="IPA SMB Domain Configuration" >}}
 
 {{< expand "SMB Domain Configuration Settings" "v" >}}
 {{< truetable >}}
-| Setting | Description |  
+| Setting | Description |
 |---------|-------------|
-| **Name** | Short name for the IPA domain used for SMB access. Typically matches the IPA domain name. |
-| **Domain Name** | Name of the SMB domain as defined in the IPA configuration for the IPA domain to which TrueNAS is joined. |
-| **Range Low**| Specifies the lowest UID or GID that the IPA maps natively. |
-| **Range High** | Specifies the highest UID or GID that IPA maps natively.  |
-| **Domain SID** | Specifies the domain SID for the IPA domain to which TrueNAS is joined. |
+| **Name** | Specifies the short name for the IPA domain used for SMB access. Typically matches the IPA domain name. |
+| **Domain Name** | Specifies the name of the Active Directory, IPA, or SMB domain (e.g., example.com) or child domain. Editable after saving. The full DNS domain name of the Active Directory or IP domain must not be a domain controller. for example, *mydomain.internal*. The name of the SMB domain is as defined in the IPA configuration for the IPA domain to which TrueNAS is joined. SMB configuration **Domain Name** shows when ***Configuration Type** is IPA and **Use Default SMB Domain Configuration** is disabled. |
+| **Range Low** | Sets the lowest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **Range High** | Sets the highest UID or GID that the IDMAP backend can assign. UIDs and GIDs outside the range are ignored. Setting shows when <b>Configuration Type</b> is set to <b>Active Directory</b> and <b>Use TrueNAS Server IDMAP Defaults</b> is disabled. |
+| **Domain SID** | Specifies the domain SID for the IPA domain to which TrueNAS is joined. Shows when **Configuration Type** is **IPA** and Use **Default SMB Domain Configuration** is disabled.|
 {{< /truetable >}}
 {{< /expand >}}
 
@@ -528,25 +538,24 @@ Each Kerberos card shows the realms or keytabs configured in TrueNAS.
 
 The **Add Kerberos Realm** screen allows adding a Kerberos realm to the TrueNAS system.
 
-{{< trueimage src="/images/SCALE/Credentials/KerberosRealmsScreen.png" alt="Kerberos Realms Screen" id="Kerberos Realms Screen" >}}
+{{< trueimage src="/images/SCALE/Credentials/AddKerberosRealmScreen.png" alt="add Kerberos Realms Screen" id="add Kerberos Realms Screen" >}}
 
 {{< truetable >}}
-| Setting | Description |  
+| Setting | Description |
 |---------|-------------|
-| **Name** | Specifies a short name for the Kerberos realm. The Kerberos standard allows upper case characters, DNS rules apply, and does not exceed 253 characters (letters, digits, and/or hyphens). TrueNAS does not enforce naming conventions, but requires entering a name.  |
-| **Primary KDC** | Specifies the master Kerberos domain controller for this realm. TrueNAS uses this as a fallback if it cannot get credentials because of an invalid password. This can help in environments where the domain uses a hub-and-spoke topology. Use this setting to reduce credential errors after TrueNAS automatically changes its machine password. |
-| **KDC**| Specifies the name of the Key Distribution Center. Pressing <kbd>Enter</kbd> separates multiple values. |
-| **Admin Server** | Defines the server where all changes to the database are performed. Pressing <kbd>Enter</kbd> separates multiple values.  |
-| **Password Server** | Defines the server where all password changes are performed. Pressing <kbd>Enter</kbd> separates multiple values. |
+| **Realm** | Specifies a short name for the Kerberos realm. The Kerberos standard allows upper case characters, DNS rules apply, and does not exceed 253 characters (letters, digits, and/or hyphens). TrueNAS does not enforce naming conventions, but requires entering a name. |
+| **Primary KDC** | Specifies the master Kerberos domain controller KDC (Key Distribution Center) for this realm. It is the one that issues tickets. If you cannot reach it, you cannot authenticate. TrueNAS uses this as a fallback if it cannot get credentials because of an invalid password. This can help in environments where the domain uses a hub-and-spoke topology. Use this setting to reduce credential errors after TrueNAS automatically changes its machine password. |
+| **KDC**| Specifies the name of the Key Distribution Center. Pressing <kbd>Enter</kbd> separates multiple values. Use additional/secondary KDC(s) for redundancy. If the primary KDC is unavailable, Kerberos can fall back to these. Environments with hub-and-spoke topology often have multiple KDCs. |
+| **Admin Server** | Defines the server where all changes (adding/modifying principals) to the database are performed. Pressing <kbd>Enter</kbd> separates multiple values. Unlike KDC, you can have many KDCs but typically only one admin server. |
+| **Password Server** | Defines the server where all password changes are performed. It is often the same host as the admin server but can be separate. Pressing <kbd>Enter</kbd> separates multiple values. |
 {{< /truetable >}}
 
 ### Add Kerberos Keytabs
 
 The **Add Kerberos Keytabs** allows adding a keytab file using the file browser option and assigning the keytab a name.
 
-{{< trueimage src="/images/SCALE/Credentials/KerberosKeytabsScreen.png" alt="Kerberos Keytabs Screen" id="Kerberos Keytabs Screen" >}}
+{{< trueimage src="/images/SCALE/Credentials/AddKerberosKeytabScreen.png" alt="Add Kerberos Keytabs Screen" id="Add Kerberos Keytabs Screen" >}}
 
 **Name** specifies a short name for the keytab on the TrueNAS system. Kerberos does not have a name convention for keytab files.
 
 **Choose File** opens the file browser to locate and upload a keytab file. Kerberos keytab files are binary files in a specific format (MIT Kerberos keytab format). Keytab files can have either the .keytab or .kt extension.
-


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 44f45fae946626f747e03bc46e38a7a950df4321
    git cherry-pick -x 3e6c95f5b6cd743218c7333a207be5a678a8b93a
    git cherry-pick -x cbb2d7bcc2a1792eef368d02b696a89d693f5690
    git cherry-pick -x 61e367e7cbf1cc94aa774d495476b71965b7c9fb

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 3ac9b29875d33633d52dff07c91a4b6247ae0f81

This PR updates the UI ref with content changes identified during the review of settings scraped from the webui and middleware/api repos. It updates the setting descriptions to what the setting is/does and not how to use them, adds missing settings or screen content, and updates the tutorials with related changes.

backport to 26

Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.


Original PR: https://github.com/truenas/documentation/pull/4793
Jira URL: https://ixsystemsinc.atlassian.net/browse/DOCS-2649